### PR TITLE
query fix for issue 42

### DIFF
--- a/azure-resources/Network/azureFirewalls/kql/1b2dbf4a-8a0b-5e4b-8f4e-3f758188910d.kql
+++ b/azure-resources/Network/azureFirewalls/kql/1b2dbf4a-8a0b-5e4b-8f4e-3f758188910d.kql
@@ -3,12 +3,12 @@
 resources
 | where type == "microsoft.network/azurefirewalls"
 | mv-expand properties.ipConfigurations
-| project name, firewallId = id, vNet = substring(properties_ipConfigurations.properties.subnet.id, 0, indexof(properties_ipConfigurations.properties.subnet, "/subnet") - 7), tags
+| project name, firewallId = id, vNet = tolower(substring(properties_ipConfigurations.properties.subnet.id, 0, indexof(properties_ipConfigurations.properties.subnet, "/subnet") - 7)), tags
 | join kind=fullouter (
     resources
     | where type == "microsoft.network/ddosprotectionplans"
     | mv-expand properties.virtualNetworks
-    | extend vNet = tostring(properties_virtualNetworks.id)
+    | extend vNet = tolower(tostring(properties_virtualNetworks.id))
     | project ddosProtectionPlan = id, vNet
     )
     on $left.vNet == $right.vNet


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Update AzFw DDoS protection query to address issue #42  https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/azure-resources/Network/azureFirewalls/#configure-ddos-protection-on-the-azure-firewall-vnet

## Related Issues/Work Items

#42 

## This PR fixes/adds/changes/removes

1. Update query 1b2dbf4a-8a0b-5e4b-8f4e-3f758188910d

### Breaking Changes

1. None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
