### PR TITLE
Updated monitoring VM recommendation based on PG feedback

### DIFF
--- a/azure-resources/Compute/virtualMachines/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachines/recommendations.yaml
@@ -394,7 +394,7 @@
     - name: Did the extension install properly?
       url: "https://learn.microsoft.com/azure/azure-monitor/vm/vminsights-troubleshoot#did-the-extension-install-properly"
 
-- description: Configure diagnostic settings for all Azure Virtual Machines
+- description: Configure monitoring for all Azure Virtual Machines
   aprlGuid: 4a9d8973-6dba-0042-b3aa-07924877ebd5
   recommendationTypeId: null
   recommendationControl: Monitoring and Alerting
@@ -410,8 +410,8 @@
   automationAvailable: arg
   tags: null
   learnMoreLink:
-    - name: Diagnostic settings in Azure Monitor
-      url: "https://learn.microsoft.com/azure/azure-monitor/essentials/diagnostic-settings?tabs=portal"
+    - name: Azure Monitor Agent overview
+      url: "https://learn.microsoft.com/en-us/azure/azure-monitor/agents/agents-overview"
 
 - description: Use maintenance configurations for the VMs
   aprlGuid: 52ab9e5c-eec0-3148-8bd7-b6dd9e1be870


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Updated the monitoring VM recommendation based on PG feedback, now recommendating enabling Azure Monitoring Agent, instead of VM Diagnostics Extension, which is no longer being invested in and set to be announced for deprecation this august.

## This PR fixes/adds/changes/removes

1. Updated monitoring VM recommendation

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
