### PR TITLE
fix: collector doc content about cloud shell requirements

### DIFF
--- a/docs/content/tools/collector/_index.md
+++ b/docs/content/tools/collector/_index.md
@@ -71,7 +71,7 @@ See at the end of this page various examples of how to run this script - [Exampl
 
 **You have two options to run the collector script:**
 
-1. Cloud Shell - Requires Cloud Shell be configured with write access to a file share within the same tenant
+1. Cloud Shell
 
 1. Local Machine - Requires current modules leveraged in the script be installed
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

<!-- Thank you for your contribution! Please add a brief description of what this Pull Request fixes, changes, etc. -->

The use of a storage account is no longer required for Cloud Shell.

![cloudshell](https://github.com/user-attachments/assets/aae2349d-e5d4-4a06-b71f-487f8d0e8d76)

I confirm that I have validated the correct operation of the collector script under these conditions.

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
