### PR TITLE
Fixed resource type for VMSS recommendation.

### DIFF
--- a/azure-resources/Compute/virtualMachineScaleSets/kql/1074f391-22bf-42f5-9c95-68af5ad89bf6.kql
+++ b/azure-resources/Compute/virtualMachineScaleSets/kql/1074f391-22bf-42f5-9c95-68af5ad89bf6.kql
@@ -1,8 +1,0 @@
-// Azure Resource Graph Query
-// Find all VMSSs Uniform not using SSD storage
-resources
-| where type == "microsoft.compute/virtualmachinescalesets"
-| where properties.orchestrationMode != "Flexible"
-| where properties.virtualMachineProfile.storageProfile.osDisk.managedDisk.storageAccountType == 'Standard_LRS'
-| project recommendationId = "1074f391-22bf-42f5-9c95-68af5ad89bf6", name, id, tags
-

--- a/azure-resources/Compute/virtualMachineScaleSets/kql/df0ff862-814d-45a3-95e4-4fad5a244ba6.kql
+++ b/azure-resources/Compute/virtualMachineScaleSets/kql/df0ff862-814d-45a3-95e4-4fad5a244ba6.kql
@@ -1,0 +1,14 @@
+// Azure Resource Graph Query
+// Find all VMSS instances that have an attached disk that is not in the Premium or Ultra sku tier.
+
+resources
+| where type =~ 'Microsoft.Compute/virtualMachines'
+| extend lname = tolower(name)
+| join kind=leftouter(resources
+    | where type =~ 'Microsoft.Compute/disks'
+    | where not(sku.tier =~ 'Premium') and not(sku.tier =~ 'Ultra')
+    | extend lname = tolower(tostring(split(managedBy, '/')[8]))
+    | project lname, name
+    | summarize disks = make_list(name) by lname) on lname
+| where isnotnull(disks)
+| project recommendationId = "df0ff862-814d-45a3-95e4-4fad5a244ba6", name, id, tags, param1=strcat("AffectedDisks: ", disks)

--- a/azure-resources/Compute/virtualMachineScaleSets/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachineScaleSets/recommendations.yaml
@@ -182,7 +182,7 @@
   recommendationTypeId: null
   recommendationControl: Scalability
   recommendationImpact: High
-  recommendationResourceType: Microsoft.Compute/virtualMachines
+  recommendationResourceType: Microsoft.Compute/virtualMachineScaleSets
   recommendationMetadataState: Active
   longDescription: |
     Compared to Standard HDD and SSD, Premium SSD, SSDv2, and Ultra SSDs offer improved performance, configurability, and higher single-instance Virtual Machine uptime SLAs. The lowest SLA of all disks on a Virtual Machine applies, so it is best to use Premium or Ultra Disks for the highest uptime SLA.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Fixed wrong resourceType reference for VMSS recommendation.

## Related Issues/Work Items

Fixed wrong resourceType reference for VMSS recommendation.

## This PR fixes/adds/changes/removes

1. Fix resourceType for VMSS recommendation.

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
