### PR TITLE
lb kql backend pool bug fix - fixes issue #46

### DIFF
--- a/azure-resources/Network/loadBalancers/kql/6d82d042-6d61-ad49-86f0-6a5455398081.kql
+++ b/azure-resources/Network/loadBalancers/kql/6d82d042-6d61-ad49-86f0-6a5455398081.kql
@@ -5,13 +5,31 @@ resources
 | extend bep = properties.backendAddressPools
 | extend BackEndPools = array_length(bep)
 | where BackEndPools == 0
-| project recommendationId = "6d82d042-6d61-ad49-86f0-6a5455398081", name, id, Param1=BackEndPools, Param2=0, tags
+| project recommendationId = "6d82d042-6d61-ad49-86f0-6a5455398081", name, id, Param1="backendPools", Param2=toint(0), tags
 | union (resources
-        | where type =~ 'Microsoft.Network/loadBalancers'
-        | extend bep = properties.backendAddressPools
-        | extend BackEndPools = array_length(bep)
-        | mv-expand bip = properties.backendAddressPools
-        | extend BackendAddresses = array_length(bip.properties.loadBalancerBackendAddresses)
-        | where BackendAddresses <= 1
-        | project recommendationId = "6d82d042-6d61-ad49-86f0-6a5455398081", name, id, tags, Param1=BackEndPools, Param2=BackendAddresses)
-
+  | where type =~ 'Microsoft.Network/loadBalancers'
+  | where sku.name == "Standard"
+  | extend bep = properties.backendAddressPools
+  | extend BackEndPools = toint(array_length(bep))
+  | mv-expand bip = properties.backendAddressPools
+  | extend BackendAddresses = array_length(bip.properties.loadBalancerBackendAddresses)
+  | where toint(BackendAddresses) <= 1
+  | project recommendationId = "6d82d042-6d61-ad49-86f0-6a5455398081", name, id, tags, Param1="backendAddresses", Param2=toint(BackendAddresses))
+| union (
+  resources
+  | where type =~ 'Microsoft.Network/loadBalancers'
+  | where sku.name == "Basic"
+  | mv-expand properties.backendAddressPools
+  | extend backendPoolId = properties_backendAddressPools.id
+  | project id, name, tags, tostring(backendPoolId), recommendationId = "6d82d042-6d61-ad49-86f0-6a5455398081", Param1="BackEndPools"
+  | join kind = leftouter (
+  resources
+  | where type =~ "Microsoft.Network/networkInterfaces"
+  | mv-expand properties.ipConfigurations
+  | mv-expand properties_ipConfigurations.properties.loadBalancerBackendAddressPools
+  | extend backendPoolId = tostring(properties_ipConfigurations_properties_loadBalancerBackendAddressPools.id)
+  | summarize poolMembers = count() by backendPoolId
+  | project tostring(backendPoolId), poolMembers ) on backendPoolId
+  | where toint(poolMembers) <= 1
+  | extend BackendAddresses = poolMembers
+  | project id, name, tags, recommendationId, Param1, Param2=toint(BackendAddresses))

--- a/azure-resources/Network/loadBalancers/kql/6d82d042-6d61-ad49-86f0-6a5455398081.kql
+++ b/azure-resources/Network/loadBalancers/kql/6d82d042-6d61-ad49-86f0-6a5455398081.kql
@@ -32,4 +32,4 @@ resources
   | project tostring(backendPoolId), poolMembers ) on backendPoolId
   | where toint(poolMembers) <= 1
   | extend BackendAddresses = poolMembers
-  | project id, name, tags, recommendationId, Param1, Param2=toint(BackendAddresses))
+  | project id, name, tags, recommendationId, Param1="backendAddresses", Param2=toint(BackendAddresses))


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

KQL fix for the load-balancer backend pools recommendation that attempts to correct an issue with Basic load balancer's not reporting correct results for backend pool counts.  This query counts the number of backend pool members by querying NIC's and aggregating their backend pool ID's to obtain a count.  This requires that the virtual machine members share the same scope as the load-balancer within the resource graph query.

While this is imperfect, it is better than the previous result of not finding any failures. If the virtual machines reside out of the scope, the query will continue to error and then they can be checked manually.

## Related Issues/Work Items

Replace this with a list of related GitHub Issues and/or ADO Work Items (Internal Only)

Fixes #46 

## This PR fixes/adds/changes/removes

1. issue #46 - Corrects an issue where basic load balancer sku's didn't report backend pool members properly.


### Breaking Changes

Builds on the previous query so no breaking changes.


## As part of this pull request I have

- [ x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x ] Ensured PR tests are passing
- [ x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
