### PR TITLE
BugFix on PPT Slide 16 for Impacted Resources

### DIFF
--- a/tools/3_wara_reports_generator.ps1
+++ b/tools/3_wara_reports_generator.ps1
@@ -422,7 +422,7 @@ $Global:Runtime = Measure-Command -Expression {
                 ($Slide16.Shapes | Where-Object { $_.Id -eq 44 }).GroupItems[6].TextFrame.TextRange.Text = [string]($ExcelCore | Where-Object { $_."Number of Impacted Resources?" -gt 0 -and $_.Impact -eq 'Low' }).count
                 if ($Heavy) {Start-Sleep -Milliseconds 100}
                 #Impacted Resources
-                ($Slide16.Shapes | Where-Object { $_.Id -eq 44 }).GroupItems[7].TextFrame.TextRange.Text = [string]($ExcelContent.id | Where-Object { ![string]::IsNullOrEmpty($_) } | Select-Object -Unique).count
+                ($Slide16.Shapes | Where-Object { $_.Id -eq 44 }).GroupItems[7].TextFrame.TextRange.Text = [string]($ExcelContent.id | Where-Object { ![string]::IsNullOrEmpty($_) } | Select-Object -Unique -CaseInsensitive).count
                 if ($Heavy) {Start-Sleep -Milliseconds 100}
               }
             catch


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

BugFix for PPTX file generated by the 3rd script (tooling). The total number of Impacted Resources may be incorrect due to case sensitive.


### Breaking Changes

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
