### PR TITLE
AKS: Update AKS guidance based on PG feedback

### DIFF
--- a/azure-resources/ContainerService/managedClusters/kql/5ee083cd-6ac3-4a83-8913-9549dd36cf56.kql
+++ b/azure-resources/ContainerService/managedClusters/kql/5ee083cd-6ac3-4a83-8913-9549dd36cf56.kql
@@ -1,10 +1,18 @@
 // Azure Resource Graph Query
-// Returns each AKS cluster with nodepools that do not have taints set
+// Returns each AKS cluster with nodepools that do not have system pods labelled with CriticalAddonsOnly
 resources
 | where type == "microsoft.containerservice/managedclusters"
 | mv-expand agentPoolProfile = properties.agentPoolProfiles
+| where agentPoolProfile.mode =~ 'System' // system node pools
 | extend taint = tostring(parse_json(agentPoolProfile.nodeTaints))
+| extend hasCriticalAddonsTaint = agentPoolProfile.kubeletConfig has 'CriticalAddonsOnly'
+| extend hasNodeLabel = agentPoolProfile.customNodeLabels has 'CriticalAddonsOnly'
+| extend hasCriticalAddonsOnly = hasCriticalAddonsTaint or hasNodeLabel or isempty(taint)
 | extend nodePool = tostring(parse_json(agentPoolProfile.name))
-| where isempty(taint)
-| project recommendationid="5ee083cd-6ac3-4a83-8913-9549dd36cf56", id, name, tags, param1=strcat("nodepoolName: ", nodePool), param2=strcat("taint: ", iff(isempty(taint), "None", taint))
-
+| where hasCriticalAddonsOnly
+| project
+    recommendationid="5ee083cd-6ac3-4a83-8913-9549dd36cf56",
+    id,
+    name,
+    tags,
+    param1=strcat("nodepoolName: ", nodePool)

--- a/azure-resources/ContainerService/managedClusters/kql/a01afc4c-7439-4919-b2da-3565992ea2a7.kql
+++ b/azure-resources/ContainerService/managedClusters/kql/a01afc4c-7439-4919-b2da-3565992ea2a7.kql
@@ -1,2 +1,1 @@
 // cannot-be-validated-with-arg
-

--- a/azure-resources/ContainerService/managedClusters/kql/ba3f7d17-9654-4038-b172-09f1b2569925.kql
+++ b/azure-resources/ContainerService/managedClusters/kql/ba3f7d17-9654-4038-b172-09f1b2569925.kql
@@ -1,7 +1,0 @@
-// Azure Resource Graph Query
-// Returns clusters that do not have private cluster or authorized IP ranges set up (both are not set)
-resources
-| where type == 'microsoft.containerservice/managedclusters'
-| mv-expand properties.apiServerAccessProfile
-| where isempty(properties.apiServerAccessProfile.enablePrivateCluster) and isempty(properties.apiServerAccessProfile.authorizedIPRanges)
-| project recommendationId="ba3f7d17-9654-4038-b172-09f1b2569925", name, id

--- a/azure-resources/ContainerService/managedClusters/recommendations.yaml
+++ b/azure-resources/ContainerService/managedClusters/recommendations.yaml
@@ -8,7 +8,7 @@
   longDescription: |
     Azure Availability Zones ensure high availability by offering independent locations within regions, equipped with their own power, cooling, and networking to ensure applications and data are protected from datacenter-level failures.
   potentialBenefits: Enhanced fault tolerance for AKS
-  pgVerified: false
+  pgVerified: true
   publishedToLearn: false
   publishedToAdvisor: false
   automationAvailable: arg
@@ -92,7 +92,7 @@
   longDescription: |
     The cluster auto-scaler in AKS adjusts node counts based on pod resource needs and available capacity, enabling scaling as per demand to prevent outages.
   potentialBenefits: Optimizes scaling and prevents outages
-  pgVerified: false
+  pgVerified: true
   publishedToLearn: false
   publishedToAdvisor: false
   automationAvailable: arg
@@ -117,7 +117,7 @@
   longDescription: |
     AKS, popular for stateful apps needing backups, can now use Azure Backup to secure clusters and attached volumes through an installed Backup Extension, enabling backup and restore operations via a Backup Vault.
   potentialBenefits: Ensures data safety for AKS
-  pgVerified: false
+  pgVerified: true
   publishedToLearn: false
   publishedToAdvisor: false
   automationAvailable: arg
@@ -155,7 +155,7 @@
   aprlGuid: d3111036-355d-431b-ab49-8ddad042800b
   recommendationTypeId: null
   recommendationControl: High Availability
-  recommendationImpact: Low
+  recommendationImpact: Medium
   recommendationResourceType: Microsoft.ContainerService/managedClusters
   recommendationMetadataState: Active
   longDescription: |
