### PR TITLE
FIX: RG Filtering

### DIFF
--- a/tools/1_wara_collector.ps1
+++ b/tools/1_wara_collector.ps1
@@ -103,7 +103,7 @@ function Get-AllResourceGroup {
       [string[]]$SubscriptionIds
     )
     $result = $SubscriptionIds ? (Get-AllResourceGroup -SubscriptionId $SubscriptionIds) : (Get-AllResourceGroup)
-    return $result | Select-Object ResourceGroup, SubscriptionName, resourceId | Out-ConsoleGridView -OutputMode Multiple -Title "Select Resource Group(s)"
+    return $result | Select-Object ResourceGroup, SubscriptionName, Id | Out-ConsoleGridView -OutputMode Multiple -Title "Select Resource Group(s)"
   }
 
   function Import-ConfigFileData($file){
@@ -1484,12 +1484,12 @@ function Get-AllResourceGroup {
     if($GUI){
       $TenantID = New-AzTenantSelection
       $SubscriptionIds = (New-AzSubscriptionSelection -TenantId $TenantID.id).id
+    }
 
-      if($ResourceGroupGUI){
-      $ResourceGroupList = (New-AzResourceGroupSelection).id.toLower()
+    if($ResourceGroupGUI){
+      $ResourceGroupList = (New-AzResourceGroupSelection).Id.tolower()
       $ResourceGroups = $ResourceGroupList | ForEach-Object {$_.split("/")[4]}
       }
-    }
 
   Write-Debug "Checking Parameters"
   Test-SubscriptionParameter


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Fixed a bug in some RG filtering that was causing it not to work at all.

<!-- Thank you for your contribution! Please add a brief description of what this Pull Request fixes, changes, etc. -->

## Related Issues/Work Items

<!--
- To associate a GitHub Issue, use a [key word](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) preceded with the GitHub issue number.
- To associate an ADO Work Item (internal Microsoft team member), use the key word `AB#` succeeded with the [ADO Work Item ID](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

### Breaking Changes

1. _Replace me_
2. _Replace me_

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
