### PR TITLE
fix: arg code for PostgreSQL read replica detection

### DIFF
--- a/azure-resources/DBforPostgreSQL/flexibleServers/kql/2ab85a67-26be-4ed2-a0bb-101b2513ec63.kql
+++ b/azure-resources/DBforPostgreSQL/flexibleServers/kql/2ab85a67-26be-4ed2-a0bb-101b2513ec63.kql
@@ -1,6 +1,8 @@
 // Azure Resource Graph Query
-// Find Database for PostgreSQL instances that are read replicas
+// Find Database for PostgreSQL instances that do not have read replicas
 resources
-| where type == "microsoft.dbforpostgresql/flexibleservers"
-| where properties.replicationRole == "AsyncReplica"
-| project recommendationId = "2ab85a67-26be-4ed2-a0bb-101b2513ec63", name, id, tags, param1 = strcat("replicationRole:", properties['replicationRole'])
+| where type == "microsoft.dbforpostgresql/flexibleservers" and properties.replicationRole == "AsyncReplica"
+| project replicaServerId = id, id = tostring(properties.sourceServerResourceId)
+| join kind=fullouter (resources | where type == "microsoft.dbforpostgresql/flexibleservers" and properties.replicationRole != "AsyncReplica") on id
+| where isempty(replicaServerId)
+| project recommendationId = "2ab85a67-26be-4ed2-a0bb-101b2513ec63", name, id = id1, tags, param1 = strcat("replicationRole:", properties['replicationRole'])


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

<!-- Thank you for your contribution! Please add a brief description of what this Pull Request fixes, changes, etc. -->

Initial ARG code "Find Database for PostgreSQL instances that are read replicas" but we're looking for "Database for PostgreSQL instances that do not have read replicas".

Before my fix 👇 

![fix-readreplica-before](https://github.com/user-attachments/assets/c1d4146d-72ec-482a-8dc0-f0e86398e626)

After my fix 👇 

![fix-readreplica-after](https://github.com/user-attachments/assets/4b640605-1d92-4592-9a77-2dd19db8d71f)

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