@@ -249,7 +249,7 @@
   longDescription: |
     Production AKS clusters require the Standard tier for a financially backed SLA and enhanced node scalability, as the free service lacks these features.
   potentialBenefits: SLA guarantee and better scalability
-  pgVerified: false
+  pgVerified: true
   publishedToLearn: false
   publishedToAdvisor: false
   automationAvailable: arg
@@ -270,7 +270,7 @@
   longDescription: |
     Azure Monitor enables real-time health and performance insights for AKS by collecting events, capturing container logs, and gathering CPU/Memory data from the Metrics API. It allows data visualization using Azure Monitor Container Insights, Prometheus, Grafana, or others.
   potentialBenefits: Real-time AKS health/performance insights
-  pgVerified: false
+  pgVerified: true
   publishedToLearn: false
   publishedToAdvisor: false
   automationAvailable: arg
@@ -344,7 +344,7 @@
     - name: GitOps for AKS - Reference Architecture
       url: "https://learn.microsoft.com/en-us/azure/architecture/example-scenario/gitops-aks/gitops-blueprint-aks"
 
-- description: Configure affinity or anti-affinity rules based on application requirements
+- description: Use pod topology spread constraints to ensure that pods are spread across different nodes or zones
   aprlGuid: 928fcc6f-5e9a-42d9-9bd4-260af42de2e5
   recommendationTypeId: null
   recommendationControl: High Availability
@@ -352,9 +352,9 @@
   recommendationResourceType: Microsoft.ContainerService/managedClusters
   recommendationMetadataState: Active
   longDescription: |
-    Configure Topology Spread Constraints to spread Pods across your cluster among failure-domains like regions, zones, nodes, and other domains for high availability and efficient resource utilization.
+    Enhance availability and reliability by using pod topology spread constraints to control pod distribution based on node or zone topology, ensuring pods are spread across your cluster.
   potentialBenefits: Ensures high availability and efficient use
-  pgVerified: false
+  pgVerified: true
   publishedToLearn: false
   publishedToAdvisor: false
   automationAvailable: no
@@ -375,7 +375,7 @@
   longDescription: |
     AKS kubelet controller uses liveness probes to validate containers and applications health, ensuring the system knows when to restart a container based on its health status.
   potentialBenefits: Enhances container health monitoring
-  pgVerified: false
+  pgVerified: true
   publishedToLearn: false
   publishedToAdvisor: false
   automationAvailable: no
@@ -386,7 +386,7 @@
     - name: Assign Pod Node
       url: "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/"
 
-- description: Configure pod replica sets in production applications to guarantee availability
+- description: Use deployments with multiple replicas in production applications to guarantee availability
   aprlGuid: bcfe71f1-ebed-49e5-a84a-193b81ad5d27
   recommendationTypeId: null
   recommendationControl: High Availability
@@ -394,9 +394,9 @@
   recommendationResourceType: Microsoft.ContainerService/managedClusters
   recommendationMetadataState: Active
   longDescription: |
-    Configuring ReplicaSets in Pod or Deployment manifests stabilizes the number of replica Pods, ensuring that a specified number of identical Pods are always available, thereby guaranteeing their availability.
+    Configuring multiple replicas in Pod or Deployment manifests stabilizes the number of replica Pods, ensuring that a specified number of identical Pods are always available, thereby guaranteeing their availability.
   potentialBenefits: Ensures stable pod availability
-  pgVerified: false
+  pgVerified: true
   publishedToLearn: false
   publishedToAdvisor: false
   automationAvailable: no
@@ -415,7 +415,7 @@
   longDescription: |
     The system node pool should be configured with a minimum node count of two to ensure critical system pods are resilient to node outages.
   potentialBenefits: Ensures pod resilience
-  pgVerified: false
+  pgVerified: true
   publishedToLearn: false
   publishedToAdvisor: false
   automationAvailable: arg
@@ -434,7 +434,7 @@
   longDescription: |
     Configuring the user node pool with at least two nodes is essential for applications needing high availability, ensuring they remain operational and accessible without interruption.
   potentialBenefits: Ensures high app availability
-  pgVerified: false
+  pgVerified: true
   publishedToLearn: false
   publishedToAdvisor: false
   automationAvailable: arg
@@ -453,7 +453,7 @@
   longDescription: |
     A Pod Disruption Budget is a Kubernetes resource configuring the minimum number or percentage of pods that should remain available during disruptions like maintenance or scaling, ensuring a minimum number of pods are always available in the cluster.
   potentialBenefits: Ensures cluster resiliency during disruptions
-  pgVerified: false
+  pgVerified: true
   publishedToLearn: false
   publishedToAdvisor: false
   automationAvailable: no
