### PR TITLE
Update 7e7daec9-6a81-3546-a4cc-9aef72fec1f7.kql Monitor your Azure SQL existing query does not return accurate results

### DIFF
--- a/azure-resources/Sql/servers/kql/7e7daec9-6a81-3546-a4cc-9aef72fec1f7.kql
+++ b/azure-resources/Sql/servers/kql/7e7daec9-6a81-3546-a4cc-9aef72fec1f7.kql
@@ -6,11 +6,11 @@ resources
 | mv-expand properties.criteria.allOf
 | project databaseid = properties_scopes, monitoredMetric = properties_criteria_allOf.metricName
 | where databaseid contains 'databases'
-| summarize monitoredMetrics=make_list(monitoredMetric) by tostring(databaseid)
-| join kind=fullouter  (
+| summarize monitoredMetrics=make_list(monitoredMetric) by databaseid=tolower(tostring(databaseid))
+| join kind=fullouter   (
    resources
-  | where type =~ 'microsoft.sql/servers/databases'
-  | project databaseid = tolower(id), name, tags
+| where type =~ 'microsoft.sql/servers/databases'
+| project databaseid = tolower(id), name, tags
 ) on databaseid
 |where isnull(monitoredMetrics)
 |project recommendationId = "7e7daec9-6a81-3546-a4cc-9aef72fec1f7", name, id=databaseid1, tags, param1=strcat("MonitoringMetrics=false" )

--- a/azure-resources/Sql/servers/kql/7e7daec9-6a81-3546-a4cc-9aef72fec1f7.kql
+++ b/azure-resources/Sql/servers/kql/7e7daec9-6a81-3546-a4cc-9aef72fec1f7.kql
@@ -9,9 +9,9 @@ resources
 | summarize monitoredMetrics=make_list(monitoredMetric) by databaseid=tolower(tostring(databaseid))
 | join kind=fullouter   (
    resources
-| where type =~ 'microsoft.sql/servers/databases'
-| project databaseid = tolower(id), name, tags
+  | where type =~ 'microsoft.sql/servers/databases'
+  | project databaseid = tolower(id), name, tags
 ) on databaseid
-|where isnull(monitoredMetrics)
-|project recommendationId = "7e7daec9-6a81-3546-a4cc-9aef72fec1f7", name, id=databaseid1, tags, param1=strcat("MonitoringMetrics=false" )
+| where isnull(monitoredMetrics)
+| project recommendationId = "7e7daec9-6a81-3546-a4cc-9aef72fec1f7", name, id=databaseid1, tags, param1=strcat("MonitoringMetrics=false" )
 

--- a/azure-resources/Sql/servers/kql/7e7daec9-6a81-3546-a4cc-9aef72fec1f7.kql
+++ b/azure-resources/Sql/servers/kql/7e7daec9-6a81-3546-a4cc-9aef72fec1f7.kql
@@ -8,7 +8,7 @@ resources
 | where databaseid contains 'databases'
 | summarize monitoredMetrics=make_list(monitoredMetric) by databaseid=tolower(tostring(databaseid))
 | join kind=fullouter   (
-   resources
+  resources
   | where type =~ 'microsoft.sql/servers/databases'
   | project databaseid = tolower(id), name, tags
 ) on databaseid


### PR DESCRIPTION


<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->



<!-- Thank you for your contribution! Please add a brief description of what this Pull Request fixes, changes, etc. -->
Modify query to give correct results :Monitor your Azure SQL Database in Near Real-Time to Detect Reliability Incidents

The current query returns databases that have a monitor alert associated with it as well as those that do not have one.

Example: I have 2 databases : **testdb** and **nomonitorsql**. I have configured an alert for **testdb** but not for **nomonitorsql**. see the screenshots below:

![DB-without-alert](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/16608331/d1405a0e-35ac-44cb-bf44-c450fe3c0d31)
![DB-with-alert](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/16608331/465694e1-b7c8-4dde-a4be-947f344b75fb)

If I run the existing query I get both databases (indicating that alerting is not set up on either), in addition to the master database.

![Existing-graph-query](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/16608331/c2396e27-24db-4337-b7f9-d8e26114afd3)
 
With the proposed query I only get the database that does not have an alert, (in addition to master of course)

![Proposed-Graph-Query](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/16608331/bb81c77b-7081-47e2-90f1-81bc38ce71dd)
 
## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
