### PR TITLE
fix: "Network Watcher" capitalization

### DIFF
--- a/azure-resources/Network/networkWatchers/recommendations.yaml
+++ b/azure-resources/Network/networkWatchers/recommendations.yaml
@@ -90,5 +90,5 @@
   automationAvailable: no
   tags: null
   learnMoreLink:
-    - name: Network watcher traffic analytics
+    - name: Network Watcher traffic analytics
       url: "https://learn.microsoft.com/en-us/azure/network-watcher/traffic-analytics"


### PR DESCRIPTION
# Overview/Summary

Fixes "Network Watcher" capitalization.

## Related Issues/Work Items

None

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
    - Built and verified with Hugo on my local machine.
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
