### PR TITLE
Closes #171

### DIFF
--- a/azure-resources/Compute/virtualMachineScaleSets/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachineScaleSets/recommendations.yaml
@@ -177,21 +177,3 @@
     - name: Deprecated Azure Marketplace images
       url: "https://learn.microsoft.com/en-us/azure/virtual-machines/deprecated-images"
 
-- description: Mission Critical Workloads should consider using Premium or Ultra Disks
-  aprlGuid: df0ff862-814d-45a3-95e4-4fad5a244ba6
-  recommendationTypeId: null
-  recommendationControl: Scalability
-  recommendationImpact: High
-  recommendationResourceType: Microsoft.Compute/virtualMachines
-  recommendationMetadataState: Active
-  longDescription: |
-    Compared to Standard HDD and SSD, Premium SSD, SSDv2, and Ultra SSDs offer improved performance, configurability, and higher single-instance Virtual Machine uptime SLAs. The lowest SLA of all disks on a Virtual Machine applies, so it is best to use Premium or Ultra Disks for the highest uptime SLA.
-  potentialBenefits: Enhanced performance, cost efficiency, and uptime SLA
-  pgVerified: true
-  publishedToLearn: false
-  publishedToAdvisor: false
-  automationAvailable: arg
-  tags: null
-  learnMoreLink:
-    - name: Disk type comparison and decision tree
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison"


### PR DESCRIPTION
## Describe the bug

The `azure-resources/Compute/virtualMachineScaleSets/recommendations.yaml` file refers to a non-existing query, certainly because a section has been copied over from the `virtualMachines` section, without updating the aprlGuid and the query contents.

Closes #171 

## Expected behaviour

YAML should consistently refer to a single resource type and point to an existing KQL file.
