### PR TITLE
Fix: Exclude Trusted Launch VMs and Confidential VMs

### DIFF
--- a/azure-resources/Compute/virtualMachines/kql/cfe22a65-b1db-fd41-9e8e-d573922709ae.kql
+++ b/azure-resources/Compute/virtualMachines/kql/cfe22a65-b1db-fd41-9e8e-d573922709ae.kql
@@ -1,19 +1,16 @@
 // Azure Resource Graph Query
 // Find all VMs that do NOT have replication with ASR enabled
-// Run query to see results.
 resources
-| where type =~ 'Microsoft.Compute/virtualMachines'
-| project name, id, tags
-| join kind=leftouter (
+| where type =~ "Microsoft.Compute/virtualMachines"
+| extend securityType = iif(isnull(properties.securityProfile.securityType), "Standard", properties.securityProfile.securityType)
+| where securityType !in~ ("TrustedLaunch", "ConfidentialVM")
+| project id, vmIdForJoin = tolower(id), name, tags
+| join kind = leftouter (
     recoveryservicesresources
-    | where type =~ 'Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems'
-    | where properties.providerSpecificDetails.dataSourceInfo.datasourceType =~ 'AzureVm'
-    | project id=properties.providerSpecificDetails.dataSourceInfo.resourceId
-    | extend name=strcat_array(array_slice(split(id, '/'), 8, -1), '/')
-) on name
-| where isnull(id1)
-| project-away id1
-| project-away name1
+    | where type =~ "Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems"
+        and properties.providerSpecificDetails.dataSourceInfo.datasourceType =~ "AzureVm"
+    | project vmResourceId = tolower(properties.providerSpecificDetails.dataSourceInfo.resourceId)
+    )
+    on $left.vmIdForJoin == $right.vmResourceId
+| where isempty(vmResourceId)
 | project recommendationId = "cfe22a65-b1db-fd41-9e8e-d573922709ae", name, id, tags
-| order by id asc
-


### PR DESCRIPTION
# Overview/Summary

Excluded Trusted Launch VMs and Confidential VMs because Azure Site Recovery does not support Trusted Launch VMs and Confidential VMs.

- Azure Site Recovery does not support [Trusted Launch VM](https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch#unsupported-features) currently.
    > Unsupported features
    > - Azure Site Recovery

- Azure Site Recovery does not support [Confidential VM](https://learn.microsoft.com/en-us/azure/confidential-computing/confidential-vm-overview#feature-support) currently.
    > Confidential VMs don't support:
    > - Azure Site Recovery

## Related Issues/Work Items

- #44 

## This PR fixes/adds/changes/removes

1. Excludes Trusted Launch VMs and Confidential VMs from the query result.
2. Simplifies the query a bit. 

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

## Screenshots

**Query result:**
![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/1618784/5ccbd8c0-5d5a-42d1-aed9-b810c7614f3c)

**All VMs in the environment:**
![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/1618784/eca03faf-2744-4c39-b1e5-1f1291bdfe0e)

**Replication enabled all VMs:**
![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/1618784/dbba10d4-eb4d-47d8-a059-c0f187c245b6)
