### PR TITLE
Improve error message in the 3_wara_reports_generator.ps1

### DIFF
--- a/tools/3_wara_reports_generator.ps1
+++ b/tools/3_wara_reports_generator.ps1
@@ -125,7 +125,7 @@ $Global:Runtime = Measure-Command -Expression {
         $ErrorStack = $_.ScriptStackTrace
         if ($CoreDebugging) { ('OfficeApps - ' + (get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Error - ' + $errorMessage) | Out-File -FilePath $LogFile -Append }
         if ($CoreDebugging) { ('OfficeApps - ' + (get-date -Format 'yyyy-MM-dd HH:mm:ss') + ' - Error - ' + $ErrorStack) | Out-File -FilePath $LogFile -Append }
-        Write-Error "Excel File not found.."
+        Write-Error "Excel File not found, or it is encrypted."
         Exit
       }
 


### PR DESCRIPTION
# Overview/Summary

Improved the error message when the specified Excel file is encrypted to provide a hint for users. The current error message `Excel File not found` will mislead users.


The **3_wara_reports_generator.ps1** script will fail with the following error message if the Excel file has a sensitivity label (= encrypted).

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/1618784/3c5f88e3-4003-4a0d-8b71-d099ae613666)

The script says `Excel File not found`. But the Excel file actually exists. The script runs with `-Debugging` option then the following logs are generated.

```
The file is not an valid Package file. If the file is encrypted, please supply the password in the constructor.
```

```
OfficeApps - 2024-06-27 14:45:51 - Error - System.Management.Automation.MethodInvocationException: Exception calling "Load" with "1" argument(s): "The file is not an valid Package file. If the file is encrypted, please supply the password in the constructor."
 ---> System.IO.InvalidDataException: The file is not an valid Package file. If the file is encrypted, please supply the password in the constructor.
   at OfficeOpenXml.Packaging.ZipPackage..ctor(Stream stream)
   at OfficeOpenXml.ExcelPackage.Load(Stream input, Stream output, String Password)
   at CallSite.Target(Closure, CallSite, ExcelPackage, Object)
   --- End of inner exception stack trace ---
   at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.Interpreter.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.LightLambda.RunVoid1[T0](T0 arg0)
   at System.Management.Automation.PSScriptCmdlet.RunClause(Action`1 clause, Object dollarUnderbar, Object inputToProcess)
   at System.Management.Automation.CommandProcessorBase.Complete()
OfficeApps - 2024-06-27 14:45:51 - Error - at Import-Excel<End>, P:\takatano\Documents\PowerShell\Modules\ImportExcel\7.8.9\Public\Import-Excel.ps1: line 125
at Excel, D:\Temp\wara\aprl-scripts-ja\3_wara_reports_generator.ps1: line 121
at <ScriptBlock>, D:\Temp\wara\aprl-scripts-ja\3_wara_reports_generator.ps1: line 2060
at <ScriptBlock>, D:\Temp\wara\aprl-scripts-ja\3_wara_reports_generator.ps1: line 69
at <ScriptBlock>, <No file>: line 1
```

## Related Issues/Work Items

None

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

## Screenshot

![image](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/assets/1618784/3b12929f-8c58-489b-ac13-06fd28888a4d)
