### PR TITLE
Update codeowners for wara tools and networking

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,9 @@
 
 azure-resources/Cdn @Azure/aprl-admins @Azure/aprl-networking
 azure-resources/Network @Azure/aprl-admins @Azure/aprl-networking
+azure-resources/NetworkCloud @Azure/aprl-admins @Azure/aprl-networking
+azure-resources/NetworkFunction @Azure/aprl-admins @Azure/aprl-networking
+azure-resources/Peerings @Azure/aprl-admins @Azure/aprl-networking
 azure-resources/Relay @Azure/aprl-admins @Azure/aprl-networking
 
 ## The aprl-hpc team is partially responsible for all HPC-related PRs
@@ -15,7 +18,8 @@ azure-specialized-workloads/hpc @Azure/aprl-admins @Azure/aprl-hpc
 
 ## The aprl-avd team is partially responsible for all AVD-related PRs
 
-azure-resources/AVS @Azure/aprl-admins @Azure/aprl-avd
 azure-resources/DesktopVirtualization @Azure/aprl-admins @Azure/aprl-avd
 azure-specialized-workloads/avd @Azure/aprl-admins @Azure/aprl-avd
-azure-specialized-workloads/avs @Azure/aprl-admins @Azure/aprl-avd
+
+
+tools @Azure/aprl-wara-tools

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # The aprl-admins team is responsible for reviewing and merging all PRs
 
-* @Azure/aprl-admins
+- @Azure/aprl-admins
 
 ## The aprl-networking team is partially responsible for all networking-related PRs
 
@@ -21,5 +21,6 @@ azure-specialized-workloads/hpc @Azure/aprl-admins @Azure/aprl-hpc
 azure-resources/DesktopVirtualization @Azure/aprl-admins @Azure/aprl-avd
 azure-specialized-workloads/avd @Azure/aprl-admins @Azure/aprl-avd
 
+## The aprl-wara-tools team is responsible for all WARA tools-related PRs
 
 tools @Azure/aprl-wara-tools


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Add aprl-wara-tools as owner of tools directory and add directories for aprl-networking ownership.

## Related Issues/Work Items

Replace this with a list of related GitHub Issues and/or ADO Work Items (Internal Only)

N/A

## This PR fixes/adds/changes/removes

1. Updates to codeowners file for two teams

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
