### PR TITLE
adds resource graph query for "Ensure endpoint configured to (All World) for geographic profiles"

### DIFF
--- a/azure-resources/Network/trafficManagerProfiles/kql/c31f76a0-48cd-9f44-aa43-99ee904db9bc.kql
+++ b/azure-resources/Network/trafficManagerProfiles/kql/c31f76a0-48cd-9f44-aa43-99ee904db9bc.kql
@@ -1,2 +1,10 @@
-// under-development
-
+// Azure Resource Graph Query
+// Provides a list of Traffic Manager resources that are not confirgured for all-World access
+Resources
+| where type == 'microsoft.network/trafficmanagerprofiles'
+| where properties.trafficRoutingMethod =~ "Geographic"
+| extend endpoints = properties.endpoints
+| mv-expand endpoint = endpoints
+| where endpoint.properties.geoMapping !contains "WORLD"
+| extend endpointName = endpoint.name
+| project recommendationId="c31f76a0-48cd-9f44-aa43-99ee904db9bc", name, id, tags, param1=strcat("endpointName:",endpointName), param2=strcat("GeoMapping:", tostring(endpoint.properties.geoMapping))

--- a/azure-resources/Network/trafficManagerProfiles/recommendations.yaml
+++ b/azure-resources/Network/trafficManagerProfiles/recommendations.yaml
@@ -73,7 +73,7 @@
   pgVerified: true
   publishedToLearn: false
   publishedToAdvisor: false
-  automationAvailable: no
+  automationAvailable: yes
   tags: null
   learnMoreLink:
     - name: Add an endpoint configured to "All (World)"


### PR DESCRIPTION
# Overview/Summary

Adds Resource Graph Query

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/5988767/695d5b97-d37a-4ce8-85a3-f2c590fc1d17)

## Related Issues/Work Items

#AB32811

## This PR fixes/adds/changes/removes

1. add query

### Breaking Changes

1. none

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
