### PR TITLE
AGW: Update first recommendation for minimum instance count.

### DIFF
--- a/azure-resources/Network/applicationGateways/recommendations.yaml
+++ b/azure-resources/Network/applicationGateways/recommendations.yaml
@@ -1,4 +1,4 @@
-﻿- description: Set a minimum instance count of 2
+﻿- description: Ensure autoscale has been enabled
   aprlGuid: 823b0cff-05c0-2e4e-a1e7-9965e1cfa16f
   recommendationTypeId: null
   recommendationControl: Scalability
@@ -6,7 +6,7 @@
   recommendationResourceType: Microsoft.Network/applicationGateways
   recommendationMetadataState: Active
   longDescription: |
-    Azure Application Gateways v2 are deployed highly available with multiple instances by default.
+    Azure Application Gateways v2 are deployed highly available with multiple instances by default. Enabling autoscale ensures the services is not relient on manual intervention for scaling.
   potentialBenefits: Enhances uptime and enables autoscaling
   pgVerified: true
   publishedToLearn: false

--- a/azure-resources/Network/applicationGateways/recommendations.yaml
+++ b/azure-resources/Network/applicationGateways/recommendations.yaml
@@ -6,7 +6,7 @@
   recommendationResourceType: Microsoft.Network/applicationGateways
   recommendationMetadataState: Active
   longDescription: |
-    Azure Application Gateways v2 are deployed highly available with multiple instances by default. Enabling autoscale ensures the services is not relient on manual intervention for scaling.
+    Azure Application Gateways v2 are always deployed in a highly available fashion with multiple instances by default. Enabling autoscale ensures the service is not reliant on manual intervention for scaling.
   potentialBenefits: Enhances uptime and enables autoscaling
   pgVerified: true
   publishedToLearn: false


### PR DESCRIPTION
# Overview/Summary

Updating description based on PGs recommendation.  App GW by default has a minimum of 2 instances so the recommendation should be around enabling autoscaling instead of a minimum instance count.

## Related Issues/Work Items
AB#34801

## This PR fixes/adds/changes/removes

1. Updated description to fit the recommendation.
2.  Added information to long description

## As part of this pull request I have

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
