### PR TITLE
fix: Fix learn more links

### DIFF
--- a/azure-resources/Network/networkWatchers/recommendations.yaml
+++ b/azure-resources/Network/networkWatchers/recommendations.yaml
@@ -71,8 +71,10 @@
   automationAvailable: no
   tags: null
   learnMoreLink:
-    - name: NSG and VNET Flow logs
+    - name: Flow logging for network security groups
       url: "https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-overview"
+    - name: Virtual network flow logs
+      url: "https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-overview"
 
 - description: Enable traffic analytics in Network Security Group and Virtual Network Flow Logs configuration.
   aprlGuid: bf0b7dbd-016d-458c-af99-70fcb03ad451


### PR DESCRIPTION
# Overview/Summary

Fixed learn more links of [Enable Network Security Group and Virtual Network Flow Logs](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/azure-resources/Network/networkWatchers/#enable-network-security-group-and-virtual-network-flow-logs).

- The existing learn more link is describe only NSG flow logs.
- The added learn more link is describe VNet flow logs.

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
