### PR TITLE
BugFix on AVS "cannot-be-validated-with-arg" off on defined standard

### DIFF
--- a/azure-resources/AVS/privateClouds/kql/29d7a115-dfb6-4df1-9205-04824109548f.kql
+++ b/azure-resources/AVS/privateClouds/kql/29d7a115-dfb6-4df1-9205-04824109548f.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-resources/AVS/privateClouds/kql/a5ef7c05-c611-4842-9af5-11efdc99123a.kql
+++ b/azure-resources/AVS/privateClouds/kql/a5ef7c05-c611-4842-9af5-11efdc99123a.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-resources/AVS/privateClouds/kql/e0ac2f57-c8c0-4b8c-a7c8-19e5797828b5.kql
+++ b/azure-resources/AVS/privateClouds/kql/e0ac2f57-c8c0-4b8c-a7c8-19e5797828b5.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-resources/AVS/privateClouds/kql/f86355e3-de7c-4dad-8080-1b0b411e66c8.kql
+++ b/azure-resources/AVS/privateClouds/kql/f86355e3-de7c-4dad-8080-1b0b411e66c8.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-resources/AVS/privateClouds/kql/fa4ab927-bced-429a-971a-53350de7f14b.kql
+++ b/azure-resources/AVS/privateClouds/kql/fa4ab927-bced-429a-971a-53350de7f14b.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-resources/AVS/privateClouds/kql/fcc2e257-23af-4c68-aac8-9cc03033c939.kql
+++ b/azure-resources/AVS/privateClouds/kql/fcc2e257-23af-4c68-aac8-9cc03033c939.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-specialized-workloads/avs/kql/0943aa90-e3db-4c61-aef1-782b6a6a3881.kql
+++ b/azure-specialized-workloads/avs/kql/0943aa90-e3db-4c61-aef1-782b6a6a3881.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-specialized-workloads/avs/kql/6be9a543-cf82-4926-82ea-7e1f1ffaad80.kql
+++ b/azure-specialized-workloads/avs/kql/6be9a543-cf82-4926-82ea-7e1f1ffaad80.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-specialized-workloads/avs/kql/6f573d60-be93-4f18-8016-42e923e3c05e.kql
+++ b/azure-specialized-workloads/avs/kql/6f573d60-be93-4f18-8016-42e923e3c05e.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-specialized-workloads/avs/kql/726abfe3-adae-4a6d-8eb8-4b27a7214ca1.kql
+++ b/azure-specialized-workloads/avs/kql/726abfe3-adae-4a6d-8eb8-4b27a7214ca1.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-specialized-workloads/avs/kql/91c84596-1c41-48fe-8d5e-3f817e6a273b.kql
+++ b/azure-specialized-workloads/avs/kql/91c84596-1c41-48fe-8d5e-3f817e6a273b.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-specialized-workloads/avs/kql/bce16eee-0933-4baa-ab4d-8d1bb5653fc2.kql
+++ b/azure-specialized-workloads/avs/kql/bce16eee-0933-4baa-ab4d-8d1bb5653fc2.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-specialized-workloads/avs/kql/bdac462a-2eda-4a67-887d-46d58f141afe.kql
+++ b/azure-specialized-workloads/avs/kql/bdac462a-2eda-4a67-887d-46d58f141afe.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg

--- a/azure-specialized-workloads/avs/kql/c2794660-ffd7-4da3-96ba-5d546b70b1c6.kql
+++ b/azure-specialized-workloads/avs/kql/c2794660-ffd7-4da3-96ba-5d546b70b1c6.kql
@@ -1,2 +1,1 @@
-// cannot be validated with ARG
-
+// cannot-be-validated-with-arg


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Several KQL files for recommendations that cannot be validaded with arg were out of standard

## Related Issues/Work Items

Just adjusted the "cannot-be-validated-with-arg" 

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [X] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
