### PR TITLE
feat: Add recommendation for Service Bus minimum TLS version 

### DIFF
--- a/azure-resources/ServiceBus/namespaces/kql/f075a1bd-de9e-4819-9a1d-1ac41037a74f.kql
+++ b/azure-resources/ServiceBus/namespaces/kql/f075a1bd-de9e-4819-9a1d-1ac41037a74f.kql
@@ -1,0 +1,8 @@
+resources
+| where type =~ "Microsoft.ServiceBus/namespaces" and properties.minimumTlsVersion in ("1.0", "1.1")
+| project
+    recommendationId = "f075a1bd-de9e-4819-9a1d-1ac41037a74f",
+    name,
+    id,
+    tags,
+    param1 = strcat("minimumTlsVersion: ", properties.minimumTlsVersion)

--- a/azure-resources/ServiceBus/namespaces/kql/f075a1bd-de9e-4819-9a1d-1ac41037a74f.kql
+++ b/azure-resources/ServiceBus/namespaces/kql/f075a1bd-de9e-4819-9a1d-1ac41037a74f.kql
@@ -1,5 +1,6 @@
 resources
-| where type =~ "Microsoft.ServiceBus/namespaces" and properties.minimumTlsVersion in ("1.0", "1.1")
+| where type =~ "Microsoft.ServiceBus/namespaces"
+| where properties.minimumTlsVersion in ("1.0", "1.1")
 | project
     recommendationId = "f075a1bd-de9e-4819-9a1d-1ac41037a74f",
     name,

--- a/azure-resources/ServiceBus/namespaces/kql/f075a1bd-de9e-4819-9a1d-1ac41037a74f.kql
+++ b/azure-resources/ServiceBus/namespaces/kql/f075a1bd-de9e-4819-9a1d-1ac41037a74f.kql
@@ -1,3 +1,5 @@
+// Azure Resource Graph Query
+// Provides a list of Service Bus Namespace resources that have the lower minimum TLS version.
 resources
 | where type =~ "Microsoft.ServiceBus/namespaces"
 | where properties.minimumTlsVersion in ("1.0", "1.1")

--- a/azure-resources/ServiceBus/namespaces/recommendations.yaml
+++ b/azure-resources/ServiceBus/namespaces/recommendations.yaml
@@ -37,3 +37,23 @@
   learnMoreLink:
     - name: Service Bus auto-scaling
       url: "https://learn.microsoft.com/azure/service-bus-messaging/automate-update-messaging-units"
+
+- description: Configure the minimum TLS version for Service Bus namespaces to TLS v1.2 or higher
+  aprlGuid: f075a1bd-de9e-4819-9a1d-1ac41037a74f
+  recommendationTypeId: null
+  recommendationControl: Service Upgrade and Retirement
+  recommendationImpact: High
+  recommendationResourceType: Microsoft.ServiceBus/namespaces
+  recommendationMetadataState: Active
+  longDescription: |
+    As of 31 October 2024, TLS 1.0 and TLS 1.1 will no longer be supported on Azure including Service Bus to enhance security and provide best-in-class encryption for your data. Change the minimum TLS version for your Service Bus namespace to TLS v1.2 or higher.
+  potentialBenefits: Avoids service disruption
+  pgVerified: false
+  publishedToLearn: false
+  automationAvailable: true
+  tags: null
+  learnMoreLink:
+    - name: Azure support for TLS 1.0 and TLS 1.1 will end by 31 October 2024
+      url: "https://azure.microsoft.com/updates/azure-support-tls-will-end-by-31-october-2024-2/"
+    - name: Configure the minimum TLS version for a Service Bus namespace
+      url: "https://learn.microsoft.com/azure/service-bus-messaging/transport-layer-security-configure-minimum-version"


### PR DESCRIPTION
# Overview/Summary

Adds a recommendation for the lower minimum TLS version of Service Bus namespaces.

## Related Issues/Work Items

- #420

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

## Screenshot

![image](https://github.com/user-attachments/assets/953b70db-720a-4160-a754-89b97479089f)

![image](https://github.com/user-attachments/assets/14b08e7e-776a-4138-9d49-a966dbb8fce2)