### PR TITLE
Add a new VM recommendation for ZRS Disk

### DIFF
--- a/azure-resources/Compute/virtualMachines/kql/fa0cf4f5-0b21-47b7-89a9-ee936f193ce1.kql
+++ b/azure-resources/Compute/virtualMachines/kql/fa0cf4f5-0b21-47b7-89a9-ee936f193ce1.kql
@@ -1,7 +1,7 @@
 // Azure Resource Graph Query
 // Find eligible Disks that are not zonal, nor zone Redundant
-Resources 
-| where type == 'microsoft.compute/disks' 
+Resources
+| where type == 'microsoft.compute/disks'
 | project recommendationId="fa0cf4f5-0b21-47b7-89a9-ee936f193ce1", subscriptionId, resourceGroup, name, location, type, sku, Zones = zones, ZoneResilient = sku.name has_cs 'ZRS' or array_length(zones) > 0
 | where sku has "Premium_LRS" or sku has "StandardSSD_LRS"
 | where ZoneResilient == 0

--- a/azure-resources/Compute/virtualMachines/kql/fa0cf4f5-0b21-47b7-89a9-ee936f193ce1.kql
+++ b/azure-resources/Compute/virtualMachines/kql/fa0cf4f5-0b21-47b7-89a9-ee936f193ce1.kql
@@ -1,7 +1,7 @@
 // Azure Resource Graph Query
-// Find eligible Disks that are not zonal, nor zone Redundant
-Resources
+// Find eligible Disks that are not zonal nor zone redundant
+resources
 | where type == 'microsoft.compute/disks'
-| project recommendationId="fa0cf4f5-0b21-47b7-89a9-ee936f193ce1", subscriptionId, resourceGroup, name, location, type, sku, Zones = zones, ZoneResilient = sku.name has_cs 'ZRS' or array_length(zones) > 0
-| where sku has "Premium_LRS" or sku has "StandardSSD_LRS"
-| where ZoneResilient == 0
+| project recommendationId="fa0cf4f5-0b21-47b7-89a9-ee936f193ce1", name, id, tags, param1 = sku, param2 = sku.name has_cs 'ZRS' or array_length(zones) > 0
+| where param1 has "Premium_LRS" or param1 has "StandardSSD_LRS"
+| where param2 == 0

--- a/azure-resources/Compute/virtualMachines/kql/fa0cf4f5-0b21-47b7-89a9-ee936f193ce1.kql
+++ b/azure-resources/Compute/virtualMachines/kql/fa0cf4f5-0b21-47b7-89a9-ee936f193ce1.kql
@@ -1,0 +1,7 @@
+// Azure Resource Graph Query
+// Find eligible Disks that are not zonal, nor zone Redundant
+Resources 
+| where type == 'microsoft.compute/disks' 
+| project recommendationId="fa0cf4f5-0b21-47b7-89a9-ee936f193ce1", subscriptionId, resourceGroup, name, location, type, sku, Zones = zones, ZoneResilient = sku.name has_cs 'ZRS' or array_length(zones) > 0
+| where sku has "Premium_LRS" or sku has "StandardSSD_LRS"
+| where ZoneResilient == 0

--- a/azure-resources/Compute/virtualMachines/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachines/recommendations.yaml
@@ -513,3 +513,24 @@
       url: "https://learn.microsoft.com/azure/virtual-machines/linux/scheduled-events"
     - name: Azure Metadata Service Scheduled Events for Windows VMs
       url: "https://learn.microsoft.com/azure/virtual-machines/windows/scheduled-events"
+
+- description: Use ZRS Disks or Protect LRS Disks from Availability Zone Failure
+  aprlGuid: fa0cf4f5-0b21-47b7-89a9-ee936f193ce1
+  recommendationTypeId: null
+  recommendationControl: High Availability
+  recommendationImpact: Medium
+  recommendationResourceType: Microsoft.Compute/virtualMachines
+  recommendationMetadataState: Active
+  longDescription: |
+    Azure managed disks offer two storage redundancy options: zone-redundant storage (ZRS) and locally redundant storage (LRS). ZRS provides resiliency in the event of a zonal outage. However, the write latency for LRS disks is better than ZRS disks. If you are using an LRS disk, please follow "Redundancy options for managed disks" documentation and take action to protect it from a zonal failure.   
+  potentialBenefits: Enhanced Disk resilience to failures
+  pgVerified: true
+  publishedToLearn: false
+  publishedToAdvisor: false
+  automationAvailable: arg
+  tags: null
+  learnMoreLink:
+    - name: Redundancy options for managed disks
+      url: "https://aka.ms/zrsdisksdoc"
+    - name: Convert a disk from LRS to ZRS
+      url: "https://aka.ms/migratedisksfromLRStoZRS"

