### PR TITLE
fix: Menu item label overflow when it has long label

### DIFF
--- a/docs/themes/hugo-geekdoc/static/custom.css
+++ b/docs/themes/hugo-geekdoc/static/custom.css
@@ -1,1 +1,4 @@
 /* You can add custom styles here. */
+.gdoc-nav__entry {
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
# Overview/Summary

Fixes the menu item label overflow issue when it has a long label.

## Related Issues/Work Items

- #315

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
    - Built and verify on my local machine with Hugo.
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

## Screenshot

![image](https://github.com/user-attachments/assets/c56bf49f-7105-45b9-970f-d5de31166f26)
