### PR TITLE
fix: OpenSSF Scorecard badge URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/Azure/Azure-Proactive-Resiliency-Library-v2.svg)](http://isitmaintained.com/project/Azure/Azure-Proactive-Resiliency-Library-v2 "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/Azure/Azure-Proactive-Resiliency-Library-v2.svg)](http://isitmaintained.com/project/Azure/Azure-Proactive-Resiliency-Library-v2 "Percentage of issues still open")
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Azure/ALZ-Bicep/badge)](https://scorecard.dev/viewer/?uri=github.com/Azure/ALZ-Bicep)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Azure/Azure-Proactive-Resiliency-Library-v2/badge)](https://scorecard.dev/viewer/?uri=github.com/Azure/Azure-Proactive-Resiliency-Library-v2)
 
 > **Please access the GitHub Pages site, unless looking to contribute, over at: [aka.ms/aprl](https://aka.ms/aprl)**
 


### PR DESCRIPTION
# Overview/Summary

Fixes the OpenSSF Scorecard badge URI.

- Current

    [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Azure/ALZ-Bicep/badge)](https://scorecard.dev/viewer/?uri=github.com/Azure/ALZ-Bicep)

- Fixed

    [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Azure/Azure-Proactive-Resiliency-Library-v2/badge)](https://scorecard.dev/viewer/?uri=github.com/Azure/Azure-Proactive-Resiliency-Library-v2)

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