@@ -480,43 +480,24 @@
   automationAvailable: arg
   tags: null
   learnMoreLink:
-    - name: AKS Networking
-      url: "https://learn.microsoft.com/azure/aks/concepts-network"
+    - name: Azure CNI Dynamic IP Allocation
+      url: "https://learn.microsoft.com/azure/aks/configure-azure-cni-dynamic-ip-allocation"
 
-- description: Enforce resource quotas at the namespace level
-  aprlGuid: d479df28-d367-4ef0-8b86-0495ab94fabd
+- description: Node pool auto-scale settings should not exceed subscription core quota
+  aprlGuid: a01afc4c-7439-4919-b2da-3565992ea2a7
   recommendationTypeId: null
   recommendationControl: High Availability
   recommendationImpact: High
   recommendationResourceType: Microsoft.ContainerService/managedClusters
   recommendationMetadataState: Active
   longDescription: |
-    Enforcing namespace-level resource quotas in AKS is crucial for reliability, preventing resource exhaustion and maintaining cluster stability. It stops applications or users from monopolizing resources, avoiding degraded performance or outages for others.
-  potentialBenefits: Prevents resource monopoly, ensures stability
+    Node pool settings should not exceed the subscription core quota to ensure AKS can scale out nodes efficiently, meeting increased demand while reducing resource constraints and potential service disruptions.
+  potentialBenefits: Reduced disruptions
   pgVerified: false
   publishedToLearn: false
   publishedToAdvisor: false
   automationAvailable: no
   tags: null
   learnMoreLink:
-    - name: Resource quotas
-      url: "https://learn.microsoft.com/azure/aks/operator-best-practices-scheduler#enforce-resource-quotas"
-
-- description: Enable AKS private cluster or set authorized IP address ranges
-  aprlGuid: ba3f7d17-9654-4038-b172-09f1b2569925
-  recommendationTypeId: null
-  recommendationControl: High Availability
-  recommendationImpact: High
-  recommendationResourceType: Microsoft.ContainerService/managedClusters
-  recommendationMetadataState: Active
-  longDescription: |
-    For optimal connectivity and security, enable private cluster in AKS to ensure direct communication between worker nodes and the control plane. If not enabled, secure API server access with authorized IP ranges.
-  potentialBenefits: Provides network reliability, reduced disruptions
-  pgVerified: false
-  publishedToLearn: false
-  publishedToAdvisor: false
-  automationAvailable: arg
-  tags: null
-  learnMoreLink:
-    - name: AKS private cluster
-      url: "https://learn.microsoft.com/azure/aks/private-clusters"
+    - name: Azure Quotas
+      url: "https://learn.microsoft.com/azure/quotas/quotas-overview"


### PR DESCRIPTION
# Overview/Summary

Added in new AKS item and revised existing ones according to PG feedback

## Related Issues/Work Items

## This PR fixes/adds/changes/removes

1. Updates pgVerified to true for AKS items:
- 4f63619f-5001-439c-bacb-8de891287727
- 902c82ff-4910-4b61-942d-0d6ef7f39b67
- 269a9f1a-6675-460a-831e-b05a887a8c4b
- 0611251f-e70f-4243-8ddd-cfe894bec2e7 
- dcaf8128-94bd-4d53-9235-3a0371df6b74 
- 928fcc6f-5e9a-42d9-9bd4-260af42de2e5 
- cd6791b1-c60e-4b37-ac98-9897b1e6f4b8
- bcfe71f1-ebed-49e5-a84a-193b81ad5d27 
- 7f7ae535-a5ba-4665-b7e0-c451dbdda01f 
- 005ccbbd-aeab-46ef-80bd-9bd4479412ec 
- a08a06a0-e41a-4b99-83bb-69ce8bca54cb

2. Updated AKS item 928fcc6f-5e9a-42d9-9bd4-260af42de2e5 description to using Pod Topology spread constraints instead of affinity rules based on PG feedback
3. Updated AKS item bcfe71f1-ebed-49e5-a84a-193b81ad5d27 description wording based on PG feedback
4. Updated AKS item e620fa98-7a40-41a0-bfc9-b4407297fb58 learn link based on PG feedback
5. Updated AKS item 5ee083cd-6ac3-4a83-8913-9549dd36cf56 query based on PG feedback
6. Added new AKS item a01afc4c-7439-4919-b2da-3565992ea2a7 
7. Consolidated AKS item d479df28-d367-4ef0-8b86-0495ab94fabd and 9a1c17e5-c9a0-43db-b920-adaf54d1bcb7 into 9a1c17e5-c9a0-43db-b920-adaf54d1bcb7 based on PG feedback
8. Removed AKS item ba3f7d17-9654-4038-b172-09f1b2569925 based on PG feedback. They feel that this should only be included in security recommendations. 

### Breaking Changes

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
