### PR TITLE
Feat/guiandfiltering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@
 
 #APRL Specific Files
 /tools/Azure-Proactive-Resiliency-Library-v2/
-/tools/wara*.json
-/tools/wara*.xlsx
+/tools/[Ww][Aa][Rr][Aa]*.json
+/tools/[Ww][Aa][Rr][Aa]*.xlsx
+/tools/[Ww][Aa][Rr][Aa]*.docx
 rg.txt
 sub.txt
 scope.txt

--- a/tools/1_wara_collector.ps1
+++ b/tools/1_wara_collector.ps1
@@ -21,6 +21,7 @@ Param(
   [switch]$AVS,
   [switch]$HPC,
   [switch]$GUI,
+  [switch]$ResourceGroupGUI,
   $RunbookFile,
   $SubscriptionIds,
   $ResourceGroups,

--- a/tools/1_wara_collector.ps1
+++ b/tools/1_wara_collector.ps1
@@ -1485,7 +1485,7 @@ function Get-AllResourceGroup {
       $TenantID = New-AzTenantSelection
       $SubscriptionIds = (New-AzSubscriptionSelection -TenantId $TenantID.id).id
 
-      if($resourcegroups){
+      if($ResourceGroupGUI){
       $ResourceGroupList = (New-AzResourceGroupSelection).id.toLower()
       $ResourceGroups = $ResourceGroupList | ForEach-Object {$_.split("/")[4]}
       }

--- a/tools/1_wara_collector.ps1
+++ b/tools/1_wara_collector.ps1
@@ -20,7 +20,7 @@ Param(
   [switch]$AVD,
   [switch]$AVS,
   [switch]$HPC,
-  [swtich]$GUI,
+  [switch]$GUI,
   $RunbookFile,
   $SubscriptionIds,
   $ResourceGroups,
@@ -38,7 +38,7 @@ if ($ConfigFile) {
   $ConfigData = Import-ConfigFileData -file $ConfigFile
   $TenantID = $ConfigData.TenantID
   $SubscriptionIds = $ConfigData.SubscriptionIds
-  $ResourceGroups = $ConfigData.ResourceGroups
+  $ResourceGroupList = $ConfigData.ResourceGroups
   $RunbookFile = $ConfigData.RunbookFile
   $Tags = $ConfigData.Tags
 }
@@ -46,8 +46,11 @@ if ($ConfigFile) {
 if($GUI){
   $TenantID = New-AzTenantSelection
   $SubscriptionIds = New-AzSubscriptionSelection -TenantId $TenantID.id
+
+  if($resourcegroups){
   $ResourceGroupList = (New-AzResourceGroupSelection).id.toLower()
   $ResourceGroups = $ResourceGroupList | ForEach-Object {$_.split("/")[4]}
+  }
 }
 
 
@@ -1430,7 +1433,7 @@ function Get-AllResourceGroup {
 
       #Ternary Expression If ResourceGroupFile is present, then get the ResourceGroups by List, else get the results
       $ResourceExporter = @{
-        Resource = $ResourceGroupFile ? $(Get-ResourceGroupsByList -ObjectList $Script:Resources -FilterList $resourcegrouplist -KeyColumn "id") : $Script:Resources
+        Resource = $ResourceGroupList ? $(Get-ResourceGroupsByList -ObjectList $Script:Resources -FilterList $resourcegrouplist -KeyColumn "id") : $Script:Resources
       }
 
       $ResourceTypeExporter = @{

--- a/tools/1_wara_collector.ps1
+++ b/tools/1_wara_collector.ps1
@@ -20,6 +20,7 @@ Param(
   [switch]$AVD,
   [switch]$AVS,
   [switch]$HPC,
+  [swtich]$GUI,
   $RunbookFile,
   $SubscriptionIds,
   $ResourceGroups,
@@ -41,6 +42,13 @@ if ($ConfigFile) {
   $RunbookFile = $ConfigData.RunbookFile
   $Tags = $ConfigData.Tags
 }
+
+if($GUI){
+  $TenantID = New-AzTenantSelection
+  $SubscriptionIds = New-AzSubscriptionSelection -TenantId $TenantID
+  $ResourceGroups = New-AzResourceGroupSelection
+}
+
 
 $Script:ShellPlatform = $PSVersionTable.Platform
 
@@ -104,10 +112,11 @@ function Get-AllResourceGroup {
 
   function New-AzResourceGroupSelection {
     param (
-      [Parameter(Mandatory=$true)]
+      [Parameter(Mandatory=$false)]
       [string[]]$SubscriptionIds
     )
-    return Get-AllResourceGroup -SubscriptionId $SubscriptionIds | Select-Object ResourceGroup, SubscriptionName, resourceId | Out-ConsoleGridView -OutputMode Multiple -Title "Select Resource Group(s)"
+    $result = $SubscriptionIds ? (Get-AllResourceGroup -SubscriptionId $SubscriptionIds) : (Get-AllResourceGroup)
+    return $result | Select-Object ResourceGroup, SubscriptionName, resourceId | Out-ConsoleGridView -OutputMode Multiple -Title "Select Resource Group(s)"
   }
 
   function Import-ConfigFileData($file){

--- a/tools/1_wara_collector.ps1
+++ b/tools/1_wara_collector.ps1
@@ -47,11 +47,11 @@ $Script:Runtime = Measure-Command -Expression {
 
   Function Get-AllAzGraphResource {
     param (
-      [string]$subscriptionId,
+      [string[]]$subscriptionId,
       [string]$query = 'Resources | project id, resourceGroup, subscriptionId, name, type, location'
     )
 
-    $result = Search-AzGraph -Query $query -first 1000 -Subscription $subscriptionId -ErrorAction SilentlyContinue # -first 1000 returns the first 1000 results and subsequently reduces the amount of queries required to get data.
+    $result = $subscriptionId ? (Search-AzGraph -Query $query -first 1000 -Subscription $subscriptionId) : (Search-AzGraph -Query $query -first 1000 -usetenantscope) # -first 1000 returns the first 1000 results and subsequently reduces the amount of queries required to get data.
 
     # Collection to store all resources
     $allResources = @($result)
@@ -59,7 +59,7 @@ $Script:Runtime = Measure-Command -Expression {
     # Loop to paginate through the results using the skip token
     while ($result.SkipToken) {
       # Retrieve the next set of results using the skip token
-      $result = Search-AzGraph -Query $query -SkipToken $result.SkipToken -Subscription $subscriptionId -First 1000 -ErrorAction SilentlyContinue
+      $result = $subscriptionId ? (Search-AzGraph -Query $query -SkipToken $result.SkipToken -Subscription $subscriptionId -First 1000) : (Search-AzGraph -query $query -SkipToken $result.SkipToken -First 1000 -UseTenantScope)
       # Add the results to the collection
       $allResources += $result
     }
@@ -68,19 +68,101 @@ $Script:Runtime = Measure-Command -Expression {
     return $allResources
   }
 
-  function Get-AllResourceGroup {
 
-    # Query to get all resource groups in the tenant
-    $q = "resourcecontainers
-    | where type == 'microsoft.resources/subscriptions'
-    | project subscriptionId, subscriptionName = name
-    | join (resourcecontainers
-        | where type == 'microsoft.resources/subscriptions/resourcegroups')
-        on subscriptionId
-    | project subscriptionName, subscriptionId, resourceGroup, id=tolower(id)"
+function Get-AllResourceGroup {
+  param (
+    [string[]]$SubscriptionIds
+  )
 
-    return Get-AllAzGraphResource -query $q
+  # Query to get all resource groups in the tenant
+  $q = "resourcecontainers
+  | where type == 'microsoft.resources/subscriptions'
+  | project subscriptionId, subscriptionName = name
+  | join (resourcecontainers
+      | where type == 'microsoft.resources/subscriptions/resourcegroups')
+      on subscriptionId
+  | project subscriptionName, subscriptionId, resourceGroup, id=tolower(id)"
+
+  $r = $SubscriptionIds ? (Get-AllAzGraphResource -query $q -subscriptionId $SubscriptionIds -usetenantscope) : (Get-AllAzGraphResource -query $q -usetenantscope)
+
+  # Returns the resource groups
+  return $r
+}
+
+  function New-AzTenantSelection {
+    return Get-AzTenant | Out-ConsoleGridView -OutputMode Single -Title "Select Tenant"
   }
+
+  function New-AzSubscriptionSelection {
+    param (
+      [Parameter(Mandatory=$true)]
+      [string]$TenantId
+    )
+    return Get-AzSubscription -TenantId $TenantId | Out-ConsoleGridView -OutputMode Multiple -title "Select Subscription(s)"
+  }
+
+  function New-AzResourceGroupSelection {
+    param (
+      [Parameter(Mandatory=$true)]
+      [string[]]$SubscriptionIds
+    )
+    return Get-AllResourceGroup -SubscriptionId $SubscriptionIds | Select-Object ResourceGroup, SubscriptionName, resourceId | Out-ConsoleGridView -OutputMode Multiple -Title "Select Resource Group(s)"
+  }
+
+  function Import-ConfigFileData($file){
+    # Read the file content and store it in a variable
+    $filecontent = (Get-content $file).trim().tolower()
+
+    # Create an array to store the line number of each section
+    $linetable = @()
+    $objarray = @{}
+
+    # Iterate through the file content and store the line number of each section
+    Foreach($line in $filecontent){
+        if (-not [string]::IsNullOrWhiteSpace($line) -and -not $line.startswith("#")){
+            # If the line is a section, store the line number
+            if ($line -match "^\[([^\]]+)\]$") {
+                # Store the section name and line number. Remove the brackets from the section name
+                $linetable += $filecontent.indexof($line)
+
+            }
+        }
+    }
+
+    # Iterate through the line numbers and extract the section content
+    $count = 0
+    foreach($entry in $linetable){
+
+        # Get the section name
+        $name = $filecontent[$entry]
+        # Remove the brackets from the section name
+        $name = $name.replace("[","").replace("]","")
+
+        # Get the start and stop line numbers for the section content
+        # If the section is the last one, set the stop line number to the end of the file
+        $start = $entry + 1
+        if($count -eq ($linetable.length-1)){
+            $stop = $filecontent.length - 1
+        }
+        else{
+            $stop = $linetable[$count+1] - 2
+        }
+
+        # Extract the section content
+        $configsection = $filecontent[$start..$stop]
+
+        # Add the section content to the object array
+        $objarray += @{$Name=$configsection}
+
+        # Increment the count
+        $count++
+    }
+
+    # Return the object array and cast to pscustomobject
+    return [pscustomobject]$objarray
+
+  }
+
 
   function Get-ResourceGroupsByList {
     param (

--- a/tools/1_wara_collector.ps1
+++ b/tools/1_wara_collector.ps1
@@ -21,24 +21,25 @@ Param(
   [switch]$AVS,
   [switch]$HPC,
   $RunbookFile,
-  $SubscriptionsFile,
   $SubscriptionIds,
-  $ResourceGroupFile,
+  $ResourceGroups,
   $TenantID,
   [ValidateSet("AzureCloud","AzureUSGovernment")]
   $AzureEnvironment = 'AzureCloud',
-  $TagsFile,
-  $Tags
+  $ConfigFile
   )
 
 #import-module "./modules/collector.psm1" -Force
 
 if ($Debugging.IsPresent) { $DebugPreference = 'Continue' } else { $DebugPreference = "silentlycontinue" }
 
-if ($ResourceGroupFile) {
-  $ResourceGroupList = (Get-Content $ResourceGroupFile).trim().tolower()
-  $ResourceGroups = $resourcegrouplist | ForEach-Object {$_.split("/")[4]}
-  $SubscriptionIds = ($resourcegrouplist | ForEach-Object {$_.split("/")[2]} | Select-Object -Unique)
+if ($ConfigFile) {
+  $ConfigData = Import-ConfigFileData -file $ConfigFile
+  $TenantID = $ConfigData.TenantID
+  $SubscriptionIds = $ConfigData.SubscriptionIds
+  $ResourceGroups = $ConfigData.ResourceGroups
+  $RunbookFile = $ConfigData.RunbookFile
+  $Tags = $ConfigData.Tags
 }
 
 $Script:ShellPlatform = $PSVersionTable.Platform

--- a/tools/1_wara_collector.ps1
+++ b/tools/1_wara_collector.ps1
@@ -45,8 +45,9 @@ if ($ConfigFile) {
 
 if($GUI){
   $TenantID = New-AzTenantSelection
-  $SubscriptionIds = New-AzSubscriptionSelection -TenantId $TenantID
-  $ResourceGroups = New-AzResourceGroupSelection
+  $SubscriptionIds = New-AzSubscriptionSelection -TenantId $TenantID.id
+  $ResourceGroupList = (New-AzResourceGroupSelection).id.toLower()
+  $ResourceGroups = $ResourceGroupList | ForEach-Object {$_.split("/")[4]}
 }
 
 
@@ -260,6 +261,15 @@ function Get-AllResourceGroup {
           {
             Write-Host "Installing Az Modules" -ForegroundColor Yellow
             Install-Module -Name Az.ResourceGraph -SkipPublisherCheck -InformationAction SilentlyContinue
+          }
+             Write-Host "Validating " -NoNewline
+        Write-Host "Az.ResourceGraph" -ForegroundColor Cyan -NoNewline
+        Write-Host " Module.."
+        $ConsoleGUITools = Get-Module -Name Microsoft.PowerShell.ConsoleGuiTools -ListAvailable -ErrorAction silentlycontinue
+        if ($null -eq $ConsoleGUITools)
+          {
+            Write-Host "Installing ConsoleGuiTools Modules" -ForegroundColor Yellow
+            Install-Module -Name Microsoft.PowerShell.ConsoleGuiTools -SkipPublisherCheck -InformationAction SilentlyContinue
           }
         Write-Host "Validating " -NoNewline
         Write-Host "Git" -ForegroundColor Cyan -NoNewline


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

<!-- Thank you for your contribution! Please add a brief description of what this Pull Request fixes, changes, etc. -->

Adds GUI elements to selection with -GUI and -ResourceGroupGUI paramters.
Adds -ConfigFile and removes -ResourceGroupFile and -SubscriptionFile.
Removes -TagFile param as well.

<!--
- To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
- To associate an ADO Work Item (internal Microsoft team member), use the key word `AB#` succeeded with the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

### Breaking Changes

1. Parameters have been changed.
2. Scoping isn't 100% implemented yet.
3. 

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
