### PR TITLE
feat: [Collector] Add RepoUrl parameter for custom ARPL repo

### DIFF
--- a/tools/1_wara_collector.ps1
+++ b/tools/1_wara_collector.ps1
@@ -69,7 +69,7 @@ NOTE: Can't be used in combination with -ConfigFile, -ResourceGroups, or -Tags p
 NOTE: This parameter is only used when a runbook file (-RunbookFile) is provided.
 
 .PARAMETER RepoUrl
-Specifies the git repository URL that contains APRL contents if you want to use non-standard APRL repository.
+Specifies the git repository URL that contains APRL contents if you want to use custom APRL repository.
 
 .EXAMPLE
 Run against all subscriptions in tenant "00000000-0000-0000-0000-000000000000":


### PR DESCRIPTION
# Overview/Summary

Added the RepoUrl parameter to specify custom ARPL repo URL.

Our team uses the [translated APRL contents into Japanese](https://github.com/tksh164/aprl-v2-ja) because customers in Japan strongly want to Japanese artifacts (Excel, PowerPoint, etc).

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
