### PR TITLE
Fix "Opt-in to Cross Region Restore for all GRS Azure Recovery Services vaults"

### DIFF
--- a/azure-resources/RecoveryServices/vaults/kql/1549b91f-2ea0-4d4f-ba2a-4596becbe3de.kql
+++ b/azure-resources/RecoveryServices/vaults/kql/1549b91f-2ea0-4d4f-ba2a-4596becbe3de.kql
@@ -1,8 +1,9 @@
 // Azure Resource Graph Query
 // Displays all recovery services vaults that do not have cross region restore enabled
-
 resources
-| where type == "microsoft.recoveryservices/vaults"
-| where properties.properties.enableCrossRegionRestore != true
-| project recommendationId = "1549b91f-2ea0-4d4f-ba2a-4596becbe3de", name, id, tags
-
+| where type =~ "Microsoft.RecoveryServices/vaults" and
+    properties.redundancySettings.crossRegionRestore !~ "Enabled"
+| extend
+    param1 = strcat("CrossRegionRestore: ", properties.redundancySettings.crossRegionRestore),
+    param2 = strcat("StorageReplicationType: ", properties.redundancySettings.standardTierStorageRedundancy)
+| project recommendationId = "1549b91f-2ea0-4d4f-ba2a-4596becbe3de", name, id, tags, param1, param2

--- a/azure-resources/RecoveryServices/vaults/kql/1549b91f-2ea0-4d4f-ba2a-4596becbe3de.kql
+++ b/azure-resources/RecoveryServices/vaults/kql/1549b91f-2ea0-4d4f-ba2a-4596becbe3de.kql
@@ -2,6 +2,7 @@
 // Displays all recovery services vaults that do not have cross region restore enabled
 resources
 | where type =~ "Microsoft.RecoveryServices/vaults" and
+    properties.redundancySettings.standardTierStorageRedundancy =~ "GeoRedundant" and
     properties.redundancySettings.crossRegionRestore !~ "Enabled"
 | extend
     param1 = strcat("CrossRegionRestore: ", properties.redundancySettings.crossRegionRestore),


### PR DESCRIPTION
# Overview/Summary

Fixed the ARG query of [Opt-in to Cross Region Restore for all GRS Azure Recovery Services vaults](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/azure-resources/RecoveryServices/vaults/#opt-in-to-cross-region-restore-for-all-geo-redundant-storage-grs-azure-recovery-services-vaults)

## Related Issues/Work Items

- Fixes #179

## This PR fixes/adds/changes/removes

1. Fixes the condition for cross region restore.
2. Adds storage replication type as a condition.
3. Addes params to the result.

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

## Screenshots

There are four Recovery Services vaults in the subscription with different configurations (LRS, ZRS, GRS, GRS+CRR).

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/1618784/135b6ce1-ab07-4341-9b54-ad92556f4020)

The fixed query returns only a GRS Recovery Services vault without CRR.

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/1618784/9269e583-bc98-4f52-b2e6-327e67e03179)
