### PR TITLE
changing verbiage of AKS pod scheduling on worker nodes

### DIFF
--- a/azure-resources/ContainerService/managedClusters/recommendations.yaml
+++ b/azure-resources/ContainerService/managedClusters/recommendations.yaml
@@ -27,7 +27,7 @@
   recommendationResourceType: Microsoft.ContainerService/managedClusters
   recommendationMetadataState: Active
   longDescription: |
-    AKS assigns the kubernetes.azure.com/mode: system label to nodes in system node pools signaling only system pods should be scheduled there. For worker nodes assign taints and label CriticalAddonsOnly to node.
+    AKS assigns the kubernetes.azure.com/mode: system label to nodes in system node pools signaling the preference for system pods should be scheduled there. The CriticalAddonsOnly=true:NoSchedule taint can be added to your system nodes to enforce the prevention of application pods from being scheduled on them. 
   potentialBenefits: Enhanced reliability via pod isolation
   pgVerified: false
   publishedToLearn: false

--- a/azure-resources/ContainerService/managedClusters/recommendations.yaml
+++ b/azure-resources/ContainerService/managedClusters/recommendations.yaml
@@ -27,7 +27,7 @@
   recommendationResourceType: Microsoft.ContainerService/managedClusters
   recommendationMetadataState: Active
   longDescription: |
-    AKS assigns the kubernetes.azure.com/mode: system label to nodes in system node pools signaling the preference for system pods should be scheduled there. The CriticalAddonsOnly=true:NoSchedule taint can be added to your system nodes to enforce the prevention of application pods from being scheduled on them. 
+    AKS assigns the kubernetes.azure.com/mode: system label to nodes in system node pools signaling the preference for system pods should be scheduled there. The CriticalAddonsOnly=true:NoSchedule taint can be added to your system nodes to prohibit application pods from being scheduled on them. 
   potentialBenefits: Enhanced reliability via pod isolation
   pgVerified: false
   publishedToLearn: false

--- a/azure-resources/ContainerService/managedClusters/recommendations.yaml
+++ b/azure-resources/ContainerService/managedClusters/recommendations.yaml
@@ -27,7 +27,7 @@
   recommendationResourceType: Microsoft.ContainerService/managedClusters
   recommendationMetadataState: Active
   longDescription: |
-    AKS assigns the kubernetes.azure.com/mode: system label to nodes in system node pools signaling system pods should be scheduled there.
+    AKS assigns the kubernetes.azure.com/mode: system label to nodes in system node pools signaling only system pods should be scheduled there. For worker nodes assign taints and label CriticalAddonsOnly to node.
   potentialBenefits: Enhanced reliability via pod isolation
   pgVerified: false
   publishedToLearn: false

--- a/azure-resources/ContainerService/managedClusters/recommendations.yaml
+++ b/azure-resources/ContainerService/managedClusters/recommendations.yaml
@@ -27,7 +27,7 @@
   recommendationResourceType: Microsoft.ContainerService/managedClusters
   recommendationMetadataState: Active
   longDescription: |
-    AKS assigns the kubernetes.azure.com/mode: system label to nodes in system node pools signaling the preference for system pods should be scheduled there. The CriticalAddonsOnly=true:NoSchedule taint can be added to your system nodes to prohibit application pods from being scheduled on them. 
+    AKS assigns the kubernetes.azure.com/mode: system label to nodes in system node pools signaling the preference for system pods should be scheduled there. The CriticalAddonsOnly=true:NoSchedule taint can be added to your system nodes to prohibit application pods from being scheduled on them.
   potentialBenefits: Enhanced reliability via pod isolation
   pgVerified: false
   publishedToLearn: false


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Changing verbiage of AKS pod scheduling on worker nodes

## Related Issues/Work Items

Replace this with a list of related GitHub Issues and/or ADO Work Items (Internal Only)

- To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
- To associate an ADO Work Item, use the key word `AB#` succeeded with the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## This PR fixes/adds/changes/removes

1. Changing verbiage of AKS pod scheduling on worker nodes

### Breaking Changes

None 

## As part of this pull request I have

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
