### PR TITLE
fix: Fix typo in learn more link URL

### DIFF
--- a/azure-resources/Databricks/workspaces/recommendations.yaml
+++ b/azure-resources/Databricks/workspaces/recommendations.yaml
@@ -513,7 +513,7 @@
   tags: null
   learnMoreLink:
     - name: Azure Databricks Best Practices
-      url: "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#do-not-store-any-production-data-in-default-dbfs-foldersr"
+      url: "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#do-not-store-any-production-data-in-default-dbfs-folders"
 
 - description: Do not use Azure Spot VMs for critical Production workloads
   aprlGuid: b5af7e26-3939-1b48-8fba-f8d4a475c67a


### PR DESCRIPTION
# Overview/Summary

Fixes a typo in the learn more link URL.

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
