### PR TITLE
Fix: Deploy AKS cluster across availability zones

### DIFF
--- a/azure-resources/ContainerService/managedClusters/kql/4f63619f-5001-439c-bacb-8de891287727.kql
+++ b/azure-resources/ContainerService/managedClusters/kql/4f63619f-5001-439c-bacb-8de891287727.kql
@@ -1,9 +1,18 @@
 // Azure Resource Graph Query
-// Returns AKS clusters that do not have any availability zones enabled
+// Returns AKS clusters that do not have any availability zones enabled or only use a single zone
 resources
-| where type == 'microsoft.containerservice/managedclusters'
-| project id, name, tags, location, properties.agentPoolProfiles
-| mv-expand properties_agentPoolProfiles
-| where isempty(array_length(properties_agentPoolProfiles.availabilityZones))
-| project recommendationId="4f63619f-5001-439c-bacb-8de891287727", id, name, tags, param1=strcat("nodePoolName: ", properties_agentPoolProfiles.name), param2=strcat("orchestratorVersion: ", properties_agentPoolProfiles.orchestratorVersion), param3=strcat("currentOrchestratorVersion: ", properties_agentPoolProfiles.currentOrchestratorVersion), param4=strcat("numberOfZones: ", iff(isempty(array_length(properties_agentPoolProfiles.availabilityZones)), 0, array_length(properties_agentPoolProfiles.availabilityZones)))
-
+| where type =~ "Microsoft.ContainerService/managedClusters"
+| project id, name, tags, location, pools = properties.agentPoolProfiles
+| mv-expand pool = pools
+| extend
+    numOfAvailabilityZones = iif(isnull(pool.availabilityZones), 0, array_length(pool.availabilityZones))
+| where numOfAvailabilityZones < 2
+| project
+    recommendationId = "4f63619f-5001-439c-bacb-8de891287727",
+    id,
+    name,
+    tags,
+    param1 = strcat("NodePoolName: ", pool.name),
+    param2 = strcat("Mode: ", pool.mode),
+    param3 = strcat("AvailabilityZones: ", iif(numOfAvailabilityZones == 0, "None", strcat("Zone ", strcat_array(pool.availabilityZones, ", ")))),
+    param4 = strcat("Location: ", location)


### PR DESCRIPTION
# Overview/Summary

Added a single zone pool to the coverage of the query to fix the issue #36.

- APRL recommendation: [Deploy AKS cluster across availability zones](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/azure-resources/ContainerService/managedClusters/#deploy-aks-cluster-across-availability-zones)

## Related Issues/Work Items

- #36 

## This PR fixes/adds/changes/removes

1. Adds a single zone pool to the coverage of the query.
2. Changes param columns.

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

### Screenshot

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/1618784/6240c5f9-a69f-4bda-8722-7931e489b8d0)