--- a/azure-resources/Compute/virtualMachines/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachines/recommendations.yaml
@@ -522,7 +522,7 @@
   recommendationResourceType: Microsoft.Compute/virtualMachines
   recommendationMetadataState: Active
   longDescription: |
-    Azure disks offer two redundancy options: zone-redundant storage (ZRS) and locally redundant storage (LRS). Use ZRS disk to let you recover from zonal failure, but it has higher write latency. If you use LRS disk, please follow the documentation and take action to protect it from zonal failure.
+    Azure disks offers a zone-redundant storage (ZRS) option for workloads that need to be resilient to an entire zone being down. Due to the cross-zone data replication, ZRS disks have higher write latency when compared to the locally-redundant option (LRS), so make sure to benchmark your disks.
   potentialBenefits: Enhanced Disk resilience to failures
   pgVerified: true
   publishedToLearn: false

--- a/azure-resources/Compute/virtualMachines/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachines/recommendations.yaml
@@ -522,7 +522,7 @@
   recommendationResourceType: Microsoft.Compute/virtualMachines
   recommendationMetadataState: Active
   longDescription: |
-    Azure managed disks offer two storage redundancy options: zone-redundant storage (ZRS) and locally redundant storage (LRS). ZRS provides resiliency in the event of a zonal outage. However, the write latency for LRS disks is better than ZRS disks. If you are using an LRS disk, please follow "Redundancy options for managed disks" documentation and take action to protect it from a zonal failure.
+    Azure disks offer two redundancy options: zone-redundant storage (ZRS) and locally redundant storage (LRS). Use ZRS disk to let you recover from zonal failure, but it has higher write latency. If you use LRS disk, please follow the documentation and take action to protect it from zonal failure.
   potentialBenefits: Enhanced Disk resilience to failures
   pgVerified: true
   publishedToLearn: false
@@ -532,5 +532,3 @@
   learnMoreLink:
     - name: Redundancy options for managed disks
       url: "https://aka.ms/zrsdisksdoc"
-    - name: Convert a disk from LRS to ZRS
-      url: "https://aka.ms/migratedisksfromLRStoZRS"

--- a/azure-resources/Compute/virtualMachines/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachines/recommendations.yaml
@@ -522,7 +522,7 @@
   recommendationResourceType: Microsoft.Compute/virtualMachines
   recommendationMetadataState: Active
   longDescription: |
-    Azure managed disks offer two storage redundancy options: zone-redundant storage (ZRS) and locally redundant storage (LRS). ZRS provides resiliency in the event of a zonal outage. However, the write latency for LRS disks is better than ZRS disks. If you are using an LRS disk, please follow "Redundancy options for managed disks" documentation and take action to protect it from a zonal failure.   
+    Azure managed disks offer two storage redundancy options: zone-redundant storage (ZRS) and locally redundant storage (LRS). ZRS provides resiliency in the event of a zonal outage. However, the write latency for LRS disks is better than ZRS disks. If you are using an LRS disk, please follow "Redundancy options for managed disks" documentation and take action to protect it from a zonal failure.
   potentialBenefits: Enhanced Disk resilience to failures
   pgVerified: true
   publishedToLearn: false


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Added a new VM recommendation and query for "Use ZRS Disks or Protect LRS Disks from Availability Zone Failure" (fa0cf4f5-0b21-47b7-89a9-ee936f193ce1) after discussion and verification with Disk PM Bea Vincent and Ryan Draper.

## Related Issues/Work Items

Replace this with a list of related GitHub Issues and/or ADO Work Items (Internal Only)

- To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
- To associate an ADO Work Item, use the key word `AB#` succeeded with the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## This PR fixes/adds/changes/removes

1. Added a new VM recommendation for "Use ZRS Disks or Protect LRS Disks from Availability Zone Failure" (fa0cf4f5-0b21-47b7-89a9-ee936f193ce1)
2. Added query for "Use ZRS Disks or Protect LRS Disks from Availability Zone Failure" (fa0cf4f5-0b21-47b7-89a9-ee936f193ce1) 

### Breaking Changes

N/A

## As part of this pull request I have

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [X] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
