### PR TITLE
fix: Fix recommendationResourceType example value

### DIFF
--- a/docs/content/contributing/create-content/create-recommendations/_index.md
+++ b/docs/content/contributing/create-content/create-recommendations/_index.md
@@ -72,7 +72,7 @@ The YAML structure for adding new recommendations consists of several key-value 
 | recommendationTypeId | 3464854d-6f75-4922-95e4-a2a308b53ce6 | String | `null` until updated by the Azure Advisor team | The unique identifier for the recommendation in the context of Advisor. |
 | recommendationControl | Monitoring and Alerting | String | [High Availability, Business Continuity, Disaster Recovery, Scalability, Monitoring and Alerting, Service Upgrade and Retirement, Other Best Practices, Personalized, Governance, Security](#recommendation-categories) | Resiliency category associated with the recommendation |
 | recommendationImpact | Medium | String | Low, Medium, High | Importance of adopting the recommendation and/or the risk of choosing not to adopt |
-| recommendationResourceType | Storage Account | String | Align with the resource type | Friendly name to identity resource type |
+| recommendationResourceType | Microsoft.Storage/storageAccounts | String | Align with the resource type | Friendly name to identity resource type |
 | recommendationMetadataState | Active | String | Active, Disabled | Indicates whether the recommendation is visible |
 | longDescription | To enable Cross-region disaster recovery and business continuity, ensure that the appropriate quotas are set for all user subscription Batch accounts. | String | The length should be less than 300 characters | Detailed description of the recommendation and its implications |
 | potentialBenefits | Enhanced data redundancy and boosts availability | String | The length should be less than 60 characters | The potential benefits of implementing the recommendation |

--- a/tools/data/recommendations.json
+++ b/tools/data/recommendations.json
@@ -6,8 +6,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-high-availability",
-        "name": "Overview of high availability with Azure Database for PostgreSQL"
+        "name": "Overview of high availability with Azure Database for PostgreSQL",
+        "url": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-high-availability"
       }
     ],
     "recommendationControl": "High Availability",
@@ -29,8 +29,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-maintenance",
-        "name": "Scheduled maintenance in Azure Database for PostgreSQL - Flexible Server"
+        "name": "Scheduled maintenance in Azure Database for PostgreSQL - Flexible Server",
+        "url": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-maintenance"
       }
     ],
     "recommendationControl": "Scalability",
@@ -52,8 +52,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-backup-restore",
-        "name": "Backup and restore in Azure Database for PostgreSQL - Flexible Server"
+        "name": "Backup and restore in Azure Database for PostgreSQL - Flexible Server",
+        "url": "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-backup-restore"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -75,8 +75,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-read-replicas",
-        "name": "Read replicas in Azure Database for PostgreSQL - Flexible Server"
+        "name": "Read replicas in Azure Database for PostgreSQL - Flexible Server",
+        "url": "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-read-replicas"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -98,8 +98,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-auto-grow-storage-portal",
-        "name": "Storage autogrow using Azure portal in Azure Database for PostgreSQL - Flexible Server"
+        "name": "Storage autogrow using Azure portal in Azure Database for PostgreSQL - Flexible Server",
+        "url": "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-auto-grow-storage-portal"
       }
     ],
     "recommendationControl": "Scalability",
@@ -121,8 +121,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-network-mapping#set-up-ip-addressing-for-target-vms",
-        "name": "Setup network mapping for site recovery"
+        "name": "Setup network mapping for site recovery",
+        "url": "https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-network-mapping#set-up-ip-addressing-for-target-vms"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -144,8 +144,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-tutorial-dr-drill#run-a-test-failover",
-        "name": "Run a test failover"
+        "name": "Run a test failover",
+        "url": "https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-tutorial-dr-drill#run-a-test-failover"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -167,12 +167,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/backup/move-to-azure-monitor-alerts",
-        "name": "Move to Azure monitor Alerts"
+        "name": "Move to Azure monitor Alerts",
+        "url": "https://learn.microsoft.com/azure/backup/move-to-azure-monitor-alerts"
       },
       {
-        "url": "https://azure.microsoft.com/updates/transition-to-builtin-azure-monitor-alerts-for-recovery-services-vaults-in-azure-backup-by-31-march-2026/",
-        "name": "Classic alerts retirement announcement"
+        "name": "Classic alerts retirement announcement",
+        "url": "https://azure.microsoft.com/updates/transition-to-builtin-azure-monitor-alerts-for-recovery-services-vaults-in-azure-backup-by-31-march-2026/"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -194,20 +194,20 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/backup/backup-create-recovery-services-vault#set-cross-region-restore",
-        "name": "Set Cross Region Restore"
+        "name": "Set Cross Region Restore",
+        "url": "https://learn.microsoft.com/azure/backup/backup-create-recovery-services-vault#set-cross-region-restore"
       },
       {
-        "url": "https://learn.microsoft.com/azure/backup/guidance-best-practices",
-        "name": "Azure Backup Best Practices"
+        "name": "Azure Backup Best Practices",
+        "url": "https://learn.microsoft.com/azure/backup/guidance-best-practices"
       },
       {
-        "url": "https://learn.microsoft.com/azure/backup/backup-rbac-rs-vault#minimum-role-requirements-for-azure-vm-backup",
-        "name": "Minimum Role Requirements for Cross Region Restore"
+        "name": "Minimum Role Requirements for Cross Region Restore",
+        "url": "https://learn.microsoft.com/azure/backup/backup-rbac-rs-vault#minimum-role-requirements-for-azure-vm-backup"
       },
       {
-        "url": "https://learn.microsoft.com/azure/backup/backup-azure-arm-vms-prepare",
-        "name": "Recovery Services Vault"
+        "name": "Recovery Services Vault",
+        "url": "https://learn.microsoft.com/azure/backup/backup-azure-arm-vms-prepare"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -229,8 +229,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/backup/backup-azure-security-feature-cloud?tabs=azure-portal",
-        "name": "Soft Delete for Azure Backup"
+        "name": "Soft Delete for Azure Backup",
+        "url": "https://learn.microsoft.com/azure/backup/backup-azure-security-feature-cloud?tabs=azure-portal"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -252,8 +252,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices",
-        "name": "Container Registry Best Practices"
+        "name": "Container Registry Best Practices",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices"
       }
     ],
     "recommendationControl": "Scalability",
@@ -275,8 +275,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/zone-redundancy?toc=%2Fazure%2Freliability%2Ftoc.json&bc=%2Fazure%2Freliability%2Fbreadcrumb%2Ftoc.json&branch=main",
-        "name": "Registry best practices - Enable zone redundancy"
+        "name": "Registry best practices - Enable zone redundancy",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/zone-redundancy?toc=%2Fazure%2Freliability%2Ftoc.json&bc=%2Fazure%2Freliability%2Fbreadcrumb%2Ftoc.json&branch=main"
       }
     ],
     "recommendationControl": "High Availability",
@@ -298,12 +298,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#geo-replicate-multi-region-deployments",
-        "name": "Registry best practices - Enable geo-replication"
+        "name": "Registry best practices - Enable geo-replication",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#geo-replicate-multi-region-deployments"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-geo-replication",
-        "name": "Geo-Replicate Container Registry"
+        "name": "Geo-Replicate Container Registry",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-geo-replication"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -325,8 +325,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#repository-namespaces",
-        "name": "Registry best practices - use repository namespaces"
+        "name": "Registry best practices - use repository namespaces",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#repository-namespaces"
       }
     ],
     "recommendationControl": "Security",
@@ -348,8 +348,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#dedicated-resource-group",
-        "name": "Registry best practices - Use dedicated resource group"
+        "name": "Registry best practices - Use dedicated resource group",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#dedicated-resource-group"
       }
     ],
     "recommendationControl": "Governance",
@@ -371,12 +371,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#manage-registry-size",
-        "name": "Registry best practices - Manage registry size"
+        "name": "Registry best practices - Manage registry size",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#manage-registry-size"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-retention-policy#about-the-retention-policy",
-        "name": "Retention Policy"
+        "name": "Retention Policy",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-retention-policy#about-the-retention-policy"
       }
     ],
     "recommendationControl": "Scalability",
@@ -398,8 +398,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/anonymous-pull-access#about-anonymous-pull-access",
-        "name": "Enable anonymous pull access"
+        "name": "Enable anonymous pull access",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/anonymous-pull-access#about-anonymous-pull-access"
       }
     ],
     "recommendationControl": "Security",
@@ -421,12 +421,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service-reference#resource-logs",
-        "name": "Monitoring Azure Container Registry data reference - Resource Logs"
+        "name": "Monitoring Azure Container Registry data reference - Resource Logs",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service-reference#resource-logs"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service#collection-and-routing",
-        "name": "Monitor Azure Container Registry - Enable diagnostic logs"
+        "name": "Monitor Azure Container Registry - Enable diagnostic logs",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service#collection-and-routing"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -448,12 +448,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service-reference#metrics",
-        "name": "Monitoring Azure Container Registry data reference"
+        "name": "Monitoring Azure Container Registry data reference",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service-reference#metrics"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service",
-        "name": "Monitor Azure Container Registry"
+        "name": "Monitor Azure Container Registry",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -475,8 +475,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-soft-delete-policy",
-        "name": "Enable soft delete policy"
+        "name": "Enable soft delete policy",
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-soft-delete-policy"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -498,8 +498,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/traffic-collector",
-        "name": "Azure ExpressRoute Traffic Collector"
+        "name": "Azure ExpressRoute Traffic Collector",
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/traffic-collector"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -521,12 +521,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/api-management/upgrade-and-scale#change-your-api-management-service-tier",
-        "name": "Change your API Management service tier"
+        "name": "Change your API Management service tier",
+        "url": "https://learn.microsoft.com/en-us/azure/api-management/upgrade-and-scale#change-your-api-management-service-tier"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/reliability/migrate-api-mgt",
-        "name": "Migrate Azure API Management to availability zone support"
+        "name": "Migrate Azure API Management to availability zone support",
+        "url": "https://learn.microsoft.com/en-us/azure/reliability/migrate-api-mgt"
       }
     ],
     "recommendationControl": "High Availability",
@@ -548,12 +548,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/api-management/high-availability#availability-zones",
-        "name": "Ensure API Management availability and reliability"
+        "name": "Ensure API Management availability and reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/api-management/high-availability#availability-zones"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/reliability/migrate-api-mgt",
-        "name": "Migrate Azure API Management to availability zone support"
+        "name": "Migrate Azure API Management to availability zone support",
+        "url": "https://learn.microsoft.com/en-us/azure/reliability/migrate-api-mgt"
       }
     ],
     "recommendationControl": "High Availability",
@@ -575,12 +575,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/api-management/breaking-changes/stv1-platform-retirement-august-2024",
-        "name": "Azure API Management - stv1 platform retirement (August 2024)"
+        "name": "Azure API Management - stv1 platform retirement (August 2024)",
+        "url": "https://learn.microsoft.com/en-us/azure/api-management/breaking-changes/stv1-platform-retirement-august-2024"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/api-management/compute-infrastructure",
-        "name": "Azure API Management compute platform"
+        "name": "Azure API Management compute platform",
+        "url": "https://learn.microsoft.com/en-us/azure/api-management/compute-infrastructure"
       }
     ],
     "recommendationControl": "High Availability",
@@ -602,8 +602,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/api-management/api-management-howto-autoscale",
-        "name": "Setting up auto-scale for Azure API Management"
+        "name": "Setting up auto-scale for Azure API Management",
+        "url": "https://learn.microsoft.com/azure/api-management/api-management-howto-autoscale"
       }
     ],
     "recommendationControl": "High Availability",
@@ -625,8 +625,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-soft-delete#purge-protection",
-        "name": "Purge protection"
+        "name": "Purge protection",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-soft-delete#purge-protection"
       }
     ],
     "recommendationControl": "Governance",
@@ -648,8 +648,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-app-configuration/faq#which-app-configuration-tier-should-i-use",
-        "name": "Choose App Configuration tier"
+        "name": "Choose App Configuration tier",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-app-configuration/faq#which-app-configuration-tier-should-i-use"
       }
     ],
     "recommendationControl": "High Availability",
@@ -671,8 +671,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/key-vault/general/soft-delete-overview",
-        "name": "Azure Key Vault soft-delete overview"
+        "name": "Azure Key Vault soft-delete overview",
+        "url": "https://learn.microsoft.com/azure/key-vault/general/soft-delete-overview"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -694,8 +694,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/key-vault/general/soft-delete-overview#purge-protection",
-        "name": "Azure Key Vault purge-protection overview"
+        "name": "Azure Key Vault purge-protection overview",
+        "url": "https://learn.microsoft.com/azure/key-vault/general/soft-delete-overview#purge-protection"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -717,8 +717,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/key-vault/general/security-features#network-security",
-        "name": "Azure Key Vault Private Link Service overview"
+        "name": "Azure Key Vault Private Link Service overview",
+        "url": "https://learn.microsoft.com/azure/key-vault/general/security-features#network-security"
       }
     ],
     "recommendationControl": "Security",
@@ -740,8 +740,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/key-vault/general/best-practices#why-we-recommend-separate-key-vaults",
-        "name": "Azure Key Vault best practices overview"
+        "name": "Azure Key Vault best practices overview",
+        "url": "https://learn.microsoft.com/azure/key-vault/general/best-practices#why-we-recommend-separate-key-vaults"
       }
     ],
     "recommendationControl": "Governance",
@@ -763,8 +763,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/key-vault/general/logging?tabs=Vault",
-        "name": "Azure Key Vault logging overview"
+        "name": "Azure Key Vault logging overview",
+        "url": "https://learn.microsoft.com/azure/key-vault/general/logging?tabs=Vault"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -786,12 +786,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/logs/logs-data-export",
-        "name": "Log Analytics workspace data export in Azure Monitor"
+        "name": "Log Analytics workspace data export in Azure Monitor",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/logs/logs-data-export"
       },
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/best-practices-logs#configuration-recommendations",
-        "name": "Azure Monitor configuration recommendations"
+        "name": "Azure Monitor configuration recommendations",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/best-practices-logs#configuration-recommendations"
       }
     ],
     "recommendationControl": "Governance",
@@ -813,12 +813,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/logs/log-analytics-workspace-health",
-        "name": "Monitor Log Analytics workspace health"
+        "name": "Monitor Log Analytics workspace health",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/logs/log-analytics-workspace-health"
       },
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/best-practices-logs#configuration-recommendations",
-        "name": "Azure Monitor configuration recommendations"
+        "name": "Azure Monitor configuration recommendations",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/best-practices-logs#configuration-recommendations"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -840,20 +840,20 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-network/concepts-and-best-practices",
-        "name": "Azure Virtual Network - Concepts and best practices | Microsoft Learn"
+        "name": "Azure Virtual Network - Concepts and best practices | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/virtual-network/concepts-and-best-practices"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsub",
-        "name": "GatewaySUbnet"
+        "name": "GatewaySUbnet",
+        "url": "https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsub"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/route-server/route-server-faq#can-i-associate-a-network-security-group-nsg-to-the-routeserversubnet",
-        "name": "Can I associate a network security group (NSG) to the RouteServerSubnet?"
+        "name": "Can I associate a network security group (NSG) to the RouteServerSubnet?",
+        "url": "https://learn.microsoft.com/en-us/azure/route-server/route-server-faq#can-i-associate-a-network-security-group-nsg-to-the-routeserversubnet"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/firewall/firewall-faq#are-network-security-groups--nsgs--supported-on-the-azurefirewallsubnet",
-        "name": "Are Network Security Groups (NSGs) supported on the AzureFirewallSubnet?"
+        "name": "Are Network Security Groups (NSGs) supported on the AzureFirewallSubnet?",
+        "url": "https://learn.microsoft.com/en-us/azure/firewall/firewall-faq#are-network-security-groups--nsgs--supported-on-the-azurefirewallsubnet"
       }
     ],
     "recommendationControl": "Security",
@@ -875,8 +875,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-virtual-network/reliability",
-        "name": "Reliability and Azure Virtual Network - Microsoft Azure Well-Architected Framework | Microsoft Learn"
+        "name": "Reliability and Azure Virtual Network - Microsoft Azure Well-Architected Framework | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-virtual-network/reliability"
       }
     ],
     "recommendationControl": "Security",
@@ -898,16 +898,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-faq",
-        "name": "Azure Virtual Network FAQ | Microsoft Learn"
+        "name": "Azure Virtual Network FAQ | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-faq"
       },
       {
-        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/network-connectivity/reliability",
-        "name": "Reliability and Network connectivity - Microsoft Azure Well-Architected Framework | Microsoft LearnNetworking Reliability"
+        "name": "Reliability and Network connectivity - Microsoft Azure Well-Architected Framework | Microsoft LearnNetworking Reliability",
+        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/network-connectivity/reliability"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/private-link/availability",
-        "name": "Azure Private Link availability"
+        "name": "Azure Private Link availability",
+        "url": "https://learn.microsoft.com/en-us/azure/private-link/availability"
       }
     ],
     "recommendationControl": "Security",
@@ -929,12 +929,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-network/ip-services/public-ip-addresses#availability-zone",
-        "name": "Public IP addresses - Availability Zones"
+        "name": "Public IP addresses - Availability Zones",
+        "url": "https://learn.microsoft.com/azure/virtual-network/ip-services/public-ip-addresses#availability-zone"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance#steps-to-complete-the-upgrade",
-        "name": "Upgrading a basic public IP address to Standard SKU"
+        "name": "Upgrading a basic public IP address to Standard SKU",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance#steps-to-complete-the-upgrade"
       }
     ],
     "recommendationControl": "High Availability",
@@ -956,12 +956,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#use-nat-gateway-for-outbound-connectivity",
-        "name": "Use NAT GW for outbound connectivity"
+        "name": "Use NAT GW for outbound connectivity",
+        "url": "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#use-nat-gateway-for-outbound-connectivity"
       },
       {
-        "url": "https://learn.microsoft.com/azure/architecture/framework/services/compute/azure-app-service/reliability#tcp-and-snat-ports",
-        "name": "TCP and SNAT Ports"
+        "name": "TCP and SNAT Ports",
+        "url": "https://learn.microsoft.com/azure/architecture/framework/services/compute/azure-app-service/reliability#tcp-and-snat-ports"
       }
     ],
     "recommendationControl": "High Availability",
@@ -983,12 +983,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance",
-        "name": "Upgrading a basic public IP address to Standard SKU - Guidance"
+        "name": "Upgrading a basic public IP address to Standard SKU - Guidance",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance"
       },
       {
-        "url": "https://azure.microsoft.com/en-us/updates/upgrade-to-standard-sku-public-ip-addresses-in-azure-by-30-september-2025-basic-sku-will-be-retired/",
-        "name": "Upgrade to Standard SKU public IP addresses in Azure by 30 September 2025 as Basic SKU will be retired"
+        "name": "Upgrade to Standard SKU public IP addresses in Azure by 30 September 2025 as Basic SKU will be retired",
+        "url": "https://azure.microsoft.com/en-us/updates/upgrade-to-standard-sku-public-ip-addresses-in-azure-by-30-september-2025-basic-sku-will-be-retired/"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1010,8 +1010,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/ddos-protection/ddos-protection-overview",
-        "name": "Azure DDoS Protection"
+        "name": "Azure DDoS Protection",
+        "url": "https://learn.microsoft.com/en-us/azure/ddos-protection/ddos-protection-overview"
       }
     ],
     "recommendationControl": "Security",
@@ -1033,8 +1033,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell",
-        "name": "Azure activity log - Azure Monitor | Microsoft Learn"
+        "name": "Azure activity log - Azure Monitor | Microsoft Learn",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1056,8 +1056,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?toc=%2Fazure%2Fvirtual-network%2Ftoc.json&tabs=json",
-        "name": "Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn"
+        "name": "Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?toc=%2Fazure%2Fvirtual-network%2Ftoc.json&tabs=json"
       }
     ],
     "recommendationControl": "Governance",
@@ -1079,12 +1079,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-gateway-design#scale-a-nat-gateway-to-meet-the-demand-of-a-dynamic-workload",
-        "name": "Scale a NAT gateway to meet the demand of a dynamic workload"
+        "name": "Scale a NAT gateway to meet the demand of a dynamic workload",
+        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-gateway-design#scale-a-nat-gateway-to-meet-the-demand-of-a-dynamic-workload"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-metrics#total-snat-connection-count",
-        "name": "Total SNAT Connection Count"
+        "name": "Total SNAT Connection Count",
+        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-metrics#total-snat-connection-count"
       }
     ],
     "recommendationControl": "Scalability",
@@ -1106,12 +1106,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-metrics",
-        "name": "What is Azure NAT Gateway metrics and alerts?"
+        "name": "What is Azure NAT Gateway metrics and alerts?",
+        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-metrics"
       },
       {
-        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/natGateways/",
-        "name": "AMBA - NAT Gateway"
+        "name": "AMBA - NAT Gateway",
+        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/natGateways/"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1133,8 +1133,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-availability-zones#zonal-nat-gateway-resource-for-each-zone-in-a-region-to-create-zone-resiliency",
-        "name": "Zonal NAT gateway resource for each zone in a region to create zone-resiliency"
+        "name": "Zonal NAT gateway resource for each zone in a region to create zone-resiliency",
+        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-availability-zones#zonal-nat-gateway-resource-for-each-zone-in-a-region-to-create-zone-resiliency"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1156,8 +1156,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-disaster-recovery-with-expressroute-privatepeering",
-        "name": "Designing for disaster recovery with ExpressRoute private peering"
+        "name": "Designing for disaster recovery with ExpressRoute private peering",
+        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-disaster-recovery-with-expressroute-privatepeering"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1179,12 +1179,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/designing-for-high-availability-with-expressroute",
-        "name": "Designing for high availability with ExpressRoute"
+        "name": "Designing for high availability with ExpressRoute",
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/designing-for-high-availability-with-expressroute"
       },
       {
-        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-expressroute#recommendations",
-        "name": "Azure Well-Architected Framework review - Azure ExpressRoute - Design Checklist"
+        "name": "Azure Well-Architected Framework review - Azure ExpressRoute - Design Checklist",
+        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-expressroute#recommendations"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1206,8 +1206,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-high-availability-with-expressroute#active-active-connections",
-        "name": "Designing for high availability with ExpressRoute - Active-active connections"
+        "name": "Designing for high availability with ExpressRoute - Active-active connections",
+        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-high-availability-with-expressroute#active-active-connections"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1229,8 +1229,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-bfd",
-        "name": "Configure BFD over ExpressRoute"
+        "name": "Configure BFD over ExpressRoute",
+        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-bfd"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1252,8 +1252,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/expressRouteCircuits/",
-        "name": "Azure Monitor Baseline Alerts - expressRouteCircuits"
+        "name": "Azure Monitor Baseline Alerts - expressRouteCircuits",
+        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/expressRouteCircuits/"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1275,8 +1275,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/expressroute/maintenance-alerts",
-        "name": "How to view and configure alerts for Azure ExpressRoute circuit maintenance"
+        "name": "How to view and configure alerts for Azure ExpressRoute circuit maintenance",
+        "url": "https://learn.microsoft.com/azure/expressroute/maintenance-alerts"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1298,8 +1298,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/rate-limit",
-        "name": "Rate limiting for ExpressRoute Direct circuits (Preview)"
+        "name": "Rate limiting for ExpressRoute Direct circuits (Preview)",
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/rate-limit"
       }
     ],
     "recommendationControl": "Scalability",
@@ -1321,8 +1321,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/diagnostic-settings",
-        "name": "Diagnostic settings in Azure Monitor"
+        "name": "Diagnostic settings in Azure Monitor",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/diagnostic-settings"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1344,8 +1344,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/activity-log?tabs=powershell",
-        "name": "Azure Monitor activity log"
+        "name": "Azure Monitor activity log",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/activity-log?tabs=powershell"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1367,8 +1367,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-resource-manager/management/lock-resources?toc=%2Fazure%2Fvirtual-network%2Ftoc.json&tabs=json",
-        "name": "Lock your resources to protect your infrastructure"
+        "name": "Lock your resources to protect your infrastructure",
+        "url": "https://learn.microsoft.com/azure/azure-resource-manager/management/lock-resources?toc=%2Fazure%2Fvirtual-network%2Ftoc.json&tabs=json"
       }
     ],
     "recommendationControl": "Governance",
@@ -1390,8 +1390,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/network-watcher/network-watcher-nsg-flow-logging-overview",
-        "name": "Flow logging for network security groups"
+        "name": "Flow logging for network security groups",
+        "url": "https://learn.microsoft.com/azure/network-watcher/network-watcher-nsg-flow-logging-overview"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1413,8 +1413,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-network/network-security-groups-overview#security-rules",
-        "name": "Security rules"
+        "name": "Security rules",
+        "url": "https://learn.microsoft.com/azure/virtual-network/network-security-groups-overview#security-rules"
       }
     ],
     "recommendationControl": "Security",
@@ -1436,12 +1436,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-firewall",
-        "name": "Azure Well Architected Framework - Azure Firewall"
+        "name": "Azure Well Architected Framework - Azure Firewall",
+        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-firewall"
       },
       {
-        "url": "https://learn.microsoft.com/azure/firewall/deploy-availability-zone-powershell",
-        "name": "Deploy Azure Firewall across multiple availability zones"
+        "name": "Deploy Azure Firewall across multiple availability zones",
+        "url": "https://learn.microsoft.com/azure/firewall/deploy-availability-zone-powershell"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1463,12 +1463,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkazurefirewalls",
-        "name": "Azure Firewall metrics supported in Azure Monitor"
+        "name": "Azure Firewall metrics supported in Azure Monitor",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkazurefirewalls"
       },
       {
-        "url": "https://learn.microsoft.com/azure/firewall/firewall-performance",
-        "name": "Azure Firewall performance"
+        "name": "Azure Firewall performance",
+        "url": "https://learn.microsoft.com/azure/firewall/firewall-performance"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1490,8 +1490,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/ddos-protection/ddos-protection-overview",
-        "name": "Azure DDoS Protection overview"
+        "name": "Azure DDoS Protection overview",
+        "url": "https://learn.microsoft.com/azure/ddos-protection/ddos-protection-overview"
       }
     ],
     "recommendationControl": "Security",
@@ -1513,8 +1513,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/firewall-manager/rule-hierarchy",
-        "name": "Azure Firewall Policy hierarchy"
+        "name": "Azure Firewall Policy hierarchy",
+        "url": "https://learn.microsoft.com/azure/firewall-manager/rule-hierarchy"
       }
     ],
     "recommendationControl": "Governance",
@@ -1536,8 +1536,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/service-guides/azure-firewall#recommendations",
-        "name": "Azure Well-Architected Framework review - Azure Firewall"
+        "name": "Azure Well-Architected Framework review - Azure Firewall",
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/service-guides/azure-firewall#recommendations"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1559,12 +1559,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/well-architected/service-guides/azure-firewall#recommendations",
-        "name": "Azure Well-Architected Framework review - Azure Firewall"
+        "name": "Azure Well-Architected Framework review - Azure Firewall",
+        "url": "https://learn.microsoft.com/azure/well-architected/service-guides/azure-firewall#recommendations"
       },
       {
-        "url": "https://learn.microsoft.com/azure/firewall/metrics",
-        "name": "Azure Firewall metrics overview"
+        "name": "Azure Firewall metrics overview",
+        "url": "https://learn.microsoft.com/azure/firewall/metrics"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1586,8 +1586,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/private-link/manage-private-endpoint?tabs=manage-private-link-powershell#private-endpoint-connections",
-        "name": "Private endpoint connections"
+        "name": "Private endpoint connections",
+        "url": "https://learn.microsoft.com/azure/private-link/manage-private-endpoint?tabs=manage-private-link-powershell#private-endpoint-connections"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1609,16 +1609,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-monitoring",
-        "name": "Azure Traffic Manager endpoint monitoring"
+        "name": "Azure Traffic Manager endpoint monitoring",
+        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-monitoring"
       },
       {
-        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-monitoring#enable-or-disable-health-checks-preview",
-        "name": "Enable or disable health checks"
+        "name": "Enable or disable health checks",
+        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-monitoring#enable-or-disable-health-checks-preview"
       },
       {
-        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-troubleshooting-degraded",
-        "name": "Troubleshooting degraded state on Azure Traffic Manager"
+        "name": "Troubleshooting degraded state on Azure Traffic Manager",
+        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-troubleshooting-degraded"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1640,8 +1640,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-endpoint-types",
-        "name": "Traffic Manager Endpoint Types"
+        "name": "Traffic Manager Endpoint Types",
+        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-endpoint-types"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1663,8 +1663,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#add-at-least-one-more-endpoint-to-the-profile-preferably-in-another-azure-region",
-        "name": "Reliability recommendations"
+        "name": "Reliability recommendations",
+        "url": "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#add-at-least-one-more-endpoint-to-the-profile-preferably-in-another-azure-region"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -1686,12 +1686,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#add-an-endpoint-configured-to-all-world",
-        "name": "Add an endpoint configured to \"All (World)\""
+        "name": "Add an endpoint configured to \"All (World)\"",
+        "url": "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#add-an-endpoint-configured-to-all-world"
       },
       {
-        "url": "https://aka.ms/Rf7vc5",
-        "name": "Traffic Manager profile - GeographicProfile (Add an endpoint configured to \"\"All (World)\"\")."
+        "name": "Traffic Manager profile - GeographicProfile (Add an endpoint configured to \"\"All (World)\"\").",
+        "url": "https://aka.ms/Rf7vc5"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -1713,8 +1713,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-disaster-recovery-with-expressroute-privatepeering",
-        "name": "Designing for disaster recovery with ExpressRoute private peering"
+        "name": "Designing for disaster recovery with ExpressRoute private peering",
+        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-disaster-recovery-with-expressroute-privatepeering"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1736,8 +1736,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#expressroute-gateway",
-        "name": "Virtual WAN Monitoring Best Practices"
+        "name": "Virtual WAN Monitoring Best Practices",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#expressroute-gateway"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1759,8 +1759,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/ddos-protection/monitor-ddos-protection-reference",
-        "name": "Monitoring Azure DDoS Protection"
+        "name": "Monitoring Azure DDoS Protection",
+        "url": "https://learn.microsoft.com/en-us/azure/ddos-protection/monitor-ddos-protection-reference"
       }
     ],
     "recommendationControl": "Security",
@@ -1782,8 +1782,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/about-fastpath",
-        "name": "About ExpressRoute FastPath"
+        "name": "About ExpressRoute FastPath",
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/about-fastpath"
       }
     ],
     "recommendationControl": "Scalability",
@@ -1805,8 +1805,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?tabs=json",
-        "name": "Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn"
+        "name": "Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?tabs=json"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1828,8 +1828,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#virtual-wan-gateways",
-        "name": "Virtual WAN Monitoring Best Practices"
+        "name": "Virtual WAN Monitoring Best Practices",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#virtual-wan-gateways"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1851,8 +1851,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/network-watcher/network-watcher-overview",
-        "name": "What is Azure Network Watcher?"
+        "name": "What is Azure Network Watcher?",
+        "url": "https://learn.microsoft.com/azure/network-watcher/network-watcher-overview"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1874,8 +1874,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/network-watcher/nsg-flow-logging",
-        "name": "Manage NSG flow logs using the Azure portal"
+        "name": "Manage NSG flow logs using the Azure portal",
+        "url": "https://learn.microsoft.com/azure/network-watcher/nsg-flow-logging"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1897,8 +1897,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/connection-monitor-overview",
-        "name": "Connection monitor overview"
+        "name": "Connection monitor overview",
+        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/connection-monitor-overview"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1920,12 +1920,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-overview",
-        "name": "Flow logging for network security groups"
+        "name": "Flow logging for network security groups",
+        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-overview"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-overview",
-        "name": "Virtual network flow logs"
+        "name": "Virtual network flow logs",
+        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-overview"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1947,8 +1947,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/traffic-analytics",
-        "name": "Network Watcher traffic analytics"
+        "name": "Network Watcher traffic analytics",
+        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/traffic-analytics"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1970,8 +1970,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-autoscaling-zone-redundant#autoscaling-and-high-availability",
-        "name": "Application Gateway Autoscaling Zone-Redundant"
+        "name": "Application Gateway Autoscaling Zone-Redundant",
+        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-autoscaling-zone-redundant#autoscaling-and-high-availability"
       }
     ],
     "recommendationControl": "Scalability",
@@ -1993,24 +1993,24 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway#security",
-        "name": "Application Gateway Security"
+        "name": "Application Gateway Security",
+        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway#security"
       },
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/ssl-overview",
-        "name": "Application Gateway SSL Overview"
+        "name": "Application Gateway SSL Overview",
+        "url": "https://learn.microsoft.com/azure/application-gateway/ssl-overview"
       },
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-ssl-policy-overview",
-        "name": "Application Gateway SSL Policy Overview"
+        "name": "Application Gateway SSL Policy Overview",
+        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-ssl-policy-overview"
       },
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/key-vault-certs",
-        "name": "Application Gateway KeyVault Certs"
+        "name": "Application Gateway KeyVault Certs",
+        "url": "https://learn.microsoft.com/azure/application-gateway/key-vault-certs"
       },
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/ssl-certificate-management",
-        "name": "Application Gateway SSL Cert Management"
+        "name": "Application Gateway SSL Cert Management",
+        "url": "https://learn.microsoft.com/azure/application-gateway/ssl-certificate-management"
       }
     ],
     "recommendationControl": "Security",
@@ -2032,12 +2032,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway",
-        "name": "Well-Architected Framework Application Gateway Overview"
+        "name": "Well-Architected Framework Application Gateway Overview",
+        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway"
       },
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/features#web-application-firewall",
-        "name": "Application Gateway - Web Application Firewall"
+        "name": "Application Gateway - Web Application Firewall",
+        "url": "https://learn.microsoft.com/azure/application-gateway/features#web-application-firewall"
       }
     ],
     "recommendationControl": "Security",
@@ -2059,16 +2059,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/overview-v2",
-        "name": "Application Gateway Overview V2"
+        "name": "Application Gateway Overview V2",
+        "url": "https://learn.microsoft.com/azure/application-gateway/overview-v2"
       },
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/overview-v2#feature-comparison-between-v1-sku-and-v2-sku",
-        "name": "Application Gateway Feature Comparison Between V1 and V2"
+        "name": "Application Gateway Feature Comparison Between V1 and V2",
+        "url": "https://learn.microsoft.com/azure/application-gateway/overview-v2#feature-comparison-between-v1-sku-and-v2-sku"
       },
       {
-        "url": "https://azure.microsoft.com/updates/application-gateway-v1-will-be-retired-on-28-april-2026-transition-to-application-gateway-v2/",
-        "name": "Application Gateway V1 Retirement"
+        "name": "Application Gateway V1 Retirement",
+        "url": "https://azure.microsoft.com/updates/application-gateway-v1-will-be-retired-on-28-april-2026-transition-to-application-gateway-v2/"
       }
     ],
     "recommendationControl": "Scalability",
@@ -2090,12 +2090,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-metrics",
-        "name": "Application Gateway Metrics"
+        "name": "Application Gateway Metrics",
+        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-metrics"
       },
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-diagnostics",
-        "name": "Application Gateway Diagnostics"
+        "name": "Application Gateway Diagnostics",
+        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-diagnostics"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2117,12 +2117,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-probe-overview",
-        "name": "Application Gateway Probe Overview"
+        "name": "Application Gateway Probe Overview",
+        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-probe-overview"
       },
       {
-        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway",
-        "name": "Well-Architected Framework Application Gateway Overview"
+        "name": "Well-Architected Framework Application Gateway Overview",
+        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2144,12 +2144,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway#reliability",
-        "name": "Well-Architected Framework Application Gateway Reliability"
+        "name": "Well-Architected Framework Application Gateway Reliability",
+        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway#reliability"
       },
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/overview-v2",
-        "name": "Application Gateway V2 Overview"
+        "name": "Application Gateway V2 Overview",
+        "url": "https://learn.microsoft.com/azure/application-gateway/overview-v2"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2171,12 +2171,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/features#connection-draining",
-        "name": "Application Gateway Connection Draining"
+        "name": "Application Gateway Connection Draining",
+        "url": "https://learn.microsoft.com/azure/application-gateway/features#connection-draining"
       },
       {
-        "url": "https://learn.microsoft.com/azure/application-gateway/configuration-http-settings#connection-draining",
-        "name": "Application Gateway Connection Draining HTTP Settings"
+        "name": "Application Gateway Connection Draining HTTP Settings",
+        "url": "https://learn.microsoft.com/azure/application-gateway/configuration-http-settings#connection-draining"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2198,8 +2198,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/application-gateway/configuration-infrastructure#size-of-the-subnet",
-        "name": "Azure Application Gateway infrastructure configuration | Microsoft Learn"
+        "name": "Azure Application Gateway infrastructure configuration | Microsoft Learn",
+        "url": "https://learn.microsoft.com/en-us/azure/application-gateway/configuration-infrastructure#size-of-the-subnet"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -2221,8 +2221,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-disaster-recovery-with-expressroute-privatepeering",
-        "name": "Designing for disaster recovery with ExpressRoute private peering"
+        "name": "Designing for disaster recovery with ExpressRoute private peering",
+        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-disaster-recovery-with-expressroute-privatepeering"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2244,16 +2244,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-about-virtual-network-gateways#zrgw",
-        "name": "About ExpressRoute virtual network gateways - Zone-redundant gateway SKUs"
+        "name": "About ExpressRoute virtual network gateways - Zone-redundant gateway SKUs",
+        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-about-virtual-network-gateways#zrgw"
       },
       {
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways",
-        "name": "About zone-redundant virtual network gateway in Azure availability zones"
+        "name": "About zone-redundant virtual network gateway in Azure availability zones",
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways"
       },
       {
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/create-zone-redundant-vnet-gateway",
-        "name": "Create a zone-redundant virtual network gateway in Azure Availability Zones"
+        "name": "Create a zone-redundant virtual network gateway in Azure Availability Zones",
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/create-zone-redundant-vnet-gateway"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2275,8 +2275,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?tabs=json",
-        "name": "Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn"
+        "name": "Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?tabs=json"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2298,12 +2298,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-monitoring-metrics-alerts#expressroute-gateways",
-        "name": "ExpressRoute monitoring, metrics, and alerts | ExpressRoute gateways"
+        "name": "ExpressRoute monitoring, metrics, and alerts | ExpressRoute gateways",
+        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-monitoring-metrics-alerts#expressroute-gateways"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-network-insights",
-        "name": "Azure ExpressRoute Insights using Network Insights"
+        "name": "Azure ExpressRoute Insights using Network Insights",
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-network-insights"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2325,8 +2325,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-about-virtual-network-gateways#vnet-to-vnet-connectivity",
-        "name": "About ExpressRoute virtual network gateways - VNet-to-VNet connectivity"
+        "name": "About ExpressRoute virtual network gateways - VNet-to-VNet connectivity",
+        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-about-virtual-network-gateways#vnet-to-vnet-connectivity"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2348,8 +2348,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/customer-controlled-gateway-maintenance#azure-portal-steps",
-        "name": "Configure customer-controlled maintenance for your virtual network gateway - ExpressRoute | Microsoft Learn"
+        "name": "Configure customer-controlled maintenance for your virtual network gateway - ExpressRoute | Microsoft Learn",
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/customer-controlled-gateway-maintenance#azure-portal-steps"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2371,16 +2371,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways",
-        "name": "Zone redundant Virtual network gateway in availability zone"
+        "name": "Zone redundant Virtual network gateway in availability zone",
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways"
       },
       {
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways#gwskus",
-        "name": "Gateway SKU"
+        "name": "Gateway SKU",
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways#gwskus"
       },
       {
-        "url": "https://www.microsoft.com/licensing/docs/view/Service-Level-Agreements-SLA-for-Online-Services?lang=1",
-        "name": "SLA summary for Azure services"
+        "name": "SLA summary for Azure services",
+        "url": "https://www.microsoft.com/licensing/docs/view/Service-Level-Agreements-SLA-for-Online-Services?lang=1"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2402,12 +2402,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/active-active-portal#gateway",
-        "name": "Active-active VPN gateway"
+        "name": "Active-active VPN gateway",
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/active-active-portal#gateway"
       },
       {
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsku",
-        "name": "Gateway SKU"
+        "name": "Gateway SKU",
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsku"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2429,8 +2429,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/vpn-gateway-highlyavailable#dual-redundancy-active-active-vpn-gateways-for-both-azure-and-on-premises-networks",
-        "name": "Dual-redundancy active-active VPN gateways for both Azure and on-premises networks"
+        "name": "Dual-redundancy active-active VPN gateways for both Azure and on-premises networks",
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/vpn-gateway-highlyavailable#dual-redundancy-active-active-vpn-gateways-for-both-azure-and-on-premises-networks"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -2452,8 +2452,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/monitor-vpn-gateway-reference",
-        "name": "VPN gateway data reference"
+        "name": "VPN gateway data reference",
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/monitor-vpn-gateway-reference"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2475,12 +2475,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/metrics-getting-started",
-        "name": "Getting started with Azure Metrics Explorer"
+        "name": "Getting started with Azure Metrics Explorer",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/metrics-getting-started"
       },
       {
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/monitor-vpn-gateway-reference#metrics",
-        "name": "Monitor VPN gateway"
+        "name": "Monitor VPN gateway",
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/monitor-vpn-gateway-reference#metrics"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2502,8 +2502,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways",
-        "name": "About zone-redundant virtual network gateway in Azure availability zones"
+        "name": "About zone-redundant virtual network gateway in Azure availability zones",
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2525,8 +2525,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#point-to-site-vpn-gateway",
-        "name": "Virtual WAN Monitoring Best Practices"
+        "name": "Virtual WAN Monitoring Best Practices",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#point-to-site-vpn-gateway"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2548,8 +2548,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/reliability/reliability-dns",
-        "name": "Reliability in Azure DNS"
+        "name": "Reliability in Azure DNS",
+        "url": "https://learn.microsoft.com/azure/reliability/reliability-dns"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -2571,8 +2571,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-howto-erdirect#state",
-        "name": "How to configure ExpressRoute Direct Change Admin State of links"
+        "name": "How to configure ExpressRoute Direct Change Admin State of links",
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-howto-erdirect#state"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2594,8 +2594,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-erdirect-about?source=recommendations#circuit-sizes",
-        "name": "About ExpressRoute Direct Circuit Sizes"
+        "name": "About ExpressRoute Direct Circuit Sizes",
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-erdirect-about?source=recommendations#circuit-sizes"
       }
     ],
     "recommendationControl": "Scalability",
@@ -2617,8 +2617,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/expressRoutePorts/",
-        "name": "Azure Monitor Baseline Alerts - expressRoutePorts"
+        "name": "Azure Monitor Baseline Alerts - expressRoutePorts",
+        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/expressRoutePorts/"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2640,12 +2640,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-load-balancer/reliability",
-        "name": "Reliability and Azure Load Balancer"
+        "name": "Reliability and Azure Load Balancer",
+        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-load-balancer/reliability"
       },
       {
-        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer",
-        "name": "Resiliency checklist for specific Azure services- Azure Load Balancer"
+        "name": "Resiliency checklist for specific Azure services- Azure Load Balancer",
+        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2667,8 +2667,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer",
-        "name": "Resiliency checklist for specific Azure services- Azure Load Balancer"
+        "name": "Resiliency checklist for specific Azure services- Azure Load Balancer",
+        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2690,8 +2690,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer",
-        "name": "Resiliency checklist for specific Azure services- Azure Load Balancer"
+        "name": "Resiliency checklist for specific Azure services- Azure Load Balancer",
+        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2713,8 +2713,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-availability-zones#zone-redundant",
-        "name": "Load Balancer and Availability Zones"
+        "name": "Load Balancer and Availability Zones",
+        "url": "https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-availability-zones#zone-redundant"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2736,8 +2736,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-custom-probe-overview",
-        "name": "Load Balancer Health Probe Overview"
+        "name": "Load Balancer Health Probe Overview",
+        "url": "https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-custom-probe-overview"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2759,8 +2759,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/dns/dns-protect-private-zones-recordsets",
-        "name": "Protecting private DNS Zones and Records - Azure DNS"
+        "name": "Protecting private DNS Zones and Records - Azure DNS",
+        "url": "https://learn.microsoft.com/en-us/azure/dns/dns-protect-private-zones-recordsets"
       }
     ],
     "recommendationControl": "Security",
@@ -2782,8 +2782,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/privateDnsZones/",
-        "name": "Azure Monitor Baseline Alerts - privateDnsZones"
+        "name": "Azure Monitor Baseline Alerts - privateDnsZones",
+        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/privateDnsZones/"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2805,8 +2805,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale",
-        "name": "Private Link and DNS integration at scale"
+        "name": "Private Link and DNS integration at scale",
+        "url": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -2828,8 +2828,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/reliability/reliability-dns",
-        "name": "Reliability in Azure DNS"
+        "name": "Reliability in Azure DNS",
+        "url": "https://learn.microsoft.com/azure/reliability/reliability-dns"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -2851,8 +2851,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#virtual-hub",
-        "name": "Virtual WAN Monitoring Best Practices"
+        "name": "Virtual WAN Monitoring Best Practices",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#virtual-hub"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2874,20 +2874,20 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-monitor?pivots=front-door-standard-premium#access-logs",
-        "name": "Azure Web Application Firewall monitoring and logging - Access Log"
+        "name": "Azure Web Application Firewall monitoring and logging - Access Log",
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-monitor?pivots=front-door-standard-premium#access-logs"
       },
       {
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-tuning?pivots=front-door-standard-premium#understanding-waf-logs",
-        "name": "Understanding WAF logs"
+        "name": "Understanding WAF logs",
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-tuning?pivots=front-door-standard-premium#understanding-waf-logs"
       },
       {
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-configuration?tabs=portal",
-        "name": "Web Application Firewall exclusion lists"
+        "name": "Web Application Firewall exclusion lists",
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-configuration?tabs=portal"
       },
       {
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-troubleshoot#fixing-false-positives",
-        "name": "Fixing a false positive"
+        "name": "Fixing a false positive",
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-troubleshoot#fixing-false-positives"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2909,12 +2909,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-metrics#logs-and-diagnostics",
-        "name": "Azure Web Application Firewall Monitoring and Logging"
+        "name": "Azure Web Application Firewall Monitoring and Logging",
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-metrics#logs-and-diagnostics"
       },
       {
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-logs#diagnostic-logs",
-        "name": "Diagnostic logs"
+        "name": "Diagnostic logs",
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-logs#diagnostic-logs"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2936,12 +2936,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/ag-overview#waf-monitoring",
-        "name": "WAF monitoring"
+        "name": "WAF monitoring",
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/ag-overview#waf-monitoring"
       },
       {
-        "url": "https://github.com/Azure/Azure-Network-Security/tree/master/Azure%20WAF/Workbook%20-%20WAF%20Monitor%20Workbook",
-        "name": "Azure Monitor Workbook for WAF"
+        "name": "Azure Monitor Workbook for WAF",
+        "url": "https://github.com/Azure/Azure-Network-Security/tree/master/Azure%20WAF/Workbook%20-%20WAF%20Monitor%20Workbook"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2963,8 +2963,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-signalr/availability-zones",
-        "name": "Availability zones support in Azure SignalR Service"
+        "name": "Availability zones support in Azure SignalR Service",
+        "url": "https://learn.microsoft.com/azure/azure-signalr/availability-zones"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2986,8 +2986,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/entra/identity/domain-services/tutorial-create-replica-set",
-        "name": "Create and use replica sets for resiliency or geolocation in Microsoft Entra Domain Services"
+        "name": "Create and use replica sets for resiliency or geolocation in Microsoft Entra Domain Services",
+        "url": "https://learn.microsoft.com/en-us/entra/identity/domain-services/tutorial-create-replica-set"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3009,8 +3009,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/entra/identity/domain-services/tutorial-create-replica-set",
-        "name": "Create and use replica sets for resiliency or geolocation in Microsoft Entra Domain Services"
+        "name": "Create and use replica sets for resiliency or geolocation in Microsoft Entra Domain Services",
+        "url": "https://learn.microsoft.com/en-us/entra/identity/domain-services/tutorial-create-replica-set"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3032,12 +3032,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/aks/availability-zones",
-        "name": "AKS Availability Zones"
+        "name": "AKS Availability Zones",
+        "url": "https://learn.microsoft.com/en-us/azure/aks/availability-zones"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones#zone-balancing",
-        "name": "Zone Balancing"
+        "name": "Zone Balancing",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones#zone-balancing"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3059,8 +3059,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/aks/use-system-pools?tabs=azure-cli#system-and-user-node-pools",
-        "name": "System and user node pools"
+        "name": "System and user node pools",
+        "url": "https://learn.microsoft.com/en-us/azure/aks/use-system-pools?tabs=azure-cli#system-and-user-node-pools"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3082,16 +3082,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/aks/concepts-identity#azure-ad-integration",
-        "name": "Entra integration"
+        "name": "Entra integration",
+        "url": "https://learn.microsoft.com/en-us/azure/aks/concepts-identity#azure-ad-integration"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/aks/manage-azure-rbac?source=recommendations",
-        "name": "Use Azure role-based access control for AKS"
+        "name": "Use Azure role-based access control for AKS",
+        "url": "https://learn.microsoft.com/en-us/azure/aks/manage-azure-rbac?source=recommendations"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/aks/manage-local-accounts-managed-azure-ad?source=recommendations",
-        "name": "Manage AKS local accounts"
+        "name": "Manage AKS local accounts",
+        "url": "https://learn.microsoft.com/en-us/azure/aks/manage-local-accounts-managed-azure-ad?source=recommendations"
       }
     ],
     "recommendationControl": "Security",
@@ -3113,12 +3113,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/aks/configure-azure-cni-dynamic-ip-allocation",
-        "name": "Configure Azure CNI networking"
+        "name": "Configure Azure CNI networking",
+        "url": "https://learn.microsoft.com/en-us/azure/aks/configure-azure-cni-dynamic-ip-allocation"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/aks/azure-cni-overlay",
-        "name": "Configure Azure CNI Overlay networking"
+        "name": "Configure Azure CNI Overlay networking",
+        "url": "https://learn.microsoft.com/en-us/azure/aks/azure-cni-overlay"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3140,20 +3140,20 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/aks/cluster-autoscaler?tabs=azure-cli",
-        "name": "Use the Cluster Autoscaler on AKS"
+        "name": "Use the Cluster Autoscaler on AKS",
+        "url": "https://learn.microsoft.com/azure/aks/cluster-autoscaler?tabs=azure-cli"
       },
       {
-        "url": "https://learn.microsoft.com/azure/aks/operator-best-practices-advanced-scheduler",
-        "name": "Best practices for advanced scheduler features"
+        "name": "Best practices for advanced scheduler features",
+        "url": "https://learn.microsoft.com/azure/aks/operator-best-practices-advanced-scheduler"
       },
       {
-        "url": "https://learn.microsoft.com/azure/aks/best-practices-performance-scale-large#node-pool-scaling",
-        "name": "Node pool scaling considerations and best practices"
+        "name": "Node pool scaling considerations and best practices",
+        "url": "https://learn.microsoft.com/azure/aks/best-practices-performance-scale-large#node-pool-scaling"
       },
       {
-        "url": "https://learn.microsoft.com/azure/aks/operator-best-practices-scheduler",
-        "name": "Best practices for basic scheduler features"
+        "name": "Best practices for basic scheduler features",
+        "url": "https://learn.microsoft.com/azure/aks/operator-best-practices-scheduler"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3175,12 +3175,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-cluster-backup",
-        "name": "AKS Backups"
+        "name": "AKS Backups",
+        "url": "https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-cluster-backup"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/aks/operator-best-practices-storage",
-        "name": "Best Practices for AKS Backups"
+        "name": "Best Practices for AKS Backups",
+        "url": "https://learn.microsoft.com/en-us/azure/aks/operator-best-practices-storage"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -3202,24 +3202,24 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/reliability/availability-zones-overview?tabs=azure-cli",
-        "name": "Availability zones overview"
+        "name": "Availability zones overview",
+        "url": "https://learn.microsoft.com/azure/reliability/availability-zones-overview?tabs=azure-cli"
       },
       {
-        "url": "https://learn.microsoft.com/azure/storage/common/storage-redundancy#zone-redundant-storage",
-        "name": "Zone-redundant storage"
+        "name": "Zone-redundant storage",
+        "url": "https://learn.microsoft.com/azure/storage/common/storage-redundancy#zone-redundant-storage"
       },
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-redundancy#zone-redundant-storage-for-managed-disks",
-        "name": "ZRS disks"
+        "name": "ZRS disks",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-redundancy#zone-redundant-storage-for-managed-disks"
       },
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-migrate-lrs-zrs",
-        "name": "Convert a disk from LRS to ZRS"
+        "name": "Convert a disk from LRS to ZRS",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-migrate-lrs-zrs"
       },
       {
-        "url": "https://learn.microsoft.com/azure/storage/container-storage/enable-multi-zone-redundancy",
-        "name": "Enable multi-zone storage redundancy in Azure Container Storage"
+        "name": "Enable multi-zone storage redundancy in Azure Container Storage",
+        "url": "https://learn.microsoft.com/azure/storage/container-storage/enable-multi-zone-redundancy"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3241,12 +3241,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/aks/csi-storage-drivers",
-        "name": "CSI Storage Drivers"
+        "name": "CSI Storage Drivers",
+        "url": "https://learn.microsoft.com/azure/aks/csi-storage-drivers"
       },
       {
-        "url": "https://learn.microsoft.com/azure/aks/csi-migrate-in-tree-volumes",
-        "name": "CSI Migrate in Tree Volumes"
+        "name": "CSI Migrate in Tree Volumes",
+        "url": "https://learn.microsoft.com/azure/aks/csi-migrate-in-tree-volumes"
       }
     ],
     "recommendationControl": "Governance",
@@ -3268,8 +3268,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://kubernetes.io/docs/concepts/policy/resource-quotas/",
-        "name": "Resource Quotas"
+        "name": "Resource Quotas",
+        "url": "https://kubernetes.io/docs/concepts/policy/resource-quotas/"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3291,12 +3291,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/aks/virtual-nodes",
-        "name": "Virtual Nodes"
+        "name": "Virtual Nodes",
+        "url": "https://learn.microsoft.com/azure/aks/virtual-nodes"
       },
       {
-        "url": "https://learn.microsoft.com/azure/container-instances/container-instances-overview",
-        "name": "Azure Container Instances"
+        "name": "Azure Container Instances",
+        "url": "https://learn.microsoft.com/azure/container-instances/container-instances-overview"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3318,12 +3318,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers",
-        "name": "Pricing Tiers"
+        "name": "Pricing Tiers",
+        "url": "https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks?toc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Faks%2Ftoc.json&bc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#kubernetes-api-server-sla",
-        "name": "AKS Baseline Architecture"
+        "name": "AKS Baseline Architecture",
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks?toc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Faks%2Ftoc.json&bc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#kubernetes-api-server-sla"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3345,8 +3345,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/aks/monitor-aks",
-        "name": "Monitor AKS"
+        "name": "Monitor AKS",
+        "url": "https://learn.microsoft.com/azure/aks/monitor-aks"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -3368,16 +3368,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/aks/concepts-storage#ephemeral-os-disk",
-        "name": "Ephemeral OS disk"
+        "name": "Ephemeral OS disk",
+        "url": "https://learn.microsoft.com/azure/aks/concepts-storage#ephemeral-os-disk"
       },
       {
-        "url": "https://learn.microsoft.com/azure/aks/cluster-configuration",
-        "name": "Configure an AKS cluster"
+        "name": "Configure an AKS cluster",
+        "url": "https://learn.microsoft.com/azure/aks/cluster-configuration"
       },
       {
-        "url": "https://learn.microsoft.com/samples/azure-samples/aks-ephemeral-os-disk/aks-ephemeral-os-disk/",
-        "name": "Everything you want to know about ephemeral OS disks and AKS"
+        "name": "Everything you want to know about ephemeral OS disks and AKS",
+        "url": "https://learn.microsoft.com/samples/azure-samples/aks-ephemeral-os-disk/aks-ephemeral-os-disk/"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3399,12 +3399,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks?toc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Faks%2Ftoc.json&bc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#policy-management",
-        "name": "AKS Baseline - Policy Management"
+        "name": "AKS Baseline - Policy Management",
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks?toc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Faks%2Ftoc.json&bc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#policy-management"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/aks/policy-reference",
-        "name": "Built-in Policy Definitions for AKS"
+        "name": "Built-in Policy Definitions for AKS",
+        "url": "https://learn.microsoft.com/en-us/azure/aks/policy-reference"
       }
     ],
     "recommendationControl": "Governance",
@@ -3426,12 +3426,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/guide/aks/aks-cicd-github-actions-and-gitops",
-        "name": "GitOps with AKS"
+        "name": "GitOps with AKS",
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/guide/aks/aks-cicd-github-actions-and-gitops"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/example-scenario/gitops-aks/gitops-blueprint-aks",
-        "name": "GitOps for AKS - Reference Architecture"
+        "name": "GitOps for AKS - Reference Architecture",
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/example-scenario/gitops-aks/gitops-blueprint-aks"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -3453,12 +3453,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/",
-        "name": "Topology Spread Constraints"
+        "name": "Topology Spread Constraints",
+        "url": "https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/"
       },
       {
-        "url": "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/",
-        "name": "Assign Pod Node"
+        "name": "Assign Pod Node",
+        "url": "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3480,12 +3480,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
-        "name": "Configure probes"
+        "name": "Configure probes",
+        "url": "https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/"
       },
       {
-        "url": "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/",
-        "name": "Assign Pod Node"
+        "name": "Assign Pod Node",
+        "url": "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3507,8 +3507,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/",
-        "name": "Replica Sets"
+        "name": "Replica Sets",
+        "url": "https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3530,8 +3530,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/aks/use-system-pools?tabs=azure-cli",
-        "name": "System nodepools"
+        "name": "System nodepools",
+        "url": "https://learn.microsoft.com/azure/aks/use-system-pools?tabs=azure-cli"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3553,8 +3553,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/well-architected/service-guides/azure-kubernetes-service#design-checklist",
-        "name": "Azure Well-Architected Framework review for Azure Kubernetes Service (AKS)"
+        "name": "Azure Well-Architected Framework review for Azure Kubernetes Service (AKS)",
+        "url": "https://learn.microsoft.com/azure/well-architected/service-guides/azure-kubernetes-service#design-checklist"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3576,12 +3576,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://kubernetes.io/docs/tasks/run-application/configure-pdb/",
-        "name": "Configure PDBs"
+        "name": "Configure PDBs",
+        "url": "https://kubernetes.io/docs/tasks/run-application/configure-pdb/"
       },
       {
-        "url": "https://learn.microsoft.com/azure/aks/operator-best-practices-scheduler#plan-for-availability-using-pod-disruption-budgets",
-        "name": "Plan availability using PDBs"
+        "name": "Plan availability using PDBs",
+        "url": "https://learn.microsoft.com/azure/aks/operator-best-practices-scheduler#plan-for-availability-using-pod-disruption-budgets"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3603,8 +3603,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/aks/configure-azure-cni-dynamic-ip-allocation",
-        "name": "Azure CNI Dynamic IP Allocation"
+        "name": "Azure CNI Dynamic IP Allocation",
+        "url": "https://learn.microsoft.com/azure/aks/configure-azure-cni-dynamic-ip-allocation"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3626,8 +3626,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/quotas/quotas-overview",
-        "name": "Azure Quotas"
+        "name": "Azure Quotas",
+        "url": "https://learn.microsoft.com/azure/quotas/quotas-overview"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3649,8 +3649,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/aks/use-azure-linux",
-        "name": "Azure Linux"
+        "name": "Azure Linux",
+        "url": "https://learn.microsoft.com/azure/aks/use-azure-linux"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3672,8 +3672,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/aks/best-practices-app-cluster-reliability#multi-replica-applications",
-        "name": "Multi-replica apps"
+        "name": "Multi-replica apps",
+        "url": "https://learn.microsoft.com/azure/aks/best-practices-app-cluster-reliability#multi-replica-applications"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3695,8 +3695,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/generation-2#features-and-capabilities",
-        "name": "Generation 1 vs generation 2 virtual machines"
+        "name": "Generation 1 vs generation 2 virtual machines",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/generation-2#features-and-capabilities"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3718,12 +3718,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-image-builder?toc=%2Fazure%2Fvirtual-machines%2Ftoc.json&bc=%2Fazure%2Fvirtual-machines%2Fbreadcrumb%2Ftoc.json#capacity-and-proactive-disaster-recovery-resiliency",
-        "name": "Image Template resiliency"
+        "name": "Image Template resiliency",
+        "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-image-builder?toc=%2Fazure%2Fvirtual-machines%2Ftoc.json&bc=%2Fazure%2Fvirtual-machines%2Fbreadcrumb%2Ftoc.json#capacity-and-proactive-disaster-recovery-resiliency"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/image-builder-overview?tabs=azure-powershell#regions",
-        "name": "Azure Image Builder Supported Regions"
+        "name": "Azure Image Builder Supported Regions",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/image-builder-overview?tabs=azure-powershell#regions"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -3745,12 +3745,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/automation/automation-disaster-recovery?tabs=win-hrw%2Cps-script%2Coption-one",
-        "name": "Disaster recovery for Automation accounts"
+        "name": "Disaster recovery for Automation accounts",
+        "url": "https://learn.microsoft.com/en-us/azure/automation/automation-disaster-recovery?tabs=win-hrw%2Cps-script%2Coption-one"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/automation/automation-disaster-recovery?tabs=win-hrw%2Cps-script%2Coption-one#scenarios-for-cloud-and-hybrid-jobs",
-        "name": "Disaster recovery scenarios for cloud and hybrid jobs"
+        "name": "Disaster recovery scenarios for cloud and hybrid jobs",
+        "url": "https://learn.microsoft.com/en-us/azure/automation/automation-disaster-recovery?tabs=win-hrw%2Cps-script%2Coption-one#scenarios-for-cloud-and-hybrid-jobs"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3772,12 +3772,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/storage/common/storage-redundancy",
-        "name": "Azure Storage redundancy"
+        "name": "Azure Storage redundancy",
+        "url": "https://learn.microsoft.com/azure/storage/common/storage-redundancy"
       },
       {
-        "url": "https://learn.microsoft.com/azure/storage/common/redundancy-migration",
-        "name": "Change the redundancy configuration for a storage account"
+        "name": "Change the redundancy configuration for a storage account",
+        "url": "https://learn.microsoft.com/azure/storage/common/redundancy-migration"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3799,12 +3799,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://azure.microsoft.com/updates/classic-azure-storage-accounts-will-be-retired-on-31-august-2024/",
-        "name": "Azure classic storage accounts retirement announcement"
+        "name": "Azure classic storage accounts retirement announcement",
+        "url": "https://azure.microsoft.com/updates/classic-azure-storage-accounts-will-be-retired-on-31-august-2024/"
       },
       {
-        "url": "https://learn.microsoft.com/azure/storage/common/classic-account-migration-overview",
-        "name": "Migrate your classic storage accounts to Azure Resource Manager"
+        "name": "Migrate your classic storage accounts to Azure Resource Manager",
+        "url": "https://learn.microsoft.com/azure/storage/common/classic-account-migration-overview"
       }
     ],
     "recommendationControl": "Service Upgrade and Retirement",
@@ -3826,24 +3826,24 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/storage/common/storage-account-overview#types-of-storage-accounts",
-        "name": "Types of storage accounts"
+        "name": "Types of storage accounts",
+        "url": "https://learn.microsoft.com/azure/storage/common/storage-account-overview#types-of-storage-accounts"
       },
       {
-        "url": "https://learn.microsoft.com/azure/storage/common/scalability-targets-standard-account",
-        "name": "Scalability and performance targets for standard storage accounts"
+        "name": "Scalability and performance targets for standard storage accounts",
+        "url": "https://learn.microsoft.com/azure/storage/common/scalability-targets-standard-account"
       },
       {
-        "url": "https://learn.microsoft.com/azure/storage/blobs/storage-performance-checklist",
-        "name": "Performance and scalability checklist for Blob storage"
+        "name": "Performance and scalability checklist for Blob storage",
+        "url": "https://learn.microsoft.com/azure/storage/blobs/storage-performance-checklist"
       },
       {
-        "url": "https://learn.microsoft.com/azure/storage/blobs/scalability-targets",
-        "name": "Scalability and performance targets for Blob storage"
+        "name": "Scalability and performance targets for Blob storage",
+        "url": "https://learn.microsoft.com/azure/storage/blobs/scalability-targets"
       },
       {
-        "url": "https://learn.microsoft.com/azure/storage/blobs/storage-blob-block-blob-premium",
-        "name": "Premium block blob storage accounts"
+        "name": "Premium block blob storage accounts",
+        "url": "https://learn.microsoft.com/azure/storage/blobs/storage-blob-block-blob-premium"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3865,8 +3865,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com//azure/storage/blobs/soft-delete-blob-enable?tabs=azure-portal ",
-        "name": "Soft delete detail docs"
+        "name": "Soft delete detail docs",
+        "url": "https://learn.microsoft.com//azure/storage/blobs/soft-delete-blob-enable?tabs=azure-portal "
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -3888,8 +3888,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/storage/blobs/versioning-overview ",
-        "name": "Blob versioning"
+        "name": "Blob versioning",
+        "url": "https://learn.microsoft.com/azure/storage/blobs/versioning-overview "
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -3911,12 +3911,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/storage/blobs/point-in-time-restore-overview",
-        "name": "Point-in-time restore for block blobs"
+        "name": "Point-in-time restore for block blobs",
+        "url": "https://learn.microsoft.com/azure/storage/blobs/point-in-time-restore-overview"
       },
       {
-        "url": "https://learn.microsoft.com/azure/storage/blobs/point-in-time-restore-manage?tabs=portal",
-        "name": "Perform a point-in-time restore on block blob data"
+        "name": "Perform a point-in-time restore on block blob data",
+        "url": "https://learn.microsoft.com/azure/storage/blobs/point-in-time-restore-manage?tabs=portal"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -3938,12 +3938,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/storage/blobs/monitor-blob-storage",
-        "name": "Monitor Azure Blob Storage"
+        "name": "Monitor Azure Blob Storage",
+        "url": "https://learn.microsoft.com/azure/storage/blobs/monitor-blob-storage"
       },
       {
-        "url": "https://learn.microsoft.com/azure/storage/blobs/blob-storage-monitoring-scenarios",
-        "name": "Best practices for monitoring Azure Blob Storage"
+        "name": "Best practices for monitoring Azure Blob Storage",
+        "url": "https://learn.microsoft.com/azure/storage/blobs/blob-storage-monitoring-scenarios"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -3965,12 +3965,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/storage/common/storage-account-overview#legacy-storage-account-types",
-        "name": "Legacy storage account types"
+        "name": "Legacy storage account types",
+        "url": "https://learn.microsoft.com/azure/storage/common/storage-account-overview#legacy-storage-account-types"
       },
       {
-        "url": "https://learn.microsoft.com/azure/storage/common/storage-account-upgrade",
-        "name": "Upgrade to a general-purpose v2 storage account"
+        "name": "Upgrade to a general-purpose v2 storage account",
+        "url": "https://learn.microsoft.com/azure/storage/common/storage-account-upgrade"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3992,12 +3992,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/example-scenario/wvd/windows-virtual-desktop#azure-virtual-desktop-limitations",
-        "name": "Learn More"
+        "name": "Learn More",
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/example-scenario/wvd/windows-virtual-desktop#azure-virtual-desktop-limitations"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-virtual-desktop/networking#private-endpoints-private-link",
-        "name": "Private Link"
+        "name": "Private Link",
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-virtual-desktop/networking#private-endpoints-private-link"
       }
     ],
     "recommendationControl": "Security",
@@ -4019,8 +4019,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/app-service/troubleshoot-diagnostic-logs",
-        "name": "Enable diagnostics logging for apps in Azure App Service"
+        "name": "Enable diagnostics logging for apps in Azure App Service",
+        "url": "https://learn.microsoft.com/azure/app-service/troubleshoot-diagnostic-logs"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4042,12 +4042,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/application-insights/app-insights-overview",
-        "name": "Application Insights"
+        "name": "Application Insights",
+        "url": "https://learn.microsoft.com/azure/application-insights/app-insights-overview"
       },
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/app/azure-web-apps",
-        "name": "Application monitoring for Azure App Service"
+        "name": "Application monitoring for Azure App Service",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/app/azure-web-apps"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4069,8 +4069,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#app-service",
-        "name": "Resiliency checklist for specific Azure services"
+        "name": "Resiliency checklist for specific Azure services",
+        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#app-service"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4092,8 +4092,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#app-service",
-        "name": "Resiliency checklist"
+        "name": "Resiliency checklist",
+        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#app-service"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4115,8 +4115,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/app-service-web/web-sites-staged-publishing",
-        "name": "Set up staging environments in Azure App Service"
+        "name": "Set up staging environments in Azure App Service",
+        "url": "https://learn.microsoft.com/azure/app-service-web/web-sites-staged-publishing"
       }
     ],
     "recommendationControl": "Governance",
@@ -4138,8 +4138,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/app-service-web/web-sites-configure",
-        "name": "Configure web apps in Azure App Service"
+        "name": "Configure web apps in Azure App Service",
+        "url": "https://learn.microsoft.com/azure/app-service-web/web-sites-configure"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -4161,8 +4161,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/app-service/monitor-instances-health-check?tabs=dotnet#enable-health-check",
-        "name": "Monitor the health of App Service instances"
+        "name": "Monitor the health of App Service instances",
+        "url": "https://learn.microsoft.com/en-us/azure/app-service/monitor-instances-health-check?tabs=dotnet#enable-health-check"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -4184,8 +4184,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions?tabs=azurecli",
-        "name": "Set up Azure App Service access restrictions"
+        "name": "Set up Azure App Service access restrictions",
+        "url": "https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions?tabs=azurecli"
       }
     ],
     "recommendationControl": "Governance",
@@ -4207,8 +4207,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://azure.github.io/AppService/2020/05/15/Robust-Apps-for-the-cloud.html",
-        "name": "Ultimate guide to running healthy apps in the cloud"
+        "name": "Ultimate guide to running healthy apps in the cloud",
+        "url": "https://azure.github.io/AppService/2020/05/15/Robust-Apps-for-the-cloud.html"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4230,8 +4230,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://azure.github.io/AppService/2018/09/10/Announcing-the-New-Auto-Healing-Experience-in-App-Service-Diagnostics.html",
-        "name": "Announcing the New Auto Healing Experience in App Service Diagnostics - Azure App Service"
+        "name": "Announcing the New Auto Healing Experience in App Service Diagnostics - Azure App Service",
+        "url": "https://azure.github.io/AppService/2018/09/10/Announcing-the-New-Auto-Healing-Experience-in-App-Service-Diagnostics.html"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4253,8 +4253,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-warmup?tabs=in-process%2Cnodejs-v4&pivots=programming-language-csharp#trigger",
-        "name": "Azure Functions Warmup Trigger"
+        "name": "Azure Functions Warmup Trigger",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-warmup?tabs=in-process%2Cnodejs-v4&pivots=programming-language-csharp#trigger"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4276,8 +4276,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules",
-        "name": "Resource naming restrictions - Azure Resource Manager"
+        "name": "Resource naming restrictions - Azure Resource Manager",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules"
       }
     ],
     "recommendationControl": "Governance",
@@ -4299,8 +4299,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-functions/migrate-version-3-version-4?tabs=net6-in-proc%2Cazure-cli%2Cwindows&pivots=programming-language-csharp",
-        "name": "Migrate version 3.x to 4.x"
+        "name": "Migrate version 3.x to 4.x",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-functions/migrate-version-3-version-4?tabs=net6-in-proc%2Cazure-cli%2Cwindows&pivots=programming-language-csharp"
       }
     ],
     "recommendationControl": "Governance",
@@ -4322,8 +4322,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#functions_worker_runtime",
-        "name": "FUNCTIONS_WORKER_RUNTIME"
+        "name": "FUNCTIONS_WORKER_RUNTIME",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#functions_worker_runtime"
       }
     ],
     "recommendationControl": "Governance",
@@ -4345,12 +4345,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/reliability/migrate-app-service",
-        "name": "Migrate App Service to availability zone support"
+        "name": "Migrate App Service to availability zone support",
+        "url": "https://learn.microsoft.com/en-us/azure/reliability/migrate-app-service"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/enterprise-integration/ase-high-availability-deployment",
-        "name": "High availability enterprise deployment using App Service Environment"
+        "name": "High availability enterprise deployment using App Service Environment",
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/enterprise-integration/ase-high-availability-deployment"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4372,8 +4372,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service",
-        "name": "Resiliency checklist for specific Azure services"
+        "name": "Resiliency checklist for specific Azure services",
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4395,8 +4395,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service",
-        "name": "Resiliency checklist for specific Azure services"
+        "name": "Resiliency checklist for specific Azure services",
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4418,8 +4418,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service",
-        "name": "Resiliency checklist for specific Azure services"
+        "name": "Resiliency checklist for specific Azure services",
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service"
       }
     ],
     "recommendationControl": "Governance",
@@ -4441,12 +4441,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/app-service/manage-automatic-scaling?tabs=azure-portal",
-        "name": "Automatic scaling in Azure App Service"
+        "name": "Automatic scaling in Azure App Service",
+        "url": "https://learn.microsoft.com/en-us/azure/app-service/manage-automatic-scaling?tabs=azure-portal"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-get-started",
-        "name": "Auto Scale Web Apps"
+        "name": "Auto Scale Web Apps",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-get-started"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4468,8 +4468,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-cache-for-redis/cache-how-to-zone-redundancy",
-        "name": "Enable zone redundancy for Azure Cache for Redis"
+        "name": "Enable zone redundancy for Azure Cache for Redis",
+        "url": "https://learn.microsoft.com/azure/azure-cache-for-redis/cache-how-to-zone-redundancy"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4491,8 +4491,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-administration#update-channel-and-schedule-updates",
-        "name": "Schedule Redis Updates"
+        "name": "Schedule Redis Updates",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-administration#update-channel-and-schedule-updates"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4514,8 +4514,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-cache-for-redis/cache-network-isolation",
-        "name": "Configure private endpoints for Azure Redis Cache"
+        "name": "Configure private endpoints for Azure Redis Cache",
+        "url": "https://learn.microsoft.com/azure/azure-cache-for-redis/cache-network-isolation"
       }
     ],
     "recommendationControl": "Security",
@@ -4537,8 +4537,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/reliability/reliability-batch#cross-region-disaster-recovery-and-business-continuity",
-        "name": "Learn More"
+        "name": "Learn More",
+        "url": "https://learn.microsoft.com/azure/reliability/reliability-batch#cross-region-disaster-recovery-and-business-continuity"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4560,8 +4560,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/batch/create-pool-availability-zones",
-        "name": "Learn More"
+        "name": "Learn More",
+        "url": "https://learn.microsoft.com/azure/batch/create-pool-availability-zones"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4583,16 +4583,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/service-health/resource-health-overview",
-        "name": "Resource Health"
+        "name": "Resource Health",
+        "url": "https://learn.microsoft.com/en-us/azure/service-health/resource-health-overview"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/service-health/resource-health-alert-monitor-guide#create-a-resource-health-alert-rule-in-the-azure-portal",
-        "name": "Configure Resource Health alerts in the Azure portal"
+        "name": "Configure Resource Health alerts in the Azure portal",
+        "url": "https://learn.microsoft.com/en-us/azure/service-health/resource-health-alert-monitor-guide#create-a-resource-health-alert-rule-in-the-azure-portal"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/service-health/alerts-activity-log-service-notifications-portal",
-        "name": "Alerts Health"
+        "name": "Alerts Health",
+        "url": "https://learn.microsoft.com/en-us/azure/service-health/alerts-activity-log-service-notifications-portal"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4614,12 +4614,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/service-health/overview",
-        "name": "What is Azure Service Health?"
+        "name": "What is Azure Service Health?",
+        "url": "https://learn.microsoft.com/azure/service-health/overview"
       },
       {
-        "url": "https://learn.microsoft.com/azure/service-health/alerts-activity-log-service-notifications-portal",
-        "name": "Configure alerts for service health events"
+        "name": "Configure alerts for service health events",
+        "url": "https://learn.microsoft.com/azure/service-health/alerts-activity-log-service-notifications-portal"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4641,8 +4641,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/app/convert-classic-resource",
-        "name": "Migrate an Application Insights classic resource to a workspace-based resource"
+        "name": "Migrate an Application Insights classic resource to a workspace-based resource",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/app/convert-classic-resource"
       }
     ],
     "recommendationControl": "Service Upgrade and Retirement",
@@ -4664,8 +4664,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/release-notes/runtime/databricks-runtime-ver",
-        "name": "Databricks runtime support lifecycles"
+        "name": "Databricks runtime support lifecycles",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/release-notes/runtime/databricks-runtime-ver"
       }
     ],
     "recommendationControl": "Governance",
@@ -4687,8 +4687,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4710,8 +4710,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-types#premium-ssd",
-        "name": "Azure managed disk types"
+        "name": "Azure managed disk types",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-types#premium-ssd"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4733,8 +4733,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#enable-autoscaling-for-batch-workloadss",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#enable-autoscaling-for-batch-workloadss"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4756,8 +4756,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#enable-autoscaling-for-sql-warehouse",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#enable-autoscaling-for-sql-warehouse"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4779,12 +4779,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices"
       },
       {
-        "url": "https://learn.microsoft.com/azure/databricks/delta-live-tables/settings#use-autoscaling-to-increase-efficiency-and-reduce-resource-usage",
-        "name": "Databricks enhanced autoscaling"
+        "name": "Databricks enhanced autoscaling",
+        "url": "https://learn.microsoft.com/azure/databricks/delta-live-tables/settings#use-autoscaling-to-increase-efficiency-and-reduce-resource-usage"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4806,8 +4806,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4829,8 +4829,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/clusters/configure#cluster-log-delivery",
-        "name": "Create a cluster"
+        "name": "Create a cluster",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/clusters/configure#cluster-log-delivery"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4852,8 +4852,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4875,8 +4875,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#use-apache-spark-or-photon-for-distributed-compute",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#use-apache-spark-or-photon-for-distributed-compute"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4898,8 +4898,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
       }
     ],
     "recommendationControl": "Business Continuity",
@@ -4921,8 +4921,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4944,8 +4944,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4967,8 +4967,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4990,8 +4990,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
       }
     ],
     "recommendationControl": "Business Continuity",
@@ -5013,8 +5013,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -5036,8 +5036,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#use-constraints-and-data-expectations",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#use-constraints-and-data-expectations"
       }
     ],
     "recommendationControl": "Business Continuity",
@@ -5059,8 +5059,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#create-regular-backups",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#create-regular-backups"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -5082,8 +5082,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#recover-from-structured-streaming-query-failures",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#recover-from-structured-streaming-query-failures"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5105,8 +5105,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#recover-etl-jobs-based-on-delta-time-travel",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#recover-etl-jobs-based-on-delta-time-travel"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -5128,8 +5128,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
-        "name": "Best practices for reliability"
+        "name": "Best practices for reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -5151,8 +5151,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://github.com/Azure/AzureDatabricksBestPractices/tree/master",
-        "name": "Azure Databricks Best Practices"
+        "name": "Azure Databricks Best Practices",
+        "url": "https://github.com/Azure/AzureDatabricksBestPractices/tree/master"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -5174,8 +5174,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/operational-excellence/best-practices#2-automate-deployments-and-workloads",
-        "name": "Best practices for operational excellence"
+        "name": "Best practices for operational excellence",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/operational-excellence/best-practices#2-automate-deployments-and-workloads"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -5197,8 +5197,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/operational-excellence/best-practices#system-monitoring",
-        "name": "Best practices for operational excellence"
+        "name": "Best practices for operational excellence",
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/operational-excellence/best-practices#system-monitoring"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -5220,8 +5220,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#deploy-workspaces-in-multiple-subscriptions-to-honor-azure-capacity-limits",
-        "name": "Azure Databricks Best Practices"
+        "name": "Azure Databricks Best Practices",
+        "url": "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#deploy-workspaces-in-multiple-subscriptions-to-honor-azure-capacity-limits"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5243,8 +5243,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#consider-isolating-each-workspace-in-its-own-vnet",
-        "name": "Azure Databricks Best Practices"
+        "name": "Azure Databricks Best Practices",
+        "url": "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#consider-isolating-each-workspace-in-its-own-vnet"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5266,8 +5266,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#do-not-store-any-production-data-in-default-dbfs-folders",
-        "name": "Azure Databricks Best Practices"
+        "name": "Azure Databricks Best Practices",
+        "url": "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#do-not-store-any-production-data-in-default-dbfs-folders"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5289,8 +5289,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/spot-vms",
-        "name": "Use Azure Spot Virtual Machines"
+        "name": "Use Azure Spot Virtual Machines",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/spot-vms"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5312,16 +5312,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/databricks/resources/supported-regions#--azure-databricks-control-plane-addresses",
-        "name": "Azure Databricks control plane addresses"
+        "name": "Azure Databricks control plane addresses",
+        "url": "https://learn.microsoft.com/azure/databricks/resources/supported-regions#--azure-databricks-control-plane-addresses"
       },
       {
-        "url": "https://github.com/databrickslabs/migrate",
-        "name": "Migrate - maintained by Databricks Inc."
+        "name": "Migrate - maintained by Databricks Inc.",
+        "url": "https://github.com/databrickslabs/migrate"
       },
       {
-        "url": "https://registry.terraform.io/providers/databricks/databricks/latest/docs/guides/experimental-exporter",
-        "name": "Databricks Terraform Exporter - maintained by Databricks Inc. (Experimental)"
+        "name": "Databricks Terraform Exporter - maintained by Databricks Inc. (Experimental)",
+        "url": "https://registry.terraform.io/providers/databricks/databricks/latest/docs/guides/experimental-exporter"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5343,12 +5343,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/databricks/compute/cluster-config-best-practices",
-        "name": "Compute configuration best practices"
+        "name": "Compute configuration best practices",
+        "url": "https://learn.microsoft.com/azure/databricks/compute/cluster-config-best-practices"
       },
       {
-        "url": "https://learn.microsoft.com/azure/databricks/compute/gpu",
-        "name": "GPU-enabled compute"
+        "name": "GPU-enabled compute",
+        "url": "https://learn.microsoft.com/azure/databricks/compute/gpu"
       }
     ],
     "recommendationControl": "Personalized",
@@ -5370,12 +5370,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-design-overview#when-to-use-scale-sets-instead-of-virtual-machines",
-        "name": "When to use VMSS instead of VMs"
+        "name": "When to use VMSS instead of VMs",
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-design-overview#when-to-use-scale-sets-instead-of-virtual-machines"
       },
       {
-        "url": "https://learn.microsoft.com/azure/well-architected/services/compute/virtual-machines/virtual-machines-review",
-        "name": "Azure Well-Architected Framework review - Virtual Machines and Scale Sets"
+        "name": "Azure Well-Architected Framework review - Virtual Machines and Scale Sets",
+        "url": "https://learn.microsoft.com/azure/well-architected/services/compute/virtual-machines/virtual-machines-review"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5397,8 +5397,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-health-extension?tabs=rest-api",
-        "name": "Using Application Health extension with Virtual Machine Scale Sets"
+        "name": "Using Application Health extension with Virtual Machine Scale Sets",
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-health-extension?tabs=rest-api"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -5420,8 +5420,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-instance-repairs#requirements-for-using-automatic-instance-repairs",
-        "name": "Automatic instance repairs for Azure Virtual Machine Scale Sets"
+        "name": "Automatic instance repairs for Azure Virtual Machine Scale Sets",
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-instance-repairs#requirements-for-using-automatic-instance-repairs"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5443,12 +5443,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-get-started?WT.mc_id=Portal-Microsoft_Azure_Monitoring",
-        "name": "Get started with autoscale in Azure"
+        "name": "Get started with autoscale in Azure",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-get-started?WT.mc_id=Portal-Microsoft_Azure_Monitoring"
       },
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-overview",
-        "name": "Overview of autoscale in Azure"
+        "name": "Overview of autoscale in Azure",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-overview"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5470,8 +5470,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-predictive",
-        "name": "Use predictive autoscale to scale out before load demands in virtual machine scale sets"
+        "name": "Use predictive autoscale to scale out before load demands in virtual machine scale sets",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-predictive"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5493,8 +5493,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-scale-in-policy",
-        "name": "Use scale-in policies with Azure Virtual Machine Scale Sets"
+        "name": "Use scale-in policies with Azure Virtual Machine Scale Sets",
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-scale-in-policy"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5516,12 +5516,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones",
-        "name": "Create a Virtual Machine Scale Set that uses Availability Zones"
+        "name": "Create a Virtual Machine Scale Set that uses Availability Zones",
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones"
       },
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones?tabs=cli-1%2Cportal-2#update-scale-set-to-add-availability-zones",
-        "name": "Update scale set to add availability zones"
+        "name": "Update scale set to add availability zones",
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones?tabs=cli-1%2Cportal-2#update-scale-set-to-add-availability-zones"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5543,12 +5543,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/automatic-vm-guest-patching",
-        "name": "Automatic VM Guest Patching for Azure VMs"
+        "name": "Automatic VM Guest Patching for Azure VMs",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/automatic-vm-guest-patching"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-upgrade",
-        "name": "Auto OS Image Upgrades"
+        "name": "Auto OS Image Upgrades",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-upgrade"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -5570,8 +5570,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/deprecated-images",
-        "name": "Deprecated Azure Marketplace images"
+        "name": "Deprecated Azure Marketplace images",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/deprecated-images"
       }
     ],
     "recommendationControl": "Governance",
@@ -5593,12 +5593,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-orchestration-modes#what-has-changed-with-flexible-orchestration-mode",
-        "name": "What has changed with Flexible orchestration mode"
+        "name": "What has changed with Flexible orchestration mode",
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-orchestration-modes#what-has-changed-with-flexible-orchestration-mode"
       },
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-attach-detach-vm?branch=main&tabs=portal-1%2Cportal-2%2Cportal-3",
-        "name": "Attach or detach a Virtual Machine to or from a Virtual Machine Scale Set"
+        "name": "Attach or detach a Virtual Machine to or from a Virtual Machine Scale Set",
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-attach-detach-vm?branch=main&tabs=portal-1%2Cportal-2%2Cportal-3"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5620,8 +5620,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/create-portal-availability-zone?tabs=standard",
-        "name": "Create virtual machines in an availability zone using the Azure portal"
+        "name": "Create virtual machines in an availability zone using the Azure portal",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/create-portal-availability-zone?tabs=standard"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5643,8 +5643,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/flexible-virtual-machine-scale-sets-migration-resources",
-        "name": "Migrate deployments and resources to Virtual Machine Scale Sets in Flexible orchestration"
+        "name": "Migrate deployments and resources to Virtual Machine Scale Sets in Flexible orchestration",
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/flexible-virtual-machine-scale-sets-migration-resources"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5666,12 +5666,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#virtual-machines",
-        "name": "Resiliency checklist for Virtual Machines"
+        "name": "Resiliency checklist for Virtual Machines",
+        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#virtual-machines"
       },
       {
-        "url": "https://learn.microsoft.com/azure/site-recovery/site-recovery-test-failover-to-azure",
-        "name": "Run a test failover (disaster recovery drill) to Azure"
+        "name": "Run a test failover (disaster recovery drill) to Azure",
+        "url": "https://learn.microsoft.com/azure/site-recovery/site-recovery-test-failover-to-azure"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -5693,16 +5693,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation",
-        "name": "Migrate your Azure unmanaged disks by Sep 30, 2025"
+        "name": "Migrate your Azure unmanaged disks by Sep 30, 2025",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation"
       },
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/windows/convert-unmanaged-to-managed-disks",
-        "name": "Migrate Windows VM from unmanaged disks to managed disks"
+        "name": "Migrate Windows VM from unmanaged disks to managed disks",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/windows/convert-unmanaged-to-managed-disks"
       },
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/linux/convert-unmanaged-to-managed-disks",
-        "name": "Migrate Linux VM from unmanaged disks to managed disks"
+        "name": "Migrate Linux VM from unmanaged disks to managed disks",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/linux/convert-unmanaged-to-managed-disks"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5724,12 +5724,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/managed-disks-overview#data-disk",
-        "name": "Introduction to Azure managed disks - Data disks"
+        "name": "Introduction to Azure managed disks - Data disks",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/managed-disks-overview#data-disk"
       },
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-types",
-        "name": "Azure managed disk types"
+        "name": "Azure managed disk types",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-types"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5751,8 +5751,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/backup/backup-overview",
-        "name": "What is the Azure Backup service?"
+        "name": "What is the Azure Backup service?",
+        "url": "https://learn.microsoft.com/azure/backup/backup-overview"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -5774,8 +5774,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/states-billing?context=%2Ftroubleshoot%2Fazure%2Fvirtual-machines%2Fcontext%2Fcontext#power-states-and-billing",
-        "name": "States and billing status of Azure Virtual Machines"
+        "name": "States and billing status of Azure Virtual Machines",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/states-billing?context=%2Ftroubleshoot%2Fazure%2Fvirtual-machines%2Fcontext%2Fcontext#power-states-and-billing"
       }
     ],
     "recommendationControl": "Governance",
@@ -5797,8 +5797,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-network/accelerated-networking-overview",
-        "name": "Accelerated Networking (AccelNet) overview"
+        "name": "Accelerated Networking (AccelNet) overview",
+        "url": "https://learn.microsoft.com/azure/virtual-network/accelerated-networking-overview"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5820,8 +5820,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-network/accelerated-networking-overview",
-        "name": "Accelerated Networking (AccelNet) overview"
+        "name": "Accelerated Networking (AccelNet) overview",
+        "url": "https://learn.microsoft.com/azure/virtual-network/accelerated-networking-overview"
       }
     ],
     "recommendationControl": "Governance",
@@ -5843,8 +5843,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/load-balancer/load-balancer-outbound-connections",
-        "name": "Use Source Network Address Translation (SNAT) for outbound connections"
+        "name": "Use Source Network Address Translation (SNAT) for outbound connections",
+        "url": "https://learn.microsoft.com/azure/load-balancer/load-balancer-outbound-connections"
       }
     ],
     "recommendationControl": "Security",
@@ -5866,8 +5866,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-network/network-security-group-how-it-works#intra-subnet-traffic",
-        "name": "How network security groups filter network traffic"
+        "name": "How network security groups filter network traffic",
+        "url": "https://learn.microsoft.com/azure/virtual-network/network-security-group-how-it-works#intra-subnet-traffic"
       }
     ],
     "recommendationControl": "Security",
@@ -5889,8 +5889,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-network/virtual-network-network-interface?tabs=network-interface-portal#enable-or-disable-ip-forwarding",
-        "name": "Enable or disable IP forwarding"
+        "name": "Enable or disable IP forwarding",
+        "url": "https://learn.microsoft.com/azure/virtual-network/virtual-network-network-interface?tabs=network-interface-portal#enable-or-disable-ip-forwarding"
       }
     ],
     "recommendationControl": "Security",
@@ -5912,8 +5912,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances",
-        "name": "Name resolution for resources in Azure virtual networks"
+        "name": "Name resolution for resources in Azure virtual networks",
+        "url": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -5935,12 +5935,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-shared",
-        "name": "Azure Shared Disk Introduction"
+        "name": "Azure Shared Disk Introduction",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-shared"
       },
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-shared-enable?tabs=azure-portal",
-        "name": "Enable Shared Disks"
+        "name": "Enable Shared Disks",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-shared-enable?tabs=azure-portal"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -5962,8 +5962,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-enable-private-links-for-import-export-portal",
-        "name": "Restrict import/export access for managed disks using Azure Private Link"
+        "name": "Restrict import/export access for managed disks using Azure Private Link",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-enable-private-links-for-import-export-portal"
       }
     ],
     "recommendationControl": "Security",
@@ -5985,12 +5985,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-principles#policy-driven-governance",
-        "name": "Policy-driven governance"
+        "name": "Policy-driven governance",
+        "url": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-principles#policy-driven-governance"
       },
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/security-policy",
-        "name": "Azure Policy Regulatory Compliance controls for Azure Virtual Machines"
+        "name": "Azure Policy Regulatory Compliance controls for Azure Virtual Machines",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/security-policy"
       }
     ],
     "recommendationControl": "Governance",
@@ -6012,8 +6012,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disk-encryption-overview",
-        "name": "Overview of managed disk encryption options"
+        "name": "Overview of managed disk encryption options",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disk-encryption-overview"
       }
     ],
     "recommendationControl": "Security",
@@ -6035,12 +6035,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/vm/vminsights-overview",
-        "name": "Overview of VM insights"
+        "name": "Overview of VM insights",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/vm/vminsights-overview"
       },
       {
-        "url": "https://learn.microsoft.com/azure/azure-monitor/vm/vminsights-troubleshoot#did-the-extension-install-properly",
-        "name": "Did the extension install properly?"
+        "name": "Did the extension install properly?",
+        "url": "https://learn.microsoft.com/azure/azure-monitor/vm/vminsights-troubleshoot#did-the-extension-install-properly"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6062,8 +6062,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/agents/agents-overview",
-        "name": "Azure Monitor Agent overview"
+        "name": "Azure Monitor Agent overview",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/agents/agents-overview"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6085,8 +6085,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/maintenance-configurations",
-        "name": "Use maintenance configurations to control and manage the VM updates"
+        "name": "Use maintenance configurations to control and manage the VM updates",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/maintenance-configurations"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6108,8 +6108,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/sizes-b-series-burstable",
-        "name": "B-series burstable virtual machine sizes"
+        "name": "B-series burstable virtual machine sizes",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/sizes-b-series-burstable"
       }
     ],
     "recommendationControl": "Scalability",
@@ -6131,8 +6131,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison",
-        "name": "Disk type comparison and decision tree"
+        "name": "Disk type comparison and decision tree",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison"
       }
     ],
     "recommendationControl": "Scalability",
@@ -6154,12 +6154,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-boost/overview",
-        "name": "Microsoft Azure Boost"
+        "name": "Microsoft Azure Boost",
+        "url": "https://learn.microsoft.com/azure/azure-boost/overview"
       },
       {
-        "url": "https://aka.ms/AzureBoostGABlog",
-        "name": "Announcing the general availability of Azure Boost"
+        "name": "Announcing the general availability of Azure Boost",
+        "url": "https://aka.ms/AzureBoostGABlog"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6181,16 +6181,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/windows/scheduled-event-service",
-        "name": "Monitor scheduled events for your Azure VMs"
+        "name": "Monitor scheduled events for your Azure VMs",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/windows/scheduled-event-service"
       },
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/linux/scheduled-events",
-        "name": "Azure Metadata Service Scheduled Events for Linux VMs"
+        "name": "Azure Metadata Service Scheduled Events for Linux VMs",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/linux/scheduled-events"
       },
       {
-        "url": "https://learn.microsoft.com/azure/virtual-machines/windows/scheduled-events",
-        "name": "Azure Metadata Service Scheduled Events for Windows VMs"
+        "name": "Azure Metadata Service Scheduled Events for Windows VMs",
+        "url": "https://learn.microsoft.com/azure/virtual-machines/windows/scheduled-events"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6212,8 +6212,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://aka.ms/zrsdisksdoc",
-        "name": "Redundancy options for managed disks"
+        "name": "Redundancy options for managed disks",
+        "url": "https://aka.ms/zrsdisksdoc"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6235,8 +6235,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://aka.ms/on-demand-capacity-reservations-docs",
-        "name": "On-demand Capacity Reservation"
+        "name": "On-demand Capacity Reservation",
+        "url": "https://aka.ms/on-demand-capacity-reservations-docs"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6258,8 +6258,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/update-linux-agent?tabs=ubuntu",
-        "name": "How to update the Azure Linux Agent on a VM"
+        "name": "How to update the Azure Linux Agent on a VM",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/update-linux-agent?tabs=ubuntu"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6281,8 +6281,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices",
-        "name": "Compute Gallery best practices"
+        "name": "Compute Gallery best practices",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6304,12 +6304,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices",
-        "name": "Compute Gallery best practices"
+        "name": "Compute Gallery best practices",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy#zone-redundant-storage",
-        "name": "Zone-redundant storage"
+        "name": "Zone-redundant storage",
+        "url": "https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy#zone-redundant-storage"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6331,16 +6331,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices",
-        "name": "Compute Gallery best practices"
+        "name": "Compute Gallery best practices",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/plan/should-i-create-a-generation-1-or-2-virtual-machine-in-hyper-v",
-        "name": "Generation 1 vs Generation 2 in Hyper-V"
+        "name": "Generation 1 vs Generation 2 in Hyper-V",
+        "url": "https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/plan/should-i-create-a-generation-1-or-2-virtual-machine-in-hyper-v"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries?tabs=azure-cli",
-        "name": "Images in Compute gallery"
+        "name": "Images in Compute gallery",
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries?tabs=azure-cli"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6362,8 +6362,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring#design-recommendations",
-        "name": "Configure Azure Service Health alerts"
+        "name": "Configure Azure Service Health alerts",
+        "url": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring#design-recommendations"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6385,8 +6385,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts",
-        "name": "Configure and streamline alerts"
+        "name": "Configure and streamline alerts",
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6408,8 +6408,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts",
-        "name": "Configure and streamline alerts"
+        "name": "Configure and streamline alerts",
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6431,12 +6431,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/infrastructure#implement-high-availability",
-        "name": "Implement high availability"
+        "name": "Implement high availability",
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/infrastructure#implement-high-availability"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/deploy-vsan-stretched-clusters",
-        "name": "Stretched Clusters"
+        "name": "Stretched Clusters",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/deploy-vsan-stretched-clusters"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6458,8 +6458,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-alerts-for-azure-vmware-solution#supported-metrics-and-activities",
-        "name": "Supported metrics and activities"
+        "name": "Supported metrics and activities",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-alerts-for-azure-vmware-solution#supported-metrics-and-activities"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6481,8 +6481,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#manage-logs-and-archives",
-        "name": "Manage logs and archives"
+        "name": "Manage logs and archives",
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#manage-logs-and-archives"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6504,8 +6504,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts",
-        "name": "Configure and streamline alerts"
+        "name": "Configure and streamline alerts",
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6527,8 +6527,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts",
-        "name": "Configure and streamline alerts"
+        "name": "Configure and streamline alerts",
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6550,8 +6550,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources",
-        "name": "Lock your resources to protect your infrastructure"
+        "name": "Lock your resources to protect your infrastructure",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources"
       }
     ],
     "recommendationControl": "Governance",
@@ -6573,8 +6573,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-customer-managed-keys?tabs=azure-portal",
-        "name": "Configure Customer Managed Keys"
+        "name": "Configure Customer Managed Keys",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-customer-managed-keys?tabs=azure-portal"
       }
     ],
     "recommendationControl": "Security",
@@ -6596,8 +6596,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-dns-azure-vmware-solution#configure-dns-forwarder",
-        "name": "Configure DNS forwarder"
+        "name": "Configure DNS forwarder",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-dns-azure-vmware-solution#configure-dns-forwarder"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6619,8 +6619,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/stream-analytics/cluster-overview",
-        "name": "Overview of Azure Stream Analytics Cluster"
+        "name": "Overview of Azure Stream Analytics Cluster",
+        "url": "https://learn.microsoft.com/azure/stream-analytics/cluster-overview"
       }
     ],
     "recommendationControl": "Scalability",
@@ -6642,8 +6642,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/stream-analytics/stream-analytics-streaming-unit-consumption",
-        "name": "Understand and adjust streaming units"
+        "name": "Understand and adjust streaming units",
+        "url": "https://learn.microsoft.com/azure/stream-analytics/stream-analytics-streaming-unit-consumption"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6665,8 +6665,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/event-hubs/event-hubs-geo-dr?tabs=portal#availability-zones",
-        "name": "Azure Event Hubs - Geo-disaster recovery"
+        "name": "Azure Event Hubs - Geo-disaster recovery",
+        "url": "https://learn.microsoft.com/azure/event-hubs/event-hubs-geo-dr?tabs=portal#availability-zones"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6688,8 +6688,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/event-hubs/event-hubs-auto-inflate",
-        "name": "Azure Event Hubs - Automatically scale throughput units"
+        "name": "Azure Event Hubs - Automatically scale throughput units",
+        "url": "https://learn.microsoft.com/azure/event-hubs/event-hubs-auto-inflate"
       }
     ],
     "recommendationControl": "Scalability",
@@ -6711,8 +6711,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-desktop/autoscale-scaling-plan?tabs=portal",
-        "name": "Create and assign an autoscale scaling plan"
+        "name": "Create and assign an autoscale scaling plan",
+        "url": "https://learn.microsoft.com/azure/virtual-desktop/autoscale-scaling-plan?tabs=portal"
       }
     ],
     "recommendationControl": "Scalability",
@@ -6734,8 +6734,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-desktop/configure-validation-environment?tabs=azure-portal",
-        "name": "Configure a host pool as a validation environment"
+        "name": "Configure a host pool as a validation environment",
+        "url": "https://learn.microsoft.com/azure/virtual-desktop/configure-validation-environment?tabs=azure-portal"
       }
     ],
     "recommendationControl": "Governance",
@@ -6757,8 +6757,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/virtual-desktop/scheduled-agent-updates",
-        "name": "Scheduled Agent Updates for Azure Virtual Desktop host pools"
+        "name": "Scheduled Agent Updates for Azure Virtual Desktop host pools",
+        "url": "https://learn.microsoft.com/azure/virtual-desktop/scheduled-agent-updates"
       }
     ],
     "recommendationControl": "Governance",
@@ -6780,8 +6780,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/deploy/virtual-dc/adds-on-azure-vm#configure-the-vms-and-install-active-directory-domain-services",
-        "name": "Configure the VMs and install Active Directory Domain Services"
+        "name": "Configure the VMs and install Active Directory Domain Services",
+        "url": "https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/deploy/virtual-dc/adds-on-azure-vm#configure-the-vms-and-install-active-directory-domain-services"
       }
     ],
     "recommendationControl": "Governance",
@@ -6803,8 +6803,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-overview",
-        "name": "About Site Recovery"
+        "name": "About Site Recovery",
+        "url": "https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-overview"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -6826,20 +6826,20 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/architecture/guide/technology-choices/load-balancing-overview",
-        "name": "Azure Load Balancing Options"
+        "name": "Azure Load Balancing Options",
+        "url": "https://learn.microsoft.com/azure/architecture/guide/technology-choices/load-balancing-overview"
       },
       {
-        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-overview",
-        "name": "Azure Traffic Manager"
+        "name": "Azure Traffic Manager",
+        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-overview"
       },
       {
-        "url": "https://learn.microsoft.com/azure/frontdoor/front-door-overview",
-        "name": "Azure Front Door"
+        "name": "Azure Front Door",
+        "url": "https://learn.microsoft.com/azure/frontdoor/front-door-overview"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/guide/networking/global-web-applications/mission-critical-content-delivery",
-        "name": "Mission-critical global content delivery"
+        "name": "Mission-critical global content delivery",
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/guide/networking/global-web-applications/mission-critical-content-delivery"
       }
     ],
     "recommendationControl": "Business Continuity",
@@ -6861,8 +6861,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/frontdoor/origin-security?tabs=app-service-functions&pivots=front-door-standard-premium",
-        "name": "Secure traffic to Azure Front Door origins"
+        "name": "Secure traffic to Azure Front Door origins",
+        "url": "https://learn.microsoft.com/azure/frontdoor/origin-security?tabs=app-service-functions&pivots=front-door-standard-premium"
       }
     ],
     "recommendationControl": "Security",
@@ -6884,16 +6884,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/rest/api/frontdoor/",
-        "name": "REST API Reference"
+        "name": "REST API Reference",
+        "url": "https://learn.microsoft.com/rest/api/frontdoor/"
       },
       {
-        "url": "https://learn.microsoft.com/java/api/overview/azure/resourcemanager-frontdoor-readme?view=azure-java-preview",
-        "name": "Client library for Java"
+        "name": "Client library for Java",
+        "url": "https://learn.microsoft.com/java/api/overview/azure/resourcemanager-frontdoor-readme?view=azure-java-preview"
       },
       {
-        "url": "https://learn.microsoft.com/python/api/overview/azure/front-door?view=azure-python",
-        "name": "SDK for Python"
+        "name": "SDK for Python",
+        "url": "https://learn.microsoft.com/python/api/overview/azure/front-door?view=azure-python"
       }
     ],
     "recommendationControl": "Scalability",
@@ -6915,16 +6915,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/frontdoor/front-door-diagnostics?pivots=front-door-standard-premium",
-        "name": "Monitor metrics and logs in Azure Front Door"
+        "name": "Monitor metrics and logs in Azure Front Door",
+        "url": "https://learn.microsoft.com/azure/frontdoor/front-door-diagnostics?pivots=front-door-standard-premium"
       },
       {
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-monitor?pivots=front-door-standard-premium#waf-logs",
-        "name": "WAF logs"
+        "name": "WAF logs",
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-monitor?pivots=front-door-standard-premium#waf-logs"
       },
       {
-        "url": "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-logs",
-        "name": "Configure Azure Front Door logs"
+        "name": "Configure Azure Front Door logs",
+        "url": "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-logs"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6946,8 +6946,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/frontdoor/end-to-end-tls?pivots=front-door-standard-premium",
-        "name": "End-to-end TLS with Azure Front Door"
+        "name": "End-to-end TLS with Azure Front Door",
+        "url": "https://learn.microsoft.com/azure/frontdoor/end-to-end-tls?pivots=front-door-standard-premium"
       }
     ],
     "recommendationControl": "Security",
@@ -6969,8 +6969,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/frontdoor/front-door-how-to-redirect-https#create-http-to-https-redirect-rule",
-        "name": "Create HTTP to HTTPS redirect rule"
+        "name": "Create HTTP to HTTPS redirect rule",
+        "url": "https://learn.microsoft.com/azure/frontdoor/front-door-how-to-redirect-https#create-http-to-https-redirect-rule"
       }
     ],
     "recommendationControl": "Security",
@@ -6992,8 +6992,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-configure-https-custom-domain?tabs=powershell",
-        "name": "Configure HTTPS on an Azure Front Door custom domain using the Azure portal"
+        "name": "Configure HTTPS on an Azure Front Door custom domain using the Azure portal",
+        "url": "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-configure-https-custom-domain?tabs=powershell"
       }
     ],
     "recommendationControl": "Security",
@@ -7015,8 +7015,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-configure-https-custom-domain?tabs=powershell#select-the-certificate-for-azure-front-door-to-deploy",
-        "name": "Select the certificate for Azure Front Door to deploy"
+        "name": "Select the certificate for Azure Front Door to deploy",
+        "url": "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-configure-https-custom-domain?tabs=powershell#select-the-certificate-for-azure-front-door-to-deploy"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7038,8 +7038,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/architecture/best-practices/host-name-preservation",
-        "name": "Preserve the original HTTP host name between a reverse proxy and its back-end web application"
+        "name": "Preserve the original HTTP host name between a reverse proxy and its back-end web application",
+        "url": "https://learn.microsoft.com/azure/architecture/best-practices/host-name-preservation"
       }
     ],
     "recommendationControl": "Governance",
@@ -7061,8 +7061,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/frontdoor/web-application-firewall",
-        "name": "Web Application Firewall on Azure Front Door"
+        "name": "Web Application Firewall on Azure Front Door",
+        "url": "https://learn.microsoft.com/azure/frontdoor/web-application-firewall"
       }
     ],
     "recommendationControl": "Security",
@@ -7084,8 +7084,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/frontdoor/health-probes",
-        "name": "Health probes"
+        "name": "Health probes",
+        "url": "https://learn.microsoft.com/azure/frontdoor/health-probes"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7107,8 +7107,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/architecture/patterns/health-endpoint-monitoring",
-        "name": "Health Endpoint Monitoring pattern"
+        "name": "Health Endpoint Monitoring pattern",
+        "url": "https://learn.microsoft.com/azure/architecture/patterns/health-endpoint-monitoring"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7130,8 +7130,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/frontdoor/health-probes#supported-http-methods-for-health-probes",
-        "name": "Supported HTTP methods for health probes"
+        "name": "Supported HTTP methods for health probes",
+        "url": "https://learn.microsoft.com/azure/frontdoor/health-probes#supported-http-methods-for-health-probes"
       }
     ],
     "recommendationControl": "Scalability",
@@ -7153,8 +7153,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-geo-filtering",
-        "name": "Geo filter WAF policy - GeoMatch"
+        "name": "Geo filter WAF policy - GeoMatch",
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-geo-filtering"
       }
     ],
     "recommendationControl": "Security",
@@ -7176,8 +7176,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/frontdoor/private-link",
-        "name": "Private link for Azure Front Door"
+        "name": "Private link for Azure Front Door",
+        "url": "https://learn.microsoft.com/azure/frontdoor/private-link"
       }
     ],
     "recommendationControl": "Security",
@@ -7199,8 +7199,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/frontdoor/understanding-pricing",
-        "name": "Compare pricing between Azure Front Door tiers"
+        "name": "Compare pricing between Azure Front Door tiers",
+        "url": "https://learn.microsoft.com/en-us/azure/frontdoor/understanding-pricing"
       }
     ],
     "recommendationControl": "Service Upgrade and Retirement",
@@ -7222,16 +7222,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/services/messaging/service-bus/reliability",
-        "name": "Service Bus and reliability"
+        "name": "Service Bus and reliability",
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/services/messaging/service-bus/reliability"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-geo-dr#availability-zones",
-        "name": "Azure Service Bus Geo-disaster recovery"
+        "name": "Azure Service Bus Geo-disaster recovery",
+        "url": "https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-geo-dr#availability-zones"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-outages-disasters",
-        "name": "Insulate Azure Service Bus applications against outages and disasters"
+        "name": "Insulate Azure Service Bus applications against outages and disasters",
+        "url": "https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-outages-disasters"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7253,8 +7253,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/service-bus-messaging/automate-update-messaging-units",
-        "name": "Service Bus auto-scaling"
+        "name": "Service Bus auto-scaling",
+        "url": "https://learn.microsoft.com/azure/service-bus-messaging/automate-update-messaging-units"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7276,8 +7276,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/container-apps/health-probes?tabs=arm-template",
-        "name": "Health probes for Azure Container Apps"
+        "name": "Health probes for Azure Container Apps",
+        "url": "https://learn.microsoft.com/azure/container-apps/health-probes?tabs=arm-template"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7299,8 +7299,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-azure-container-apps",
-        "name": "Reliability in Azure Container Apps"
+        "name": "Reliability in Azure Container Apps",
+        "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-azure-container-apps"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7322,8 +7322,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/high-availability-sla-local-zone-redundancy?view=azuresql-mi#zone-redundant-availability",
-        "name": "High availability through zone-redundancy"
+        "name": "High availability through zone-redundancy",
+        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/high-availability-sla-local-zone-redundancy?view=azuresql-mi#zone-redundant-availability"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7345,8 +7345,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/automated-backups-overview?view=azuresql-mi&preserve-view=true#backup-storage-redundancy",
-        "name": "Backup storage redundancy"
+        "name": "Backup storage redundancy",
+        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/automated-backups-overview?view=azuresql-mi&preserve-view=true#backup-storage-redundancy"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7368,8 +7368,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/connection-types-overview?view=azuresql#connection-types",
-        "name": "Connection types"
+        "name": "Connection types",
+        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/connection-types-overview?view=azuresql#connection-types"
       }
     ],
     "recommendationControl": "Scalability",
@@ -7391,8 +7391,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/failover-group-sql-mi?view=azuresql",
-        "name": "Failover groups overview and best practices"
+        "name": "Failover groups overview and best practices",
+        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/failover-group-sql-mi?view=azuresql"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7414,8 +7414,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://techcommunity.microsoft.com/t5/azure-sql/monitoring-options-available-for-azure-sql-managed-instance/ba-p/1065416",
-        "name": "Azure SQL Managed Instance monitoring options"
+        "name": "Azure SQL Managed Instance monitoring options",
+        "url": "https://techcommunity.microsoft.com/t5/azure-sql/monitoring-options-available-for-azure-sql-managed-instance/ba-p/1065416"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -7437,8 +7437,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-sql/database/always-encrypted-landing?view=azuresql",
-        "name": "Overview of Always Encrypted"
+        "name": "Overview of Always Encrypted",
+        "url": "https://learn.microsoft.com/azure/azure-sql/database/always-encrypted-landing?view=azuresql"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7460,8 +7460,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/active-geo-replication-overview",
-        "name": "Active Geo Replication"
+        "name": "Active Geo Replication",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/active-geo-replication-overview"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7483,12 +7483,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/auto-failover-group-overview?tabs=azure-powershell",
-        "name": "AutoFailover Groups"
+        "name": "AutoFailover Groups",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/auto-failover-group-overview?tabs=azure-powershell"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/designing-cloud-solutions-for-disaster-recovery",
-        "name": "DR Design"
+        "name": "DR Design",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/designing-cloud-solutions-for-disaster-recovery"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7510,8 +7510,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/high-availability-sla",
-        "name": "Zone Redundant Databases"
+        "name": "Zone Redundant Databases",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/high-availability-sla"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7533,8 +7533,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/troubleshoot-common-connectivity-issues",
-        "name": "How to Implement Retry Logic"
+        "name": "How to Implement Retry Logic",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/troubleshoot-common-connectivity-issues"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7556,16 +7556,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/insights/azure-sql#analyze-data-and-create-alerts",
-        "name": "Azure Monitor"
+        "name": "Azure Monitor",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/insights/azure-sql#analyze-data-and-create-alerts"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/monitoring-sql-database-azure-monitor",
-        "name": "Azure SQL Database Monitoring"
+        "name": "Azure SQL Database Monitoring",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/monitoring-sql-database-azure-monitor"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/monitoring-sql-database-azure-monitor-reference",
-        "name": "Monitoring SQL Database Reference"
+        "name": "Monitoring SQL Database Reference",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/monitoring-sql-database-azure-monitor-reference"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -7587,12 +7587,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/key-vault/general/overview",
-        "name": "Azure Key Vault"
+        "name": "Azure Key Vault",
+        "url": "https://learn.microsoft.com/en-us/azure/key-vault/general/overview"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/always-encrypted-landing?view=azuresql",
-        "name": "Getting Started with Always Encrypted"
+        "name": "Getting Started with Always Encrypted",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/always-encrypted-landing?view=azuresql"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7614,8 +7614,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-sql/database/failover-group-sql-db?view=azuresql#endpoint-redirection",
-        "name": "Failover Group endpoint redirection"
+        "name": "Failover Group endpoint redirection",
+        "url": "https://learn.microsoft.com/azure/azure-sql/database/failover-group-sql-db?view=azuresql#endpoint-redirection"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7637,12 +7637,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/cosmos-db/distribute-data-globally",
-        "name": "Distribute data globally with Azure Cosmos DB"
+        "name": "Distribute data globally with Azure Cosmos DB",
+        "url": "https://learn.microsoft.com/azure/cosmos-db/distribute-data-globally"
       },
       {
-        "url": "https://learn.microsoft.com/azure/cosmos-db/high-availability#tips-for-building-highly-available-applications",
-        "name": "Tips for building highly available applications"
+        "name": "Tips for building highly available applications",
+        "url": "https://learn.microsoft.com/azure/cosmos-db/high-availability#tips-for-building-highly-available-applications"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7664,8 +7664,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/cosmos-db/how-to-manage-database-account#automatic-failover",
-        "name": "Manage an Azure Cosmos DB account by using the Azure portal"
+        "name": "Manage an Azure Cosmos DB account by using the Azure portal",
+        "url": "https://learn.microsoft.com/azure/cosmos-db/how-to-manage-database-account#automatic-failover"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7687,8 +7687,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-cosmos-db-nosql",
-        "name": "High availability in Azure Cosmos DB"
+        "name": "High availability in Azure Cosmos DB",
+        "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-cosmos-db-nosql"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7710,12 +7710,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/cosmos-db/distribute-data-globally",
-        "name": "Distribute data globally with Azure Cosmos DB"
+        "name": "Distribute data globally with Azure Cosmos DB",
+        "url": "https://learn.microsoft.com/azure/cosmos-db/distribute-data-globally"
       },
       {
-        "url": "https://learn.microsoft.com/azure/cosmos-db/conflict-resolution-policies",
-        "name": "Conflict resolution types and resolution policies in Azure Cosmos DB"
+        "name": "Conflict resolution types and resolution policies in Azure Cosmos DB",
+        "url": "https://learn.microsoft.com/azure/cosmos-db/conflict-resolution-policies"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7737,8 +7737,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/cosmos-db/continuous-backup-restore-introduction",
-        "name": "Continuous backup with point in time restore feature in Azure Cosmos DB"
+        "name": "Continuous backup with point in time restore feature in Azure Cosmos DB",
+        "url": "https://learn.microsoft.com/azure/cosmos-db/continuous-backup-restore-introduction"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7760,8 +7760,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/cosmos-db/nosql/query/pagination#handling-multiple-pages-of-results",
-        "name": "Pagination in Azure Cosmos DB"
+        "name": "Pagination in Azure Cosmos DB",
+        "url": "https://learn.microsoft.com/azure/cosmos-db/nosql/query/pagination#handling-multiple-pages-of-results"
       }
     ],
     "recommendationControl": "Scalability",
@@ -7783,8 +7783,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/cosmos-db/nosql/conceptual-resilient-sdk-applications",
-        "name": "Designing resilient applications with Azure Cosmos DB SDKs"
+        "name": "Designing resilient applications with Azure Cosmos DB SDKs",
+        "url": "https://learn.microsoft.com/azure/cosmos-db/nosql/conceptual-resilient-sdk-applications"
       }
     ],
     "recommendationControl": "Scalability",
@@ -7806,8 +7806,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/cosmos-db/nosql/conceptual-resilient-sdk-applications",
-        "name": "Designing resilient applications with Azure Cosmos DB SDKs"
+        "name": "Designing resilient applications with Azure Cosmos DB SDKs",
+        "url": "https://learn.microsoft.com/azure/cosmos-db/nosql/conceptual-resilient-sdk-applications"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7829,8 +7829,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/cosmos-db/create-alerts",
-        "name": "Create alerts for Azure Cosmos DB using Azure Monitor"
+        "name": "Create alerts for Azure Cosmos DB using Azure Monitor",
+        "url": "https://learn.microsoft.com/azure/cosmos-db/create-alerts"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -7852,8 +7852,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-service-levels",
-        "name": "Service levels for Azure NetApp Files | Microsoft Learn"
+        "name": "Service levels for Azure NetApp Files | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-service-levels"
       }
     ],
     "recommendationControl": "Scalability",
@@ -7875,8 +7875,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-network-topologies",
-        "name": "Guidelines for Azure NetApp Files network planning | Microsoft Learn"
+        "name": "Guidelines for Azure NetApp Files network planning | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-network-topologies"
       }
     ],
     "recommendationControl": "Scalability",
@@ -7898,8 +7898,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/use-availability-zones",
-        "name": "Use availability zones for high availability in Azure NetApp Files | Microsoft Learn"
+        "name": "Use availability zones for high availability in Azure NetApp Files | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/use-availability-zones"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7921,8 +7921,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/manage-availability-zone-volume-placement",
-        "name": "Manage availability zone volume placement for Azure NetApp Files | Microsoft Learn"
+        "name": "Manage availability zone volume placement for Azure NetApp Files | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/manage-availability-zone-volume-placement"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -7944,8 +7944,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/snapshots-introduction",
-        "name": "How Azure NetApp Files snapshots work | Microsoft Learn"
+        "name": "How Azure NetApp Files snapshots work | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/snapshots-introduction"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7967,8 +7967,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/backup-introduction",
-        "name": "Understand Azure NetApp Files backup | Microsoft Learn"
+        "name": "Understand Azure NetApp Files backup | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/backup-introduction"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7990,8 +7990,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-netapp-files/cross-region-replication-introduction",
-        "name": "Cross-region replication of Azure NetApp Files volumes"
+        "name": "Cross-region replication of Azure NetApp Files volumes",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-netapp-files/cross-region-replication-introduction"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -8013,8 +8013,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/cross-zone-replication-introduction",
-        "name": "Cross-zone replication of Azure NetApp Files volumes | Microsoft Learn"
+        "name": "Cross-zone replication of Azure NetApp Files volumes | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/cross-zone-replication-introduction"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -8036,8 +8036,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/monitor-azure-netapp-files",
-        "name": "Ways to monitor Azure NetApp Files | Microsoft Learn"
+        "name": "Ways to monitor Azure NetApp Files | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/monitor-azure-netapp-files"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -8059,12 +8059,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-policy-definitions",
-        "name": "Azure Policy definitions for Azure NetApp Files | Microsoft Learn"
+        "name": "Azure Policy definitions for Azure NetApp Files | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-policy-definitions"
       },
       {
-        "url": "https://learn.microsoft.com/azure/governance/policy/tutorials/create-custom-policy-definition",
-        "name": "Creating custom policy definitions | Microsoft Learn"
+        "name": "Creating custom policy definitions | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/governance/policy/tutorials/create-custom-policy-definition"
       }
     ],
     "recommendationControl": "Governance",
@@ -8086,24 +8086,24 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/configure-network-features",
-        "name": "Configure network features for an Azure NetApp Files volume"
+        "name": "Configure network features for an Azure NetApp Files volume",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/configure-network-features"
       },
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/manage-smb-share-access-control-lists",
-        "name": "Manage SMB share ACLs in Azure NetApp Files"
+        "name": "Manage SMB share ACLs in Azure NetApp Files",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/manage-smb-share-access-control-lists"
       },
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-configure-export-policy",
-        "name": "Configure export policy for NFS or dual-protocol volumes"
+        "name": "Configure export policy for NFS or dual-protocol volumes",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-configure-export-policy"
       },
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/configure-access-control-lists",
-        "name": "Configure access control lists on NFSv4.1 volumes for Azure NetApp Files"
+        "name": "Configure access control lists on NFSv4.1 volumes for Azure NetApp Files",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/configure-access-control-lists"
       },
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/configure-unix-permissions-change-ownership-mode",
-        "name": "Configure Unix permissions and change ownership mode for NFS and dual-protocol volumes"
+        "name": "Configure Unix permissions and change ownership mode for NFS and dual-protocol volumes",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/configure-unix-permissions-change-ownership-mode"
       }
     ],
     "recommendationControl": "Security",
@@ -8125,8 +8125,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/faq-application-resilience#do-i-need-to-take-special-precautions-for-smb-based-applications",
-        "name": "Do I need to take special precautions for SMB-based applications? | Microsoft Learn"
+        "name": "Do I need to take special precautions for SMB-based applications? | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/faq-application-resilience#do-i-need-to-take-special-precautions-for-smb-based-applications"
       }
     ],
     "recommendationControl": "High Availability",
@@ -8148,8 +8148,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/faq-application-resilience#what-do-you-recommend-for-handling-potential-application-disruptions-due-to-storage-service-maintenance-events",
-        "name": "What do you recommend for handling potential application disruptions due to storage service maintenance events? | Microsoft Learn"
+        "name": "What do you recommend for handling potential application disruptions due to storage service maintenance events? | Microsoft Learn",
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/faq-application-resilience#what-do-you-recommend-for-handling-potential-application-disruptions-due-to-storage-service-maintenance-events"
       }
     ],
     "recommendationControl": "High Availability",
@@ -8171,8 +8171,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/event-grid/enable-diagnostic-logs-topic",
-        "name": "Azure Event Grid - Enable diagnostic logs for Event Grid resources"
+        "name": "Azure Event Grid - Enable diagnostic logs for Event Grid resources",
+        "url": "https://learn.microsoft.com/en-us/azure/event-grid/enable-diagnostic-logs-topic"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -8194,8 +8194,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry#dead-letter-events",
-        "name": "Azure Event Grid delivery and retry"
+        "name": "Azure Event Grid delivery and retry",
+        "url": "https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry#dead-letter-events"
       }
     ],
     "recommendationControl": "Personalized",
@@ -8217,8 +8217,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/event-grid/configure-private-endpoints",
-        "name": "Configure private endpoints for Azure Event Grid topics or domains"
+        "name": "Configure private endpoints for Azure Event Grid topics or domains",
+        "url": "https://learn.microsoft.com/en-us/azure/event-grid/configure-private-endpoints"
       }
     ],
     "recommendationControl": "Security",
@@ -8240,8 +8240,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://docs.citrix.com/en-us/citrix-daas-azure/limits",
-        "name": "Citrix Limits"
+        "name": "Citrix Limits",
+        "url": "https://docs.citrix.com/en-us/citrix-daas-azure/limits"
       }
     ],
     "recommendationControl": "Governance",
@@ -8263,12 +8263,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-group-recommendations",
-        "name": "Management group recommendations"
+        "name": "Management group recommendations",
+        "url": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-group-recommendations"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory",
-        "name": "Root management group for each directory"
+        "name": "Root management group for each directory",
+        "url": "https://learn.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory"
       }
     ],
     "recommendationControl": "Governance",
@@ -8290,12 +8290,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-bulk-identity-mgmt",
-        "name": "Import and export IoT Hub device identities in bulk"
+        "name": "Import and export IoT Hub device identities in bulk",
+        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-bulk-identity-mgmt"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr#manual-failover",
-        "name": "IoT Hub high availability and disaster recovery"
+        "name": "IoT Hub high availability and disaster recovery",
+        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr#manual-failover"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -8317,8 +8317,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-scaling",
-        "name": "Choose the right IoT Hub tier and size for your solution"
+        "name": "Choose the right IoT Hub tier and size for your solution",
+        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-scaling"
       }
     ],
     "recommendationControl": "High Availability",
@@ -8340,8 +8340,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr#availability-zones",
-        "name": "Azure IoT Hub high availability and disaster recovery"
+        "name": "Azure IoT Hub high availability and disaster recovery",
+        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr#availability-zones"
       }
     ],
     "recommendationControl": "High Availability",
@@ -8363,16 +8363,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/iot-dps/concepts-service",
-        "name": "IoT Hub Device Provisioning Service (DPS) terminology"
+        "name": "IoT Hub Device Provisioning Service (DPS) terminology",
+        "url": "https://learn.microsoft.com/en-us/azure/iot-dps/concepts-service"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/iot-dps/concepts-deploy-at-scale",
-        "name": "Best practices for large-scale IoT device deployments"
+        "name": "Best practices for large-scale IoT device deployments",
+        "url": "https://learn.microsoft.com/en-us/azure/iot-dps/concepts-deploy-at-scale"
       },
       {
-        "url": "https://learn.microsoft.com/en-us/azure/iot-dps/iot-dps-ha-dr",
-        "name": "IoT Hub Device Provisioning Service high availability and disaster recovery"
+        "name": "IoT Hub Device Provisioning Service high availability and disaster recovery",
+        "url": "https://learn.microsoft.com/en-us/azure/iot-dps/iot-dps-ha-dr"
       }
     ],
     "recommendationControl": "Scalability",
@@ -8394,8 +8394,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr",
-        "name": "IoT Hub high availability and disaster recovery"
+        "name": "IoT Hub high availability and disaster recovery",
+        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr"
       }
     ],
     "recommendationControl": "High Availability",
@@ -8417,8 +8417,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-d2c#fallback-route",
-        "name": "Use message routing - Fallback route"
+        "name": "Use message routing - Fallback route",
+        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-d2c#fallback-route"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -8440,8 +8440,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-group-location-alignment",
-        "name": "Azure Resource Manager Overview"
+        "name": "Azure Resource Manager Overview",
+        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-group-location-alignment"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -8463,8 +8463,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/mysql/flexible-server/concepts-high-availability",
-        "name": "High availability concepts in Azure Database for MySQL - Flexible Server"
+        "name": "High availability concepts in Azure Database for MySQL - Flexible Server",
+        "url": "https://learn.microsoft.com/azure/mysql/flexible-server/concepts-high-availability"
       }
     ],
     "recommendationControl": "High Availability",
@@ -8486,8 +8486,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/azure/mysql/flexible-server/concepts-maintenance",
-        "name": "Scheduled maintenance in Azure Database for MySQL - Flexible Server"
+        "name": "Scheduled maintenance in Azure Database for MySQL - Flexible Server",
+        "url": "https://learn.microsoft.com/azure/mysql/flexible-server/concepts-maintenance"
       }
     ],
     "recommendationControl": "Scalability",
@@ -8509,8 +8509,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-backup-restore",
-        "name": "Backup and restore in Azure Database for MySQL - Flexible Server"
+        "name": "Backup and restore in Azure Database for MySQL - Flexible Server",
+        "url": "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-backup-restore"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -8532,8 +8532,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-read-replicas",
-        "name": "Read replicas in Azure Database for MySQL - Flexible Server"
+        "name": "Read replicas in Azure Database for MySQL - Flexible Server",
+        "url": "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-read-replicas"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -8555,8 +8555,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "url": "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-service-tiers-storage#storage-auto-grow",
-        "name": "Azure Database for MySQL - Flexible Server service tiers - Storage auto grow"
+        "name": "Azure Database for MySQL - Flexible Server service tiers - Storage auto grow",
+        "url": "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-service-tiers-storage#storage-auto-grow"
       }
     ],
     "recommendationControl": "Scalability",

--- a/tools/data/recommendations.json
+++ b/tools/data/recommendations.json
@@ -6,8 +6,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Overview of high availability with Azure Database for PostgreSQL",
-        "url": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-high-availability"
+        "url": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-high-availability",
+        "name": "Overview of high availability with Azure Database for PostgreSQL"
       }
     ],
     "recommendationControl": "High Availability",
@@ -29,8 +29,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Scheduled maintenance in Azure Database for PostgreSQL - Flexible Server",
-        "url": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-maintenance"
+        "url": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-maintenance",
+        "name": "Scheduled maintenance in Azure Database for PostgreSQL - Flexible Server"
       }
     ],
     "recommendationControl": "Scalability",
@@ -52,8 +52,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Backup and restore in Azure Database for PostgreSQL - Flexible Server",
-        "url": "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-backup-restore"
+        "url": "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-backup-restore",
+        "name": "Backup and restore in Azure Database for PostgreSQL - Flexible Server"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -75,8 +75,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Read replicas in Azure Database for PostgreSQL - Flexible Server",
-        "url": "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-read-replicas"
+        "url": "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-read-replicas",
+        "name": "Read replicas in Azure Database for PostgreSQL - Flexible Server"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -98,8 +98,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Storage autogrow using Azure portal in Azure Database for PostgreSQL - Flexible Server",
-        "url": "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-auto-grow-storage-portal"
+        "url": "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-auto-grow-storage-portal",
+        "name": "Storage autogrow using Azure portal in Azure Database for PostgreSQL - Flexible Server"
       }
     ],
     "recommendationControl": "Scalability",
@@ -121,8 +121,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Setup network mapping for site recovery",
-        "url": "https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-network-mapping#set-up-ip-addressing-for-target-vms"
+        "url": "https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-network-mapping#set-up-ip-addressing-for-target-vms",
+        "name": "Setup network mapping for site recovery"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -144,8 +144,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Run a test failover",
-        "url": "https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-tutorial-dr-drill#run-a-test-failover"
+        "url": "https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-tutorial-dr-drill#run-a-test-failover",
+        "name": "Run a test failover"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -167,12 +167,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Move to Azure monitor Alerts",
-        "url": "https://learn.microsoft.com/azure/backup/move-to-azure-monitor-alerts"
+        "url": "https://learn.microsoft.com/azure/backup/move-to-azure-monitor-alerts",
+        "name": "Move to Azure monitor Alerts"
       },
       {
-        "name": "Classic alerts retirement announcement",
-        "url": "https://azure.microsoft.com/updates/transition-to-builtin-azure-monitor-alerts-for-recovery-services-vaults-in-azure-backup-by-31-march-2026/"
+        "url": "https://azure.microsoft.com/updates/transition-to-builtin-azure-monitor-alerts-for-recovery-services-vaults-in-azure-backup-by-31-march-2026/",
+        "name": "Classic alerts retirement announcement"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -194,20 +194,20 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Set Cross Region Restore",
-        "url": "https://learn.microsoft.com/azure/backup/backup-create-recovery-services-vault#set-cross-region-restore"
+        "url": "https://learn.microsoft.com/azure/backup/backup-create-recovery-services-vault#set-cross-region-restore",
+        "name": "Set Cross Region Restore"
       },
       {
-        "name": "Azure Backup Best Practices",
-        "url": "https://learn.microsoft.com/azure/backup/guidance-best-practices"
+        "url": "https://learn.microsoft.com/azure/backup/guidance-best-practices",
+        "name": "Azure Backup Best Practices"
       },
       {
-        "name": "Minimum Role Requirements for Cross Region Restore",
-        "url": "https://learn.microsoft.com/azure/backup/backup-rbac-rs-vault#minimum-role-requirements-for-azure-vm-backup"
+        "url": "https://learn.microsoft.com/azure/backup/backup-rbac-rs-vault#minimum-role-requirements-for-azure-vm-backup",
+        "name": "Minimum Role Requirements for Cross Region Restore"
       },
       {
-        "name": "Recovery Services Vault",
-        "url": "https://learn.microsoft.com/azure/backup/backup-azure-arm-vms-prepare"
+        "url": "https://learn.microsoft.com/azure/backup/backup-azure-arm-vms-prepare",
+        "name": "Recovery Services Vault"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -229,8 +229,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Soft Delete for Azure Backup",
-        "url": "https://learn.microsoft.com/azure/backup/backup-azure-security-feature-cloud?tabs=azure-portal"
+        "url": "https://learn.microsoft.com/azure/backup/backup-azure-security-feature-cloud?tabs=azure-portal",
+        "name": "Soft Delete for Azure Backup"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -252,8 +252,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Container Registry Best Practices",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices",
+        "name": "Container Registry Best Practices"
       }
     ],
     "recommendationControl": "Scalability",
@@ -275,8 +275,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Registry best practices - Enable zone redundancy",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/zone-redundancy?toc=%2Fazure%2Freliability%2Ftoc.json&bc=%2Fazure%2Freliability%2Fbreadcrumb%2Ftoc.json&branch=main"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/zone-redundancy?toc=%2Fazure%2Freliability%2Ftoc.json&bc=%2Fazure%2Freliability%2Fbreadcrumb%2Ftoc.json&branch=main",
+        "name": "Registry best practices - Enable zone redundancy"
       }
     ],
     "recommendationControl": "High Availability",
@@ -298,12 +298,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Registry best practices - Enable geo-replication",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#geo-replicate-multi-region-deployments"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#geo-replicate-multi-region-deployments",
+        "name": "Registry best practices - Enable geo-replication"
       },
       {
-        "name": "Geo-Replicate Container Registry",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-geo-replication"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-geo-replication",
+        "name": "Geo-Replicate Container Registry"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -325,8 +325,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Registry best practices - use repository namespaces",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#repository-namespaces"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#repository-namespaces",
+        "name": "Registry best practices - use repository namespaces"
       }
     ],
     "recommendationControl": "Security",
@@ -348,8 +348,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Registry best practices - Use dedicated resource group",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#dedicated-resource-group"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#dedicated-resource-group",
+        "name": "Registry best practices - Use dedicated resource group"
       }
     ],
     "recommendationControl": "Governance",
@@ -371,12 +371,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Registry best practices - Manage registry size",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#manage-registry-size"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#manage-registry-size",
+        "name": "Registry best practices - Manage registry size"
       },
       {
-        "name": "Retention Policy",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-retention-policy#about-the-retention-policy"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-retention-policy#about-the-retention-policy",
+        "name": "Retention Policy"
       }
     ],
     "recommendationControl": "Scalability",
@@ -398,8 +398,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Enable anonymous pull access",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/anonymous-pull-access#about-anonymous-pull-access"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/anonymous-pull-access#about-anonymous-pull-access",
+        "name": "Enable anonymous pull access"
       }
     ],
     "recommendationControl": "Security",
@@ -421,12 +421,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Monitoring Azure Container Registry data reference - Resource Logs",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service-reference#resource-logs"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service-reference#resource-logs",
+        "name": "Monitoring Azure Container Registry data reference - Resource Logs"
       },
       {
-        "name": "Monitor Azure Container Registry - Enable diagnostic logs",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service#collection-and-routing"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service#collection-and-routing",
+        "name": "Monitor Azure Container Registry - Enable diagnostic logs"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -448,12 +448,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Monitoring Azure Container Registry data reference",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service-reference#metrics"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service-reference#metrics",
+        "name": "Monitoring Azure Container Registry data reference"
       },
       {
-        "name": "Monitor Azure Container Registry",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service",
+        "name": "Monitor Azure Container Registry"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -475,8 +475,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Enable soft delete policy",
-        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-soft-delete-policy"
+        "url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-soft-delete-policy",
+        "name": "Enable soft delete policy"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -498,8 +498,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure ExpressRoute Traffic Collector",
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/traffic-collector"
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/traffic-collector",
+        "name": "Azure ExpressRoute Traffic Collector"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -521,12 +521,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Change your API Management service tier",
-        "url": "https://learn.microsoft.com/en-us/azure/api-management/upgrade-and-scale#change-your-api-management-service-tier"
+        "url": "https://learn.microsoft.com/en-us/azure/api-management/upgrade-and-scale#change-your-api-management-service-tier",
+        "name": "Change your API Management service tier"
       },
       {
-        "name": "Migrate Azure API Management to availability zone support",
-        "url": "https://learn.microsoft.com/en-us/azure/reliability/migrate-api-mgt"
+        "url": "https://learn.microsoft.com/en-us/azure/reliability/migrate-api-mgt",
+        "name": "Migrate Azure API Management to availability zone support"
       }
     ],
     "recommendationControl": "High Availability",
@@ -548,12 +548,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Ensure API Management availability and reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/api-management/high-availability#availability-zones"
+        "url": "https://learn.microsoft.com/en-us/azure/api-management/high-availability#availability-zones",
+        "name": "Ensure API Management availability and reliability"
       },
       {
-        "name": "Migrate Azure API Management to availability zone support",
-        "url": "https://learn.microsoft.com/en-us/azure/reliability/migrate-api-mgt"
+        "url": "https://learn.microsoft.com/en-us/azure/reliability/migrate-api-mgt",
+        "name": "Migrate Azure API Management to availability zone support"
       }
     ],
     "recommendationControl": "High Availability",
@@ -575,12 +575,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure API Management - stv1 platform retirement (August 2024)",
-        "url": "https://learn.microsoft.com/en-us/azure/api-management/breaking-changes/stv1-platform-retirement-august-2024"
+        "url": "https://learn.microsoft.com/en-us/azure/api-management/breaking-changes/stv1-platform-retirement-august-2024",
+        "name": "Azure API Management - stv1 platform retirement (August 2024)"
       },
       {
-        "name": "Azure API Management compute platform",
-        "url": "https://learn.microsoft.com/en-us/azure/api-management/compute-infrastructure"
+        "url": "https://learn.microsoft.com/en-us/azure/api-management/compute-infrastructure",
+        "name": "Azure API Management compute platform"
       }
     ],
     "recommendationControl": "High Availability",
@@ -602,8 +602,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Setting up auto-scale for Azure API Management",
-        "url": "https://learn.microsoft.com/azure/api-management/api-management-howto-autoscale"
+        "url": "https://learn.microsoft.com/azure/api-management/api-management-howto-autoscale",
+        "name": "Setting up auto-scale for Azure API Management"
       }
     ],
     "recommendationControl": "High Availability",
@@ -625,8 +625,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Purge protection",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-soft-delete#purge-protection"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-soft-delete#purge-protection",
+        "name": "Purge protection"
       }
     ],
     "recommendationControl": "Governance",
@@ -648,8 +648,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Choose App Configuration tier",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-app-configuration/faq#which-app-configuration-tier-should-i-use"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-app-configuration/faq#which-app-configuration-tier-should-i-use",
+        "name": "Choose App Configuration tier"
       }
     ],
     "recommendationControl": "High Availability",
@@ -671,8 +671,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Key Vault soft-delete overview",
-        "url": "https://learn.microsoft.com/azure/key-vault/general/soft-delete-overview"
+        "url": "https://learn.microsoft.com/azure/key-vault/general/soft-delete-overview",
+        "name": "Azure Key Vault soft-delete overview"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -694,8 +694,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Key Vault purge-protection overview",
-        "url": "https://learn.microsoft.com/azure/key-vault/general/soft-delete-overview#purge-protection"
+        "url": "https://learn.microsoft.com/azure/key-vault/general/soft-delete-overview#purge-protection",
+        "name": "Azure Key Vault purge-protection overview"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -717,8 +717,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Key Vault Private Link Service overview",
-        "url": "https://learn.microsoft.com/azure/key-vault/general/security-features#network-security"
+        "url": "https://learn.microsoft.com/azure/key-vault/general/security-features#network-security",
+        "name": "Azure Key Vault Private Link Service overview"
       }
     ],
     "recommendationControl": "Security",
@@ -740,8 +740,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Key Vault best practices overview",
-        "url": "https://learn.microsoft.com/azure/key-vault/general/best-practices#why-we-recommend-separate-key-vaults"
+        "url": "https://learn.microsoft.com/azure/key-vault/general/best-practices#why-we-recommend-separate-key-vaults",
+        "name": "Azure Key Vault best practices overview"
       }
     ],
     "recommendationControl": "Governance",
@@ -763,8 +763,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Key Vault logging overview",
-        "url": "https://learn.microsoft.com/azure/key-vault/general/logging?tabs=Vault"
+        "url": "https://learn.microsoft.com/azure/key-vault/general/logging?tabs=Vault",
+        "name": "Azure Key Vault logging overview"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -786,12 +786,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Log Analytics workspace data export in Azure Monitor",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/logs/logs-data-export"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/logs/logs-data-export",
+        "name": "Log Analytics workspace data export in Azure Monitor"
       },
       {
-        "name": "Azure Monitor configuration recommendations",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/best-practices-logs#configuration-recommendations"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/best-practices-logs#configuration-recommendations",
+        "name": "Azure Monitor configuration recommendations"
       }
     ],
     "recommendationControl": "Governance",
@@ -813,12 +813,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Monitor Log Analytics workspace health",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/logs/log-analytics-workspace-health"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/logs/log-analytics-workspace-health",
+        "name": "Monitor Log Analytics workspace health"
       },
       {
-        "name": "Azure Monitor configuration recommendations",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/best-practices-logs#configuration-recommendations"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/best-practices-logs#configuration-recommendations",
+        "name": "Azure Monitor configuration recommendations"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -840,20 +840,20 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Virtual Network - Concepts and best practices | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/virtual-network/concepts-and-best-practices"
+        "url": "https://learn.microsoft.com/azure/virtual-network/concepts-and-best-practices",
+        "name": "Azure Virtual Network - Concepts and best practices | Microsoft Learn"
       },
       {
-        "name": "GatewaySUbnet",
-        "url": "https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsub"
+        "url": "https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsub",
+        "name": "GatewaySUbnet"
       },
       {
-        "name": "Can I associate a network security group (NSG) to the RouteServerSubnet?",
-        "url": "https://learn.microsoft.com/en-us/azure/route-server/route-server-faq#can-i-associate-a-network-security-group-nsg-to-the-routeserversubnet"
+        "url": "https://learn.microsoft.com/en-us/azure/route-server/route-server-faq#can-i-associate-a-network-security-group-nsg-to-the-routeserversubnet",
+        "name": "Can I associate a network security group (NSG) to the RouteServerSubnet?"
       },
       {
-        "name": "Are Network Security Groups (NSGs) supported on the AzureFirewallSubnet?",
-        "url": "https://learn.microsoft.com/en-us/azure/firewall/firewall-faq#are-network-security-groups--nsgs--supported-on-the-azurefirewallsubnet"
+        "url": "https://learn.microsoft.com/en-us/azure/firewall/firewall-faq#are-network-security-groups--nsgs--supported-on-the-azurefirewallsubnet",
+        "name": "Are Network Security Groups (NSGs) supported on the AzureFirewallSubnet?"
       }
     ],
     "recommendationControl": "Security",
@@ -875,8 +875,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Reliability and Azure Virtual Network - Microsoft Azure Well-Architected Framework | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-virtual-network/reliability"
+        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-virtual-network/reliability",
+        "name": "Reliability and Azure Virtual Network - Microsoft Azure Well-Architected Framework | Microsoft Learn"
       }
     ],
     "recommendationControl": "Security",
@@ -898,16 +898,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Virtual Network FAQ | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-faq"
+        "url": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-faq",
+        "name": "Azure Virtual Network FAQ | Microsoft Learn"
       },
       {
-        "name": "Reliability and Network connectivity - Microsoft Azure Well-Architected Framework | Microsoft LearnNetworking Reliability",
-        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/network-connectivity/reliability"
+        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/network-connectivity/reliability",
+        "name": "Reliability and Network connectivity - Microsoft Azure Well-Architected Framework | Microsoft LearnNetworking Reliability"
       },
       {
-        "name": "Azure Private Link availability",
-        "url": "https://learn.microsoft.com/en-us/azure/private-link/availability"
+        "url": "https://learn.microsoft.com/en-us/azure/private-link/availability",
+        "name": "Azure Private Link availability"
       }
     ],
     "recommendationControl": "Security",
@@ -929,12 +929,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Public IP addresses - Availability Zones",
-        "url": "https://learn.microsoft.com/azure/virtual-network/ip-services/public-ip-addresses#availability-zone"
+        "url": "https://learn.microsoft.com/azure/virtual-network/ip-services/public-ip-addresses#availability-zone",
+        "name": "Public IP addresses - Availability Zones"
       },
       {
-        "name": "Upgrading a basic public IP address to Standard SKU",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance#steps-to-complete-the-upgrade"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance#steps-to-complete-the-upgrade",
+        "name": "Upgrading a basic public IP address to Standard SKU"
       }
     ],
     "recommendationControl": "High Availability",
@@ -956,12 +956,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Use NAT GW for outbound connectivity",
-        "url": "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#use-nat-gateway-for-outbound-connectivity"
+        "url": "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#use-nat-gateway-for-outbound-connectivity",
+        "name": "Use NAT GW for outbound connectivity"
       },
       {
-        "name": "TCP and SNAT Ports",
-        "url": "https://learn.microsoft.com/azure/architecture/framework/services/compute/azure-app-service/reliability#tcp-and-snat-ports"
+        "url": "https://learn.microsoft.com/azure/architecture/framework/services/compute/azure-app-service/reliability#tcp-and-snat-ports",
+        "name": "TCP and SNAT Ports"
       }
     ],
     "recommendationControl": "High Availability",
@@ -983,12 +983,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Upgrading a basic public IP address to Standard SKU - Guidance",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance",
+        "name": "Upgrading a basic public IP address to Standard SKU - Guidance"
       },
       {
-        "name": "Upgrade to Standard SKU public IP addresses in Azure by 30 September 2025 as Basic SKU will be retired",
-        "url": "https://azure.microsoft.com/en-us/updates/upgrade-to-standard-sku-public-ip-addresses-in-azure-by-30-september-2025-basic-sku-will-be-retired/"
+        "url": "https://azure.microsoft.com/en-us/updates/upgrade-to-standard-sku-public-ip-addresses-in-azure-by-30-september-2025-basic-sku-will-be-retired/",
+        "name": "Upgrade to Standard SKU public IP addresses in Azure by 30 September 2025 as Basic SKU will be retired"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1010,8 +1010,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure DDoS Protection",
-        "url": "https://learn.microsoft.com/en-us/azure/ddos-protection/ddos-protection-overview"
+        "url": "https://learn.microsoft.com/en-us/azure/ddos-protection/ddos-protection-overview",
+        "name": "Azure DDoS Protection"
       }
     ],
     "recommendationControl": "Security",
@@ -1033,8 +1033,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure activity log - Azure Monitor | Microsoft Learn",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell",
+        "name": "Azure activity log - Azure Monitor | Microsoft Learn"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1056,8 +1056,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?toc=%2Fazure%2Fvirtual-network%2Ftoc.json&tabs=json"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?toc=%2Fazure%2Fvirtual-network%2Ftoc.json&tabs=json",
+        "name": "Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn"
       }
     ],
     "recommendationControl": "Governance",
@@ -1079,12 +1079,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Scale a NAT gateway to meet the demand of a dynamic workload",
-        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-gateway-design#scale-a-nat-gateway-to-meet-the-demand-of-a-dynamic-workload"
+        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-gateway-design#scale-a-nat-gateway-to-meet-the-demand-of-a-dynamic-workload",
+        "name": "Scale a NAT gateway to meet the demand of a dynamic workload"
       },
       {
-        "name": "Total SNAT Connection Count",
-        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-metrics#total-snat-connection-count"
+        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-metrics#total-snat-connection-count",
+        "name": "Total SNAT Connection Count"
       }
     ],
     "recommendationControl": "Scalability",
@@ -1106,12 +1106,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "What is Azure NAT Gateway metrics and alerts?",
-        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-metrics"
+        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-metrics",
+        "name": "What is Azure NAT Gateway metrics and alerts?"
       },
       {
-        "name": "AMBA - NAT Gateway",
-        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/natGateways/"
+        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/natGateways/",
+        "name": "AMBA - NAT Gateway"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1133,8 +1133,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Zonal NAT gateway resource for each zone in a region to create zone-resiliency",
-        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-availability-zones#zonal-nat-gateway-resource-for-each-zone-in-a-region-to-create-zone-resiliency"
+        "url": "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-availability-zones#zonal-nat-gateway-resource-for-each-zone-in-a-region-to-create-zone-resiliency",
+        "name": "Zonal NAT gateway resource for each zone in a region to create zone-resiliency"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1156,8 +1156,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Designing for disaster recovery with ExpressRoute private peering",
-        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-disaster-recovery-with-expressroute-privatepeering"
+        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-disaster-recovery-with-expressroute-privatepeering",
+        "name": "Designing for disaster recovery with ExpressRoute private peering"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1179,12 +1179,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Designing for high availability with ExpressRoute",
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/designing-for-high-availability-with-expressroute"
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/designing-for-high-availability-with-expressroute",
+        "name": "Designing for high availability with ExpressRoute"
       },
       {
-        "name": "Azure Well-Architected Framework review - Azure ExpressRoute - Design Checklist",
-        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-expressroute#recommendations"
+        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-expressroute#recommendations",
+        "name": "Azure Well-Architected Framework review - Azure ExpressRoute - Design Checklist"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1206,8 +1206,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Designing for high availability with ExpressRoute - Active-active connections",
-        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-high-availability-with-expressroute#active-active-connections"
+        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-high-availability-with-expressroute#active-active-connections",
+        "name": "Designing for high availability with ExpressRoute - Active-active connections"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1229,8 +1229,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure BFD over ExpressRoute",
-        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-bfd"
+        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-bfd",
+        "name": "Configure BFD over ExpressRoute"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1252,8 +1252,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Monitor Baseline Alerts - expressRouteCircuits",
-        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/expressRouteCircuits/"
+        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/expressRouteCircuits/",
+        "name": "Azure Monitor Baseline Alerts - expressRouteCircuits"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1275,8 +1275,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "How to view and configure alerts for Azure ExpressRoute circuit maintenance",
-        "url": "https://learn.microsoft.com/azure/expressroute/maintenance-alerts"
+        "url": "https://learn.microsoft.com/azure/expressroute/maintenance-alerts",
+        "name": "How to view and configure alerts for Azure ExpressRoute circuit maintenance"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1298,8 +1298,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Rate limiting for ExpressRoute Direct circuits (Preview)",
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/rate-limit"
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/rate-limit",
+        "name": "Rate limiting for ExpressRoute Direct circuits (Preview)"
       }
     ],
     "recommendationControl": "Scalability",
@@ -1321,8 +1321,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Diagnostic settings in Azure Monitor",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/diagnostic-settings"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/diagnostic-settings",
+        "name": "Diagnostic settings in Azure Monitor"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1344,8 +1344,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Monitor activity log",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/activity-log?tabs=powershell"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/activity-log?tabs=powershell",
+        "name": "Azure Monitor activity log"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1367,8 +1367,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Lock your resources to protect your infrastructure",
-        "url": "https://learn.microsoft.com/azure/azure-resource-manager/management/lock-resources?toc=%2Fazure%2Fvirtual-network%2Ftoc.json&tabs=json"
+        "url": "https://learn.microsoft.com/azure/azure-resource-manager/management/lock-resources?toc=%2Fazure%2Fvirtual-network%2Ftoc.json&tabs=json",
+        "name": "Lock your resources to protect your infrastructure"
       }
     ],
     "recommendationControl": "Governance",
@@ -1390,8 +1390,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Flow logging for network security groups",
-        "url": "https://learn.microsoft.com/azure/network-watcher/network-watcher-nsg-flow-logging-overview"
+        "url": "https://learn.microsoft.com/azure/network-watcher/network-watcher-nsg-flow-logging-overview",
+        "name": "Flow logging for network security groups"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1413,8 +1413,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Security rules",
-        "url": "https://learn.microsoft.com/azure/virtual-network/network-security-groups-overview#security-rules"
+        "url": "https://learn.microsoft.com/azure/virtual-network/network-security-groups-overview#security-rules",
+        "name": "Security rules"
       }
     ],
     "recommendationControl": "Security",
@@ -1436,12 +1436,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Well Architected Framework - Azure Firewall",
-        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-firewall"
+        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-firewall",
+        "name": "Azure Well Architected Framework - Azure Firewall"
       },
       {
-        "name": "Deploy Azure Firewall across multiple availability zones",
-        "url": "https://learn.microsoft.com/azure/firewall/deploy-availability-zone-powershell"
+        "url": "https://learn.microsoft.com/azure/firewall/deploy-availability-zone-powershell",
+        "name": "Deploy Azure Firewall across multiple availability zones"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1463,12 +1463,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Firewall metrics supported in Azure Monitor",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkazurefirewalls"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkazurefirewalls",
+        "name": "Azure Firewall metrics supported in Azure Monitor"
       },
       {
-        "name": "Azure Firewall performance",
-        "url": "https://learn.microsoft.com/azure/firewall/firewall-performance"
+        "url": "https://learn.microsoft.com/azure/firewall/firewall-performance",
+        "name": "Azure Firewall performance"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1490,8 +1490,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure DDoS Protection overview",
-        "url": "https://learn.microsoft.com/azure/ddos-protection/ddos-protection-overview"
+        "url": "https://learn.microsoft.com/azure/ddos-protection/ddos-protection-overview",
+        "name": "Azure DDoS Protection overview"
       }
     ],
     "recommendationControl": "Security",
@@ -1513,8 +1513,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Firewall Policy hierarchy",
-        "url": "https://learn.microsoft.com/azure/firewall-manager/rule-hierarchy"
+        "url": "https://learn.microsoft.com/azure/firewall-manager/rule-hierarchy",
+        "name": "Azure Firewall Policy hierarchy"
       }
     ],
     "recommendationControl": "Governance",
@@ -1536,8 +1536,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Well-Architected Framework review - Azure Firewall",
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/service-guides/azure-firewall#recommendations"
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/service-guides/azure-firewall#recommendations",
+        "name": "Azure Well-Architected Framework review - Azure Firewall"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1559,12 +1559,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Well-Architected Framework review - Azure Firewall",
-        "url": "https://learn.microsoft.com/azure/well-architected/service-guides/azure-firewall#recommendations"
+        "url": "https://learn.microsoft.com/azure/well-architected/service-guides/azure-firewall#recommendations",
+        "name": "Azure Well-Architected Framework review - Azure Firewall"
       },
       {
-        "name": "Azure Firewall metrics overview",
-        "url": "https://learn.microsoft.com/azure/firewall/metrics"
+        "url": "https://learn.microsoft.com/azure/firewall/metrics",
+        "name": "Azure Firewall metrics overview"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1586,8 +1586,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Private endpoint connections",
-        "url": "https://learn.microsoft.com/azure/private-link/manage-private-endpoint?tabs=manage-private-link-powershell#private-endpoint-connections"
+        "url": "https://learn.microsoft.com/azure/private-link/manage-private-endpoint?tabs=manage-private-link-powershell#private-endpoint-connections",
+        "name": "Private endpoint connections"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1609,16 +1609,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Traffic Manager endpoint monitoring",
-        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-monitoring"
+        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-monitoring",
+        "name": "Azure Traffic Manager endpoint monitoring"
       },
       {
-        "name": "Enable or disable health checks",
-        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-monitoring#enable-or-disable-health-checks-preview"
+        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-monitoring#enable-or-disable-health-checks-preview",
+        "name": "Enable or disable health checks"
       },
       {
-        "name": "Troubleshooting degraded state on Azure Traffic Manager",
-        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-troubleshooting-degraded"
+        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-troubleshooting-degraded",
+        "name": "Troubleshooting degraded state on Azure Traffic Manager"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1640,8 +1640,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Traffic Manager Endpoint Types",
-        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-endpoint-types"
+        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-endpoint-types",
+        "name": "Traffic Manager Endpoint Types"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1663,8 +1663,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Reliability recommendations",
-        "url": "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#add-at-least-one-more-endpoint-to-the-profile-preferably-in-another-azure-region"
+        "url": "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#add-at-least-one-more-endpoint-to-the-profile-preferably-in-another-azure-region",
+        "name": "Reliability recommendations"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -1686,12 +1686,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Add an endpoint configured to \"All (World)\"",
-        "url": "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#add-an-endpoint-configured-to-all-world"
+        "url": "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#add-an-endpoint-configured-to-all-world",
+        "name": "Add an endpoint configured to \"All (World)\""
       },
       {
-        "name": "Traffic Manager profile - GeographicProfile (Add an endpoint configured to \"\"All (World)\"\").",
-        "url": "https://aka.ms/Rf7vc5"
+        "url": "https://aka.ms/Rf7vc5",
+        "name": "Traffic Manager profile - GeographicProfile (Add an endpoint configured to \"\"All (World)\"\")."
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -1713,8 +1713,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Designing for disaster recovery with ExpressRoute private peering",
-        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-disaster-recovery-with-expressroute-privatepeering"
+        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-disaster-recovery-with-expressroute-privatepeering",
+        "name": "Designing for disaster recovery with ExpressRoute private peering"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1736,8 +1736,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Virtual WAN Monitoring Best Practices",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#expressroute-gateway"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#expressroute-gateway",
+        "name": "Virtual WAN Monitoring Best Practices"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1759,8 +1759,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Monitoring Azure DDoS Protection",
-        "url": "https://learn.microsoft.com/en-us/azure/ddos-protection/monitor-ddos-protection-reference"
+        "url": "https://learn.microsoft.com/en-us/azure/ddos-protection/monitor-ddos-protection-reference",
+        "name": "Monitoring Azure DDoS Protection"
       }
     ],
     "recommendationControl": "Security",
@@ -1782,8 +1782,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "About ExpressRoute FastPath",
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/about-fastpath"
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/about-fastpath",
+        "name": "About ExpressRoute FastPath"
       }
     ],
     "recommendationControl": "Scalability",
@@ -1805,8 +1805,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?tabs=json"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?tabs=json",
+        "name": "Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn"
       }
     ],
     "recommendationControl": "High Availability",
@@ -1828,8 +1828,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Virtual WAN Monitoring Best Practices",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#virtual-wan-gateways"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#virtual-wan-gateways",
+        "name": "Virtual WAN Monitoring Best Practices"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1851,8 +1851,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "What is Azure Network Watcher?",
-        "url": "https://learn.microsoft.com/azure/network-watcher/network-watcher-overview"
+        "url": "https://learn.microsoft.com/azure/network-watcher/network-watcher-overview",
+        "name": "What is Azure Network Watcher?"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1874,8 +1874,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Manage NSG flow logs using the Azure portal",
-        "url": "https://learn.microsoft.com/azure/network-watcher/nsg-flow-logging"
+        "url": "https://learn.microsoft.com/azure/network-watcher/nsg-flow-logging",
+        "name": "Manage NSG flow logs using the Azure portal"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1897,8 +1897,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Connection monitor overview",
-        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/connection-monitor-overview"
+        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/connection-monitor-overview",
+        "name": "Connection monitor overview"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1920,12 +1920,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Flow logging for network security groups",
-        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-overview"
+        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-overview",
+        "name": "Flow logging for network security groups"
       },
       {
-        "name": "Virtual network flow logs",
-        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-overview"
+        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/vnet-flow-logs-overview",
+        "name": "Virtual network flow logs"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1947,8 +1947,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Network Watcher traffic analytics",
-        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/traffic-analytics"
+        "url": "https://learn.microsoft.com/en-us/azure/network-watcher/traffic-analytics",
+        "name": "Network Watcher traffic analytics"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -1970,8 +1970,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Application Gateway Autoscaling Zone-Redundant",
-        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-autoscaling-zone-redundant#autoscaling-and-high-availability"
+        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-autoscaling-zone-redundant#autoscaling-and-high-availability",
+        "name": "Application Gateway Autoscaling Zone-Redundant"
       }
     ],
     "recommendationControl": "Scalability",
@@ -1993,24 +1993,24 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Application Gateway Security",
-        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway#security"
+        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway#security",
+        "name": "Application Gateway Security"
       },
       {
-        "name": "Application Gateway SSL Overview",
-        "url": "https://learn.microsoft.com/azure/application-gateway/ssl-overview"
+        "url": "https://learn.microsoft.com/azure/application-gateway/ssl-overview",
+        "name": "Application Gateway SSL Overview"
       },
       {
-        "name": "Application Gateway SSL Policy Overview",
-        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-ssl-policy-overview"
+        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-ssl-policy-overview",
+        "name": "Application Gateway SSL Policy Overview"
       },
       {
-        "name": "Application Gateway KeyVault Certs",
-        "url": "https://learn.microsoft.com/azure/application-gateway/key-vault-certs"
+        "url": "https://learn.microsoft.com/azure/application-gateway/key-vault-certs",
+        "name": "Application Gateway KeyVault Certs"
       },
       {
-        "name": "Application Gateway SSL Cert Management",
-        "url": "https://learn.microsoft.com/azure/application-gateway/ssl-certificate-management"
+        "url": "https://learn.microsoft.com/azure/application-gateway/ssl-certificate-management",
+        "name": "Application Gateway SSL Cert Management"
       }
     ],
     "recommendationControl": "Security",
@@ -2032,12 +2032,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Well-Architected Framework Application Gateway Overview",
-        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway"
+        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway",
+        "name": "Well-Architected Framework Application Gateway Overview"
       },
       {
-        "name": "Application Gateway - Web Application Firewall",
-        "url": "https://learn.microsoft.com/azure/application-gateway/features#web-application-firewall"
+        "url": "https://learn.microsoft.com/azure/application-gateway/features#web-application-firewall",
+        "name": "Application Gateway - Web Application Firewall"
       }
     ],
     "recommendationControl": "Security",
@@ -2059,16 +2059,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Application Gateway Overview V2",
-        "url": "https://learn.microsoft.com/azure/application-gateway/overview-v2"
+        "url": "https://learn.microsoft.com/azure/application-gateway/overview-v2",
+        "name": "Application Gateway Overview V2"
       },
       {
-        "name": "Application Gateway Feature Comparison Between V1 and V2",
-        "url": "https://learn.microsoft.com/azure/application-gateway/overview-v2#feature-comparison-between-v1-sku-and-v2-sku"
+        "url": "https://learn.microsoft.com/azure/application-gateway/overview-v2#feature-comparison-between-v1-sku-and-v2-sku",
+        "name": "Application Gateway Feature Comparison Between V1 and V2"
       },
       {
-        "name": "Application Gateway V1 Retirement",
-        "url": "https://azure.microsoft.com/updates/application-gateway-v1-will-be-retired-on-28-april-2026-transition-to-application-gateway-v2/"
+        "url": "https://azure.microsoft.com/updates/application-gateway-v1-will-be-retired-on-28-april-2026-transition-to-application-gateway-v2/",
+        "name": "Application Gateway V1 Retirement"
       }
     ],
     "recommendationControl": "Scalability",
@@ -2090,12 +2090,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Application Gateway Metrics",
-        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-metrics"
+        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-metrics",
+        "name": "Application Gateway Metrics"
       },
       {
-        "name": "Application Gateway Diagnostics",
-        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-diagnostics"
+        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-diagnostics",
+        "name": "Application Gateway Diagnostics"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2117,12 +2117,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Application Gateway Probe Overview",
-        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-probe-overview"
+        "url": "https://learn.microsoft.com/azure/application-gateway/application-gateway-probe-overview",
+        "name": "Application Gateway Probe Overview"
       },
       {
-        "name": "Well-Architected Framework Application Gateway Overview",
-        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway"
+        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway",
+        "name": "Well-Architected Framework Application Gateway Overview"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2144,12 +2144,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Well-Architected Framework Application Gateway Reliability",
-        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway#reliability"
+        "url": "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway#reliability",
+        "name": "Well-Architected Framework Application Gateway Reliability"
       },
       {
-        "name": "Application Gateway V2 Overview",
-        "url": "https://learn.microsoft.com/azure/application-gateway/overview-v2"
+        "url": "https://learn.microsoft.com/azure/application-gateway/overview-v2",
+        "name": "Application Gateway V2 Overview"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2171,12 +2171,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Application Gateway Connection Draining",
-        "url": "https://learn.microsoft.com/azure/application-gateway/features#connection-draining"
+        "url": "https://learn.microsoft.com/azure/application-gateway/features#connection-draining",
+        "name": "Application Gateway Connection Draining"
       },
       {
-        "name": "Application Gateway Connection Draining HTTP Settings",
-        "url": "https://learn.microsoft.com/azure/application-gateway/configuration-http-settings#connection-draining"
+        "url": "https://learn.microsoft.com/azure/application-gateway/configuration-http-settings#connection-draining",
+        "name": "Application Gateway Connection Draining HTTP Settings"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2198,8 +2198,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Application Gateway infrastructure configuration | Microsoft Learn",
-        "url": "https://learn.microsoft.com/en-us/azure/application-gateway/configuration-infrastructure#size-of-the-subnet"
+        "url": "https://learn.microsoft.com/en-us/azure/application-gateway/configuration-infrastructure#size-of-the-subnet",
+        "name": "Azure Application Gateway infrastructure configuration | Microsoft Learn"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -2221,8 +2221,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Designing for disaster recovery with ExpressRoute private peering",
-        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-disaster-recovery-with-expressroute-privatepeering"
+        "url": "https://learn.microsoft.com/azure/expressroute/designing-for-disaster-recovery-with-expressroute-privatepeering",
+        "name": "Designing for disaster recovery with ExpressRoute private peering"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2244,16 +2244,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "About ExpressRoute virtual network gateways - Zone-redundant gateway SKUs",
-        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-about-virtual-network-gateways#zrgw"
+        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-about-virtual-network-gateways#zrgw",
+        "name": "About ExpressRoute virtual network gateways - Zone-redundant gateway SKUs"
       },
       {
-        "name": "About zone-redundant virtual network gateway in Azure availability zones",
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways"
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways",
+        "name": "About zone-redundant virtual network gateway in Azure availability zones"
       },
       {
-        "name": "Create a zone-redundant virtual network gateway in Azure Availability Zones",
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/create-zone-redundant-vnet-gateway"
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/create-zone-redundant-vnet-gateway",
+        "name": "Create a zone-redundant virtual network gateway in Azure Availability Zones"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2275,8 +2275,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?tabs=json"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?tabs=json",
+        "name": "Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2298,12 +2298,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "ExpressRoute monitoring, metrics, and alerts | ExpressRoute gateways",
-        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-monitoring-metrics-alerts#expressroute-gateways"
+        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-monitoring-metrics-alerts#expressroute-gateways",
+        "name": "ExpressRoute monitoring, metrics, and alerts | ExpressRoute gateways"
       },
       {
-        "name": "Azure ExpressRoute Insights using Network Insights",
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-network-insights"
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-network-insights",
+        "name": "Azure ExpressRoute Insights using Network Insights"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2325,8 +2325,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "About ExpressRoute virtual network gateways - VNet-to-VNet connectivity",
-        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-about-virtual-network-gateways#vnet-to-vnet-connectivity"
+        "url": "https://learn.microsoft.com/azure/expressroute/expressroute-about-virtual-network-gateways#vnet-to-vnet-connectivity",
+        "name": "About ExpressRoute virtual network gateways - VNet-to-VNet connectivity"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2348,8 +2348,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure customer-controlled maintenance for your virtual network gateway - ExpressRoute | Microsoft Learn",
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/customer-controlled-gateway-maintenance#azure-portal-steps"
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/customer-controlled-gateway-maintenance#azure-portal-steps",
+        "name": "Configure customer-controlled maintenance for your virtual network gateway - ExpressRoute | Microsoft Learn"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2371,16 +2371,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Zone redundant Virtual network gateway in availability zone",
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways"
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways",
+        "name": "Zone redundant Virtual network gateway in availability zone"
       },
       {
-        "name": "Gateway SKU",
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways#gwskus"
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways#gwskus",
+        "name": "Gateway SKU"
       },
       {
-        "name": "SLA summary for Azure services",
-        "url": "https://www.microsoft.com/licensing/docs/view/Service-Level-Agreements-SLA-for-Online-Services?lang=1"
+        "url": "https://www.microsoft.com/licensing/docs/view/Service-Level-Agreements-SLA-for-Online-Services?lang=1",
+        "name": "SLA summary for Azure services"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2402,12 +2402,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Active-active VPN gateway",
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/active-active-portal#gateway"
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/active-active-portal#gateway",
+        "name": "Active-active VPN gateway"
       },
       {
-        "name": "Gateway SKU",
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsku"
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsku",
+        "name": "Gateway SKU"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2429,8 +2429,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Dual-redundancy active-active VPN gateways for both Azure and on-premises networks",
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/vpn-gateway-highlyavailable#dual-redundancy-active-active-vpn-gateways-for-both-azure-and-on-premises-networks"
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/vpn-gateway-highlyavailable#dual-redundancy-active-active-vpn-gateways-for-both-azure-and-on-premises-networks",
+        "name": "Dual-redundancy active-active VPN gateways for both Azure and on-premises networks"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -2452,8 +2452,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "VPN gateway data reference",
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/monitor-vpn-gateway-reference"
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/monitor-vpn-gateway-reference",
+        "name": "VPN gateway data reference"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2475,12 +2475,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Getting started with Azure Metrics Explorer",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/metrics-getting-started"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/essentials/metrics-getting-started",
+        "name": "Getting started with Azure Metrics Explorer"
       },
       {
-        "name": "Monitor VPN gateway",
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/monitor-vpn-gateway-reference#metrics"
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/monitor-vpn-gateway-reference#metrics",
+        "name": "Monitor VPN gateway"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2502,8 +2502,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "About zone-redundant virtual network gateway in Azure availability zones",
-        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways"
+        "url": "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways",
+        "name": "About zone-redundant virtual network gateway in Azure availability zones"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2525,8 +2525,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Virtual WAN Monitoring Best Practices",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#point-to-site-vpn-gateway"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#point-to-site-vpn-gateway",
+        "name": "Virtual WAN Monitoring Best Practices"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2548,8 +2548,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Reliability in Azure DNS",
-        "url": "https://learn.microsoft.com/azure/reliability/reliability-dns"
+        "url": "https://learn.microsoft.com/azure/reliability/reliability-dns",
+        "name": "Reliability in Azure DNS"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -2571,8 +2571,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "How to configure ExpressRoute Direct Change Admin State of links",
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-howto-erdirect#state"
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-howto-erdirect#state",
+        "name": "How to configure ExpressRoute Direct Change Admin State of links"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2594,8 +2594,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "About ExpressRoute Direct Circuit Sizes",
-        "url": "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-erdirect-about?source=recommendations#circuit-sizes"
+        "url": "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-erdirect-about?source=recommendations#circuit-sizes",
+        "name": "About ExpressRoute Direct Circuit Sizes"
       }
     ],
     "recommendationControl": "Scalability",
@@ -2617,8 +2617,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Monitor Baseline Alerts - expressRoutePorts",
-        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/expressRoutePorts/"
+        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/expressRoutePorts/",
+        "name": "Azure Monitor Baseline Alerts - expressRoutePorts"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2640,12 +2640,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Reliability and Azure Load Balancer",
-        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-load-balancer/reliability"
+        "url": "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-load-balancer/reliability",
+        "name": "Reliability and Azure Load Balancer"
       },
       {
-        "name": "Resiliency checklist for specific Azure services- Azure Load Balancer",
-        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer"
+        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer",
+        "name": "Resiliency checklist for specific Azure services- Azure Load Balancer"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2667,8 +2667,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Resiliency checklist for specific Azure services- Azure Load Balancer",
-        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer"
+        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer",
+        "name": "Resiliency checklist for specific Azure services- Azure Load Balancer"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2690,8 +2690,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Resiliency checklist for specific Azure services- Azure Load Balancer",
-        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer"
+        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer",
+        "name": "Resiliency checklist for specific Azure services- Azure Load Balancer"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2713,8 +2713,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Load Balancer and Availability Zones",
-        "url": "https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-availability-zones#zone-redundant"
+        "url": "https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-availability-zones#zone-redundant",
+        "name": "Load Balancer and Availability Zones"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2736,8 +2736,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Load Balancer Health Probe Overview",
-        "url": "https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-custom-probe-overview"
+        "url": "https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-custom-probe-overview",
+        "name": "Load Balancer Health Probe Overview"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2759,8 +2759,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Protecting private DNS Zones and Records - Azure DNS",
-        "url": "https://learn.microsoft.com/en-us/azure/dns/dns-protect-private-zones-recordsets"
+        "url": "https://learn.microsoft.com/en-us/azure/dns/dns-protect-private-zones-recordsets",
+        "name": "Protecting private DNS Zones and Records - Azure DNS"
       }
     ],
     "recommendationControl": "Security",
@@ -2782,8 +2782,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Monitor Baseline Alerts - privateDnsZones",
-        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/privateDnsZones/"
+        "url": "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/privateDnsZones/",
+        "name": "Azure Monitor Baseline Alerts - privateDnsZones"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2805,8 +2805,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Private Link and DNS integration at scale",
-        "url": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale"
+        "url": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/private-link-and-dns-integration-at-scale",
+        "name": "Private Link and DNS integration at scale"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -2828,8 +2828,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Reliability in Azure DNS",
-        "url": "https://learn.microsoft.com/azure/reliability/reliability-dns"
+        "url": "https://learn.microsoft.com/azure/reliability/reliability-dns",
+        "name": "Reliability in Azure DNS"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -2851,8 +2851,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Virtual WAN Monitoring Best Practices",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#virtual-hub"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#virtual-hub",
+        "name": "Virtual WAN Monitoring Best Practices"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2874,20 +2874,20 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Web Application Firewall monitoring and logging - Access Log",
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-monitor?pivots=front-door-standard-premium#access-logs"
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-monitor?pivots=front-door-standard-premium#access-logs",
+        "name": "Azure Web Application Firewall monitoring and logging - Access Log"
       },
       {
-        "name": "Understanding WAF logs",
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-tuning?pivots=front-door-standard-premium#understanding-waf-logs"
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-tuning?pivots=front-door-standard-premium#understanding-waf-logs",
+        "name": "Understanding WAF logs"
       },
       {
-        "name": "Web Application Firewall exclusion lists",
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-configuration?tabs=portal"
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-configuration?tabs=portal",
+        "name": "Web Application Firewall exclusion lists"
       },
       {
-        "name": "Fixing a false positive",
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-troubleshoot#fixing-false-positives"
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-troubleshoot#fixing-false-positives",
+        "name": "Fixing a false positive"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2909,12 +2909,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Web Application Firewall Monitoring and Logging",
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-metrics#logs-and-diagnostics"
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-metrics#logs-and-diagnostics",
+        "name": "Azure Web Application Firewall Monitoring and Logging"
       },
       {
-        "name": "Diagnostic logs",
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-logs#diagnostic-logs"
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-logs#diagnostic-logs",
+        "name": "Diagnostic logs"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2936,12 +2936,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "WAF monitoring",
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/ag-overview#waf-monitoring"
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/ag/ag-overview#waf-monitoring",
+        "name": "WAF monitoring"
       },
       {
-        "name": "Azure Monitor Workbook for WAF",
-        "url": "https://github.com/Azure/Azure-Network-Security/tree/master/Azure%20WAF/Workbook%20-%20WAF%20Monitor%20Workbook"
+        "url": "https://github.com/Azure/Azure-Network-Security/tree/master/Azure%20WAF/Workbook%20-%20WAF%20Monitor%20Workbook",
+        "name": "Azure Monitor Workbook for WAF"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -2963,8 +2963,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Availability zones support in Azure SignalR Service",
-        "url": "https://learn.microsoft.com/azure/azure-signalr/availability-zones"
+        "url": "https://learn.microsoft.com/azure/azure-signalr/availability-zones",
+        "name": "Availability zones support in Azure SignalR Service"
       }
     ],
     "recommendationControl": "High Availability",
@@ -2986,8 +2986,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Create and use replica sets for resiliency or geolocation in Microsoft Entra Domain Services",
-        "url": "https://learn.microsoft.com/en-us/entra/identity/domain-services/tutorial-create-replica-set"
+        "url": "https://learn.microsoft.com/en-us/entra/identity/domain-services/tutorial-create-replica-set",
+        "name": "Create and use replica sets for resiliency or geolocation in Microsoft Entra Domain Services"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3009,8 +3009,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Create and use replica sets for resiliency or geolocation in Microsoft Entra Domain Services",
-        "url": "https://learn.microsoft.com/en-us/entra/identity/domain-services/tutorial-create-replica-set"
+        "url": "https://learn.microsoft.com/en-us/entra/identity/domain-services/tutorial-create-replica-set",
+        "name": "Create and use replica sets for resiliency or geolocation in Microsoft Entra Domain Services"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3032,12 +3032,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "AKS Availability Zones",
-        "url": "https://learn.microsoft.com/en-us/azure/aks/availability-zones"
+        "url": "https://learn.microsoft.com/en-us/azure/aks/availability-zones",
+        "name": "AKS Availability Zones"
       },
       {
-        "name": "Zone Balancing",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones#zone-balancing"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones#zone-balancing",
+        "name": "Zone Balancing"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3059,8 +3059,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "System and user node pools",
-        "url": "https://learn.microsoft.com/en-us/azure/aks/use-system-pools?tabs=azure-cli#system-and-user-node-pools"
+        "url": "https://learn.microsoft.com/en-us/azure/aks/use-system-pools?tabs=azure-cli#system-and-user-node-pools",
+        "name": "System and user node pools"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3082,16 +3082,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Entra integration",
-        "url": "https://learn.microsoft.com/en-us/azure/aks/concepts-identity#azure-ad-integration"
+        "url": "https://learn.microsoft.com/en-us/azure/aks/concepts-identity#azure-ad-integration",
+        "name": "Entra integration"
       },
       {
-        "name": "Use Azure role-based access control for AKS",
-        "url": "https://learn.microsoft.com/en-us/azure/aks/manage-azure-rbac?source=recommendations"
+        "url": "https://learn.microsoft.com/en-us/azure/aks/manage-azure-rbac?source=recommendations",
+        "name": "Use Azure role-based access control for AKS"
       },
       {
-        "name": "Manage AKS local accounts",
-        "url": "https://learn.microsoft.com/en-us/azure/aks/manage-local-accounts-managed-azure-ad?source=recommendations"
+        "url": "https://learn.microsoft.com/en-us/azure/aks/manage-local-accounts-managed-azure-ad?source=recommendations",
+        "name": "Manage AKS local accounts"
       }
     ],
     "recommendationControl": "Security",
@@ -3113,12 +3113,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure Azure CNI networking",
-        "url": "https://learn.microsoft.com/en-us/azure/aks/configure-azure-cni-dynamic-ip-allocation"
+        "url": "https://learn.microsoft.com/en-us/azure/aks/configure-azure-cni-dynamic-ip-allocation",
+        "name": "Configure Azure CNI networking"
       },
       {
-        "name": "Configure Azure CNI Overlay networking",
-        "url": "https://learn.microsoft.com/en-us/azure/aks/azure-cni-overlay"
+        "url": "https://learn.microsoft.com/en-us/azure/aks/azure-cni-overlay",
+        "name": "Configure Azure CNI Overlay networking"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3140,20 +3140,20 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Use the Cluster Autoscaler on AKS",
-        "url": "https://learn.microsoft.com/azure/aks/cluster-autoscaler?tabs=azure-cli"
+        "url": "https://learn.microsoft.com/azure/aks/cluster-autoscaler?tabs=azure-cli",
+        "name": "Use the Cluster Autoscaler on AKS"
       },
       {
-        "name": "Best practices for advanced scheduler features",
-        "url": "https://learn.microsoft.com/azure/aks/operator-best-practices-advanced-scheduler"
+        "url": "https://learn.microsoft.com/azure/aks/operator-best-practices-advanced-scheduler",
+        "name": "Best practices for advanced scheduler features"
       },
       {
-        "name": "Node pool scaling considerations and best practices",
-        "url": "https://learn.microsoft.com/azure/aks/best-practices-performance-scale-large#node-pool-scaling"
+        "url": "https://learn.microsoft.com/azure/aks/best-practices-performance-scale-large#node-pool-scaling",
+        "name": "Node pool scaling considerations and best practices"
       },
       {
-        "name": "Best practices for basic scheduler features",
-        "url": "https://learn.microsoft.com/azure/aks/operator-best-practices-scheduler"
+        "url": "https://learn.microsoft.com/azure/aks/operator-best-practices-scheduler",
+        "name": "Best practices for basic scheduler features"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3175,12 +3175,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "AKS Backups",
-        "url": "https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-cluster-backup"
+        "url": "https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-cluster-backup",
+        "name": "AKS Backups"
       },
       {
-        "name": "Best Practices for AKS Backups",
-        "url": "https://learn.microsoft.com/en-us/azure/aks/operator-best-practices-storage"
+        "url": "https://learn.microsoft.com/en-us/azure/aks/operator-best-practices-storage",
+        "name": "Best Practices for AKS Backups"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -3202,24 +3202,24 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Availability zones overview",
-        "url": "https://learn.microsoft.com/azure/reliability/availability-zones-overview?tabs=azure-cli"
+        "url": "https://learn.microsoft.com/azure/reliability/availability-zones-overview?tabs=azure-cli",
+        "name": "Availability zones overview"
       },
       {
-        "name": "Zone-redundant storage",
-        "url": "https://learn.microsoft.com/azure/storage/common/storage-redundancy#zone-redundant-storage"
+        "url": "https://learn.microsoft.com/azure/storage/common/storage-redundancy#zone-redundant-storage",
+        "name": "Zone-redundant storage"
       },
       {
-        "name": "ZRS disks",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-redundancy#zone-redundant-storage-for-managed-disks"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-redundancy#zone-redundant-storage-for-managed-disks",
+        "name": "ZRS disks"
       },
       {
-        "name": "Convert a disk from LRS to ZRS",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-migrate-lrs-zrs"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-migrate-lrs-zrs",
+        "name": "Convert a disk from LRS to ZRS"
       },
       {
-        "name": "Enable multi-zone storage redundancy in Azure Container Storage",
-        "url": "https://learn.microsoft.com/azure/storage/container-storage/enable-multi-zone-redundancy"
+        "url": "https://learn.microsoft.com/azure/storage/container-storage/enable-multi-zone-redundancy",
+        "name": "Enable multi-zone storage redundancy in Azure Container Storage"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3241,12 +3241,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "CSI Storage Drivers",
-        "url": "https://learn.microsoft.com/azure/aks/csi-storage-drivers"
+        "url": "https://learn.microsoft.com/azure/aks/csi-storage-drivers",
+        "name": "CSI Storage Drivers"
       },
       {
-        "name": "CSI Migrate in Tree Volumes",
-        "url": "https://learn.microsoft.com/azure/aks/csi-migrate-in-tree-volumes"
+        "url": "https://learn.microsoft.com/azure/aks/csi-migrate-in-tree-volumes",
+        "name": "CSI Migrate in Tree Volumes"
       }
     ],
     "recommendationControl": "Governance",
@@ -3268,8 +3268,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Resource Quotas",
-        "url": "https://kubernetes.io/docs/concepts/policy/resource-quotas/"
+        "url": "https://kubernetes.io/docs/concepts/policy/resource-quotas/",
+        "name": "Resource Quotas"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3291,12 +3291,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Virtual Nodes",
-        "url": "https://learn.microsoft.com/azure/aks/virtual-nodes"
+        "url": "https://learn.microsoft.com/azure/aks/virtual-nodes",
+        "name": "Virtual Nodes"
       },
       {
-        "name": "Azure Container Instances",
-        "url": "https://learn.microsoft.com/azure/container-instances/container-instances-overview"
+        "url": "https://learn.microsoft.com/azure/container-instances/container-instances-overview",
+        "name": "Azure Container Instances"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3318,12 +3318,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Pricing Tiers",
-        "url": "https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers"
+        "url": "https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers",
+        "name": "Pricing Tiers"
       },
       {
-        "name": "AKS Baseline Architecture",
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks?toc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Faks%2Ftoc.json&bc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#kubernetes-api-server-sla"
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks?toc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Faks%2Ftoc.json&bc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#kubernetes-api-server-sla",
+        "name": "AKS Baseline Architecture"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3345,8 +3345,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Monitor AKS",
-        "url": "https://learn.microsoft.com/azure/aks/monitor-aks"
+        "url": "https://learn.microsoft.com/azure/aks/monitor-aks",
+        "name": "Monitor AKS"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -3368,16 +3368,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Ephemeral OS disk",
-        "url": "https://learn.microsoft.com/azure/aks/concepts-storage#ephemeral-os-disk"
+        "url": "https://learn.microsoft.com/azure/aks/concepts-storage#ephemeral-os-disk",
+        "name": "Ephemeral OS disk"
       },
       {
-        "name": "Configure an AKS cluster",
-        "url": "https://learn.microsoft.com/azure/aks/cluster-configuration"
+        "url": "https://learn.microsoft.com/azure/aks/cluster-configuration",
+        "name": "Configure an AKS cluster"
       },
       {
-        "name": "Everything you want to know about ephemeral OS disks and AKS",
-        "url": "https://learn.microsoft.com/samples/azure-samples/aks-ephemeral-os-disk/aks-ephemeral-os-disk/"
+        "url": "https://learn.microsoft.com/samples/azure-samples/aks-ephemeral-os-disk/aks-ephemeral-os-disk/",
+        "name": "Everything you want to know about ephemeral OS disks and AKS"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3399,12 +3399,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "AKS Baseline - Policy Management",
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks?toc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Faks%2Ftoc.json&bc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#policy-management"
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks?toc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Faks%2Ftoc.json&bc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#policy-management",
+        "name": "AKS Baseline - Policy Management"
       },
       {
-        "name": "Built-in Policy Definitions for AKS",
-        "url": "https://learn.microsoft.com/en-us/azure/aks/policy-reference"
+        "url": "https://learn.microsoft.com/en-us/azure/aks/policy-reference",
+        "name": "Built-in Policy Definitions for AKS"
       }
     ],
     "recommendationControl": "Governance",
@@ -3426,12 +3426,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "GitOps with AKS",
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/guide/aks/aks-cicd-github-actions-and-gitops"
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/guide/aks/aks-cicd-github-actions-and-gitops",
+        "name": "GitOps with AKS"
       },
       {
-        "name": "GitOps for AKS - Reference Architecture",
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/example-scenario/gitops-aks/gitops-blueprint-aks"
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/example-scenario/gitops-aks/gitops-blueprint-aks",
+        "name": "GitOps for AKS - Reference Architecture"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -3453,12 +3453,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Topology Spread Constraints",
-        "url": "https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/"
+        "url": "https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/",
+        "name": "Topology Spread Constraints"
       },
       {
-        "name": "Assign Pod Node",
-        "url": "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/"
+        "url": "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/",
+        "name": "Assign Pod Node"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3480,12 +3480,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure probes",
-        "url": "https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/"
+        "url": "https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
+        "name": "Configure probes"
       },
       {
-        "name": "Assign Pod Node",
-        "url": "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/"
+        "url": "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/",
+        "name": "Assign Pod Node"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3507,8 +3507,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Replica Sets",
-        "url": "https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/"
+        "url": "https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/",
+        "name": "Replica Sets"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3530,8 +3530,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "System nodepools",
-        "url": "https://learn.microsoft.com/azure/aks/use-system-pools?tabs=azure-cli"
+        "url": "https://learn.microsoft.com/azure/aks/use-system-pools?tabs=azure-cli",
+        "name": "System nodepools"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3553,8 +3553,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Well-Architected Framework review for Azure Kubernetes Service (AKS)",
-        "url": "https://learn.microsoft.com/azure/well-architected/service-guides/azure-kubernetes-service#design-checklist"
+        "url": "https://learn.microsoft.com/azure/well-architected/service-guides/azure-kubernetes-service#design-checklist",
+        "name": "Azure Well-Architected Framework review for Azure Kubernetes Service (AKS)"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3576,12 +3576,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure PDBs",
-        "url": "https://kubernetes.io/docs/tasks/run-application/configure-pdb/"
+        "url": "https://kubernetes.io/docs/tasks/run-application/configure-pdb/",
+        "name": "Configure PDBs"
       },
       {
-        "name": "Plan availability using PDBs",
-        "url": "https://learn.microsoft.com/azure/aks/operator-best-practices-scheduler#plan-for-availability-using-pod-disruption-budgets"
+        "url": "https://learn.microsoft.com/azure/aks/operator-best-practices-scheduler#plan-for-availability-using-pod-disruption-budgets",
+        "name": "Plan availability using PDBs"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3603,8 +3603,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure CNI Dynamic IP Allocation",
-        "url": "https://learn.microsoft.com/azure/aks/configure-azure-cni-dynamic-ip-allocation"
+        "url": "https://learn.microsoft.com/azure/aks/configure-azure-cni-dynamic-ip-allocation",
+        "name": "Azure CNI Dynamic IP Allocation"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3626,8 +3626,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Quotas",
-        "url": "https://learn.microsoft.com/azure/quotas/quotas-overview"
+        "url": "https://learn.microsoft.com/azure/quotas/quotas-overview",
+        "name": "Azure Quotas"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3649,8 +3649,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Linux",
-        "url": "https://learn.microsoft.com/azure/aks/use-azure-linux"
+        "url": "https://learn.microsoft.com/azure/aks/use-azure-linux",
+        "name": "Azure Linux"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3672,8 +3672,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Multi-replica apps",
-        "url": "https://learn.microsoft.com/azure/aks/best-practices-app-cluster-reliability#multi-replica-applications"
+        "url": "https://learn.microsoft.com/azure/aks/best-practices-app-cluster-reliability#multi-replica-applications",
+        "name": "Multi-replica apps"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3695,8 +3695,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Generation 1 vs generation 2 virtual machines",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/generation-2#features-and-capabilities"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/generation-2#features-and-capabilities",
+        "name": "Generation 1 vs generation 2 virtual machines"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3718,12 +3718,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Image Template resiliency",
-        "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-image-builder?toc=%2Fazure%2Fvirtual-machines%2Ftoc.json&bc=%2Fazure%2Fvirtual-machines%2Fbreadcrumb%2Ftoc.json#capacity-and-proactive-disaster-recovery-resiliency"
+        "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-image-builder?toc=%2Fazure%2Fvirtual-machines%2Ftoc.json&bc=%2Fazure%2Fvirtual-machines%2Fbreadcrumb%2Ftoc.json#capacity-and-proactive-disaster-recovery-resiliency",
+        "name": "Image Template resiliency"
       },
       {
-        "name": "Azure Image Builder Supported Regions",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/image-builder-overview?tabs=azure-powershell#regions"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/image-builder-overview?tabs=azure-powershell#regions",
+        "name": "Azure Image Builder Supported Regions"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -3745,12 +3745,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Disaster recovery for Automation accounts",
-        "url": "https://learn.microsoft.com/en-us/azure/automation/automation-disaster-recovery?tabs=win-hrw%2Cps-script%2Coption-one"
+        "url": "https://learn.microsoft.com/en-us/azure/automation/automation-disaster-recovery?tabs=win-hrw%2Cps-script%2Coption-one",
+        "name": "Disaster recovery for Automation accounts"
       },
       {
-        "name": "Disaster recovery scenarios for cloud and hybrid jobs",
-        "url": "https://learn.microsoft.com/en-us/azure/automation/automation-disaster-recovery?tabs=win-hrw%2Cps-script%2Coption-one#scenarios-for-cloud-and-hybrid-jobs"
+        "url": "https://learn.microsoft.com/en-us/azure/automation/automation-disaster-recovery?tabs=win-hrw%2Cps-script%2Coption-one#scenarios-for-cloud-and-hybrid-jobs",
+        "name": "Disaster recovery scenarios for cloud and hybrid jobs"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3772,12 +3772,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Storage redundancy",
-        "url": "https://learn.microsoft.com/azure/storage/common/storage-redundancy"
+        "url": "https://learn.microsoft.com/azure/storage/common/storage-redundancy",
+        "name": "Azure Storage redundancy"
       },
       {
-        "name": "Change the redundancy configuration for a storage account",
-        "url": "https://learn.microsoft.com/azure/storage/common/redundancy-migration"
+        "url": "https://learn.microsoft.com/azure/storage/common/redundancy-migration",
+        "name": "Change the redundancy configuration for a storage account"
       }
     ],
     "recommendationControl": "High Availability",
@@ -3799,12 +3799,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure classic storage accounts retirement announcement",
-        "url": "https://azure.microsoft.com/updates/classic-azure-storage-accounts-will-be-retired-on-31-august-2024/"
+        "url": "https://azure.microsoft.com/updates/classic-azure-storage-accounts-will-be-retired-on-31-august-2024/",
+        "name": "Azure classic storage accounts retirement announcement"
       },
       {
-        "name": "Migrate your classic storage accounts to Azure Resource Manager",
-        "url": "https://learn.microsoft.com/azure/storage/common/classic-account-migration-overview"
+        "url": "https://learn.microsoft.com/azure/storage/common/classic-account-migration-overview",
+        "name": "Migrate your classic storage accounts to Azure Resource Manager"
       }
     ],
     "recommendationControl": "Service Upgrade and Retirement",
@@ -3826,24 +3826,24 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Types of storage accounts",
-        "url": "https://learn.microsoft.com/azure/storage/common/storage-account-overview#types-of-storage-accounts"
+        "url": "https://learn.microsoft.com/azure/storage/common/storage-account-overview#types-of-storage-accounts",
+        "name": "Types of storage accounts"
       },
       {
-        "name": "Scalability and performance targets for standard storage accounts",
-        "url": "https://learn.microsoft.com/azure/storage/common/scalability-targets-standard-account"
+        "url": "https://learn.microsoft.com/azure/storage/common/scalability-targets-standard-account",
+        "name": "Scalability and performance targets for standard storage accounts"
       },
       {
-        "name": "Performance and scalability checklist for Blob storage",
-        "url": "https://learn.microsoft.com/azure/storage/blobs/storage-performance-checklist"
+        "url": "https://learn.microsoft.com/azure/storage/blobs/storage-performance-checklist",
+        "name": "Performance and scalability checklist for Blob storage"
       },
       {
-        "name": "Scalability and performance targets for Blob storage",
-        "url": "https://learn.microsoft.com/azure/storage/blobs/scalability-targets"
+        "url": "https://learn.microsoft.com/azure/storage/blobs/scalability-targets",
+        "name": "Scalability and performance targets for Blob storage"
       },
       {
-        "name": "Premium block blob storage accounts",
-        "url": "https://learn.microsoft.com/azure/storage/blobs/storage-blob-block-blob-premium"
+        "url": "https://learn.microsoft.com/azure/storage/blobs/storage-blob-block-blob-premium",
+        "name": "Premium block blob storage accounts"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3865,8 +3865,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Soft delete detail docs",
-        "url": "https://learn.microsoft.com//azure/storage/blobs/soft-delete-blob-enable?tabs=azure-portal "
+        "url": "https://learn.microsoft.com//azure/storage/blobs/soft-delete-blob-enable?tabs=azure-portal ",
+        "name": "Soft delete detail docs"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -3888,8 +3888,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Blob versioning",
-        "url": "https://learn.microsoft.com/azure/storage/blobs/versioning-overview "
+        "url": "https://learn.microsoft.com/azure/storage/blobs/versioning-overview ",
+        "name": "Blob versioning"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -3911,12 +3911,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Point-in-time restore for block blobs",
-        "url": "https://learn.microsoft.com/azure/storage/blobs/point-in-time-restore-overview"
+        "url": "https://learn.microsoft.com/azure/storage/blobs/point-in-time-restore-overview",
+        "name": "Point-in-time restore for block blobs"
       },
       {
-        "name": "Perform a point-in-time restore on block blob data",
-        "url": "https://learn.microsoft.com/azure/storage/blobs/point-in-time-restore-manage?tabs=portal"
+        "url": "https://learn.microsoft.com/azure/storage/blobs/point-in-time-restore-manage?tabs=portal",
+        "name": "Perform a point-in-time restore on block blob data"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -3938,12 +3938,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Monitor Azure Blob Storage",
-        "url": "https://learn.microsoft.com/azure/storage/blobs/monitor-blob-storage"
+        "url": "https://learn.microsoft.com/azure/storage/blobs/monitor-blob-storage",
+        "name": "Monitor Azure Blob Storage"
       },
       {
-        "name": "Best practices for monitoring Azure Blob Storage",
-        "url": "https://learn.microsoft.com/azure/storage/blobs/blob-storage-monitoring-scenarios"
+        "url": "https://learn.microsoft.com/azure/storage/blobs/blob-storage-monitoring-scenarios",
+        "name": "Best practices for monitoring Azure Blob Storage"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -3965,12 +3965,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Legacy storage account types",
-        "url": "https://learn.microsoft.com/azure/storage/common/storage-account-overview#legacy-storage-account-types"
+        "url": "https://learn.microsoft.com/azure/storage/common/storage-account-overview#legacy-storage-account-types",
+        "name": "Legacy storage account types"
       },
       {
-        "name": "Upgrade to a general-purpose v2 storage account",
-        "url": "https://learn.microsoft.com/azure/storage/common/storage-account-upgrade"
+        "url": "https://learn.microsoft.com/azure/storage/common/storage-account-upgrade",
+        "name": "Upgrade to a general-purpose v2 storage account"
       }
     ],
     "recommendationControl": "Scalability",
@@ -3992,12 +3992,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Learn More",
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/example-scenario/wvd/windows-virtual-desktop#azure-virtual-desktop-limitations"
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/example-scenario/wvd/windows-virtual-desktop#azure-virtual-desktop-limitations",
+        "name": "Learn More"
       },
       {
-        "name": "Private Link",
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-virtual-desktop/networking#private-endpoints-private-link"
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-virtual-desktop/networking#private-endpoints-private-link",
+        "name": "Private Link"
       }
     ],
     "recommendationControl": "Security",
@@ -4019,8 +4019,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Enable diagnostics logging for apps in Azure App Service",
-        "url": "https://learn.microsoft.com/azure/app-service/troubleshoot-diagnostic-logs"
+        "url": "https://learn.microsoft.com/azure/app-service/troubleshoot-diagnostic-logs",
+        "name": "Enable diagnostics logging for apps in Azure App Service"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4042,12 +4042,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Application Insights",
-        "url": "https://learn.microsoft.com/azure/application-insights/app-insights-overview"
+        "url": "https://learn.microsoft.com/azure/application-insights/app-insights-overview",
+        "name": "Application Insights"
       },
       {
-        "name": "Application monitoring for Azure App Service",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/app/azure-web-apps"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/app/azure-web-apps",
+        "name": "Application monitoring for Azure App Service"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4069,8 +4069,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Resiliency checklist for specific Azure services",
-        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#app-service"
+        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#app-service",
+        "name": "Resiliency checklist for specific Azure services"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4092,8 +4092,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Resiliency checklist",
-        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#app-service"
+        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#app-service",
+        "name": "Resiliency checklist"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4115,8 +4115,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Set up staging environments in Azure App Service",
-        "url": "https://learn.microsoft.com/azure/app-service-web/web-sites-staged-publishing"
+        "url": "https://learn.microsoft.com/azure/app-service-web/web-sites-staged-publishing",
+        "name": "Set up staging environments in Azure App Service"
       }
     ],
     "recommendationControl": "Governance",
@@ -4138,8 +4138,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure web apps in Azure App Service",
-        "url": "https://learn.microsoft.com/azure/app-service-web/web-sites-configure"
+        "url": "https://learn.microsoft.com/azure/app-service-web/web-sites-configure",
+        "name": "Configure web apps in Azure App Service"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -4161,8 +4161,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Monitor the health of App Service instances",
-        "url": "https://learn.microsoft.com/en-us/azure/app-service/monitor-instances-health-check?tabs=dotnet#enable-health-check"
+        "url": "https://learn.microsoft.com/en-us/azure/app-service/monitor-instances-health-check?tabs=dotnet#enable-health-check",
+        "name": "Monitor the health of App Service instances"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -4184,8 +4184,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Set up Azure App Service access restrictions",
-        "url": "https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions?tabs=azurecli"
+        "url": "https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions?tabs=azurecli",
+        "name": "Set up Azure App Service access restrictions"
       }
     ],
     "recommendationControl": "Governance",
@@ -4207,8 +4207,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Ultimate guide to running healthy apps in the cloud",
-        "url": "https://azure.github.io/AppService/2020/05/15/Robust-Apps-for-the-cloud.html"
+        "url": "https://azure.github.io/AppService/2020/05/15/Robust-Apps-for-the-cloud.html",
+        "name": "Ultimate guide to running healthy apps in the cloud"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4230,8 +4230,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Announcing the New Auto Healing Experience in App Service Diagnostics - Azure App Service",
-        "url": "https://azure.github.io/AppService/2018/09/10/Announcing-the-New-Auto-Healing-Experience-in-App-Service-Diagnostics.html"
+        "url": "https://azure.github.io/AppService/2018/09/10/Announcing-the-New-Auto-Healing-Experience-in-App-Service-Diagnostics.html",
+        "name": "Announcing the New Auto Healing Experience in App Service Diagnostics - Azure App Service"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4253,8 +4253,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Functions Warmup Trigger",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-warmup?tabs=in-process%2Cnodejs-v4&pivots=programming-language-csharp#trigger"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-warmup?tabs=in-process%2Cnodejs-v4&pivots=programming-language-csharp#trigger",
+        "name": "Azure Functions Warmup Trigger"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4276,8 +4276,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Resource naming restrictions - Azure Resource Manager",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules",
+        "name": "Resource naming restrictions - Azure Resource Manager"
       }
     ],
     "recommendationControl": "Governance",
@@ -4299,8 +4299,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Migrate version 3.x to 4.x",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-functions/migrate-version-3-version-4?tabs=net6-in-proc%2Cazure-cli%2Cwindows&pivots=programming-language-csharp"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-functions/migrate-version-3-version-4?tabs=net6-in-proc%2Cazure-cli%2Cwindows&pivots=programming-language-csharp",
+        "name": "Migrate version 3.x to 4.x"
       }
     ],
     "recommendationControl": "Governance",
@@ -4322,8 +4322,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "FUNCTIONS_WORKER_RUNTIME",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#functions_worker_runtime"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#functions_worker_runtime",
+        "name": "FUNCTIONS_WORKER_RUNTIME"
       }
     ],
     "recommendationControl": "Governance",
@@ -4345,12 +4345,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Migrate App Service to availability zone support",
-        "url": "https://learn.microsoft.com/en-us/azure/reliability/migrate-app-service"
+        "url": "https://learn.microsoft.com/en-us/azure/reliability/migrate-app-service",
+        "name": "Migrate App Service to availability zone support"
       },
       {
-        "name": "High availability enterprise deployment using App Service Environment",
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/enterprise-integration/ase-high-availability-deployment"
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/enterprise-integration/ase-high-availability-deployment",
+        "name": "High availability enterprise deployment using App Service Environment"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4372,8 +4372,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Resiliency checklist for specific Azure services",
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service"
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service",
+        "name": "Resiliency checklist for specific Azure services"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4395,8 +4395,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Resiliency checklist for specific Azure services",
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service"
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service",
+        "name": "Resiliency checklist for specific Azure services"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4418,8 +4418,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Resiliency checklist for specific Azure services",
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service"
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service",
+        "name": "Resiliency checklist for specific Azure services"
       }
     ],
     "recommendationControl": "Governance",
@@ -4441,12 +4441,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Automatic scaling in Azure App Service",
-        "url": "https://learn.microsoft.com/en-us/azure/app-service/manage-automatic-scaling?tabs=azure-portal"
+        "url": "https://learn.microsoft.com/en-us/azure/app-service/manage-automatic-scaling?tabs=azure-portal",
+        "name": "Automatic scaling in Azure App Service"
       },
       {
-        "name": "Auto Scale Web Apps",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-get-started"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-get-started",
+        "name": "Auto Scale Web Apps"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4468,8 +4468,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Enable zone redundancy for Azure Cache for Redis",
-        "url": "https://learn.microsoft.com/azure/azure-cache-for-redis/cache-how-to-zone-redundancy"
+        "url": "https://learn.microsoft.com/azure/azure-cache-for-redis/cache-how-to-zone-redundancy",
+        "name": "Enable zone redundancy for Azure Cache for Redis"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4491,8 +4491,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Schedule Redis Updates",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-administration#update-channel-and-schedule-updates"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-administration#update-channel-and-schedule-updates",
+        "name": "Schedule Redis Updates"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4514,8 +4514,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure private endpoints for Azure Redis Cache",
-        "url": "https://learn.microsoft.com/azure/azure-cache-for-redis/cache-network-isolation"
+        "url": "https://learn.microsoft.com/azure/azure-cache-for-redis/cache-network-isolation",
+        "name": "Configure private endpoints for Azure Redis Cache"
       }
     ],
     "recommendationControl": "Security",
@@ -4537,8 +4537,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Learn More",
-        "url": "https://learn.microsoft.com/azure/reliability/reliability-batch#cross-region-disaster-recovery-and-business-continuity"
+        "url": "https://learn.microsoft.com/azure/reliability/reliability-batch#cross-region-disaster-recovery-and-business-continuity",
+        "name": "Learn More"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4560,8 +4560,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Learn More",
-        "url": "https://learn.microsoft.com/azure/batch/create-pool-availability-zones"
+        "url": "https://learn.microsoft.com/azure/batch/create-pool-availability-zones",
+        "name": "Learn More"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4583,16 +4583,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Resource Health",
-        "url": "https://learn.microsoft.com/en-us/azure/service-health/resource-health-overview"
+        "url": "https://learn.microsoft.com/en-us/azure/service-health/resource-health-overview",
+        "name": "Resource Health"
       },
       {
-        "name": "Configure Resource Health alerts in the Azure portal",
-        "url": "https://learn.microsoft.com/en-us/azure/service-health/resource-health-alert-monitor-guide#create-a-resource-health-alert-rule-in-the-azure-portal"
+        "url": "https://learn.microsoft.com/en-us/azure/service-health/resource-health-alert-monitor-guide#create-a-resource-health-alert-rule-in-the-azure-portal",
+        "name": "Configure Resource Health alerts in the Azure portal"
       },
       {
-        "name": "Alerts Health",
-        "url": "https://learn.microsoft.com/en-us/azure/service-health/alerts-activity-log-service-notifications-portal"
+        "url": "https://learn.microsoft.com/en-us/azure/service-health/alerts-activity-log-service-notifications-portal",
+        "name": "Alerts Health"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4614,12 +4614,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "What is Azure Service Health?",
-        "url": "https://learn.microsoft.com/azure/service-health/overview"
+        "url": "https://learn.microsoft.com/azure/service-health/overview",
+        "name": "What is Azure Service Health?"
       },
       {
-        "name": "Configure alerts for service health events",
-        "url": "https://learn.microsoft.com/azure/service-health/alerts-activity-log-service-notifications-portal"
+        "url": "https://learn.microsoft.com/azure/service-health/alerts-activity-log-service-notifications-portal",
+        "name": "Configure alerts for service health events"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4641,8 +4641,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Migrate an Application Insights classic resource to a workspace-based resource",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/app/convert-classic-resource"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/app/convert-classic-resource",
+        "name": "Migrate an Application Insights classic resource to a workspace-based resource"
       }
     ],
     "recommendationControl": "Service Upgrade and Retirement",
@@ -4664,8 +4664,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Databricks runtime support lifecycles",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/release-notes/runtime/databricks-runtime-ver"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/release-notes/runtime/databricks-runtime-ver",
+        "name": "Databricks runtime support lifecycles"
       }
     ],
     "recommendationControl": "Governance",
@@ -4687,8 +4687,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4710,8 +4710,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure managed disk types",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-types#premium-ssd"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-types#premium-ssd",
+        "name": "Azure managed disk types"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4733,8 +4733,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#enable-autoscaling-for-batch-workloadss"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#enable-autoscaling-for-batch-workloadss",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4756,8 +4756,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#enable-autoscaling-for-sql-warehouse"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#enable-autoscaling-for-sql-warehouse",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4779,12 +4779,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices"
+        "url": "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices",
+        "name": "Best practices for reliability"
       },
       {
-        "name": "Databricks enhanced autoscaling",
-        "url": "https://learn.microsoft.com/azure/databricks/delta-live-tables/settings#use-autoscaling-to-increase-efficiency-and-reduce-resource-usage"
+        "url": "https://learn.microsoft.com/azure/databricks/delta-live-tables/settings#use-autoscaling-to-increase-efficiency-and-reduce-resource-usage",
+        "name": "Databricks enhanced autoscaling"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4806,8 +4806,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4829,8 +4829,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Create a cluster",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/clusters/configure#cluster-log-delivery"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/clusters/configure#cluster-log-delivery",
+        "name": "Create a cluster"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -4852,8 +4852,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4875,8 +4875,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#use-apache-spark-or-photon-for-distributed-compute"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#use-apache-spark-or-photon-for-distributed-compute",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4898,8 +4898,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "Business Continuity",
@@ -4921,8 +4921,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4944,8 +4944,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "Scalability",
@@ -4967,8 +4967,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "High Availability",
@@ -4990,8 +4990,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "Business Continuity",
@@ -5013,8 +5013,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -5036,8 +5036,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#use-constraints-and-data-expectations"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#use-constraints-and-data-expectations",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "Business Continuity",
@@ -5059,8 +5059,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#create-regular-backups"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#create-regular-backups",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -5082,8 +5082,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#recover-from-structured-streaming-query-failures"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#recover-from-structured-streaming-query-failures",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5105,8 +5105,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#recover-etl-jobs-based-on-delta-time-travel"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#recover-etl-jobs-based-on-delta-time-travel",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -5128,8 +5128,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices",
+        "name": "Best practices for reliability"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -5151,8 +5151,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Databricks Best Practices",
-        "url": "https://github.com/Azure/AzureDatabricksBestPractices/tree/master"
+        "url": "https://github.com/Azure/AzureDatabricksBestPractices/tree/master",
+        "name": "Azure Databricks Best Practices"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -5174,8 +5174,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for operational excellence",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/operational-excellence/best-practices#2-automate-deployments-and-workloads"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/operational-excellence/best-practices#2-automate-deployments-and-workloads",
+        "name": "Best practices for operational excellence"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -5197,8 +5197,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Best practices for operational excellence",
-        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/operational-excellence/best-practices#system-monitoring"
+        "url": "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/operational-excellence/best-practices#system-monitoring",
+        "name": "Best practices for operational excellence"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -5220,8 +5220,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Databricks Best Practices",
-        "url": "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#deploy-workspaces-in-multiple-subscriptions-to-honor-azure-capacity-limits"
+        "url": "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#deploy-workspaces-in-multiple-subscriptions-to-honor-azure-capacity-limits",
+        "name": "Azure Databricks Best Practices"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5243,8 +5243,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Databricks Best Practices",
-        "url": "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#consider-isolating-each-workspace-in-its-own-vnet"
+        "url": "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#consider-isolating-each-workspace-in-its-own-vnet",
+        "name": "Azure Databricks Best Practices"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5266,8 +5266,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Databricks Best Practices",
-        "url": "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#do-not-store-any-production-data-in-default-dbfs-folders"
+        "url": "https://github.com/Azure/AzureDatabricksBestPractices/blob/master/toc.md#do-not-store-any-production-data-in-default-dbfs-folders",
+        "name": "Azure Databricks Best Practices"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5289,8 +5289,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Use Azure Spot Virtual Machines",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/spot-vms"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/spot-vms",
+        "name": "Use Azure Spot Virtual Machines"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5312,16 +5312,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Databricks control plane addresses",
-        "url": "https://learn.microsoft.com/azure/databricks/resources/supported-regions#--azure-databricks-control-plane-addresses"
+        "url": "https://learn.microsoft.com/azure/databricks/resources/supported-regions#--azure-databricks-control-plane-addresses",
+        "name": "Azure Databricks control plane addresses"
       },
       {
-        "name": "Migrate - maintained by Databricks Inc.",
-        "url": "https://github.com/databrickslabs/migrate"
+        "url": "https://github.com/databrickslabs/migrate",
+        "name": "Migrate - maintained by Databricks Inc."
       },
       {
-        "name": "Databricks Terraform Exporter - maintained by Databricks Inc. (Experimental)",
-        "url": "https://registry.terraform.io/providers/databricks/databricks/latest/docs/guides/experimental-exporter"
+        "url": "https://registry.terraform.io/providers/databricks/databricks/latest/docs/guides/experimental-exporter",
+        "name": "Databricks Terraform Exporter - maintained by Databricks Inc. (Experimental)"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5343,12 +5343,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Compute configuration best practices",
-        "url": "https://learn.microsoft.com/azure/databricks/compute/cluster-config-best-practices"
+        "url": "https://learn.microsoft.com/azure/databricks/compute/cluster-config-best-practices",
+        "name": "Compute configuration best practices"
       },
       {
-        "name": "GPU-enabled compute",
-        "url": "https://learn.microsoft.com/azure/databricks/compute/gpu"
+        "url": "https://learn.microsoft.com/azure/databricks/compute/gpu",
+        "name": "GPU-enabled compute"
       }
     ],
     "recommendationControl": "Personalized",
@@ -5370,12 +5370,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "When to use VMSS instead of VMs",
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-design-overview#when-to-use-scale-sets-instead-of-virtual-machines"
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-design-overview#when-to-use-scale-sets-instead-of-virtual-machines",
+        "name": "When to use VMSS instead of VMs"
       },
       {
-        "name": "Azure Well-Architected Framework review - Virtual Machines and Scale Sets",
-        "url": "https://learn.microsoft.com/azure/well-architected/services/compute/virtual-machines/virtual-machines-review"
+        "url": "https://learn.microsoft.com/azure/well-architected/services/compute/virtual-machines/virtual-machines-review",
+        "name": "Azure Well-Architected Framework review - Virtual Machines and Scale Sets"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5397,8 +5397,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Using Application Health extension with Virtual Machine Scale Sets",
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-health-extension?tabs=rest-api"
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-health-extension?tabs=rest-api",
+        "name": "Using Application Health extension with Virtual Machine Scale Sets"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -5420,8 +5420,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Automatic instance repairs for Azure Virtual Machine Scale Sets",
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-instance-repairs#requirements-for-using-automatic-instance-repairs"
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-instance-repairs#requirements-for-using-automatic-instance-repairs",
+        "name": "Automatic instance repairs for Azure Virtual Machine Scale Sets"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5443,12 +5443,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Get started with autoscale in Azure",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-get-started?WT.mc_id=Portal-Microsoft_Azure_Monitoring"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-get-started?WT.mc_id=Portal-Microsoft_Azure_Monitoring",
+        "name": "Get started with autoscale in Azure"
       },
       {
-        "name": "Overview of autoscale in Azure",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-overview"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-overview",
+        "name": "Overview of autoscale in Azure"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5470,8 +5470,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Use predictive autoscale to scale out before load demands in virtual machine scale sets",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-predictive"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-predictive",
+        "name": "Use predictive autoscale to scale out before load demands in virtual machine scale sets"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5493,8 +5493,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Use scale-in policies with Azure Virtual Machine Scale Sets",
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-scale-in-policy"
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-scale-in-policy",
+        "name": "Use scale-in policies with Azure Virtual Machine Scale Sets"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5516,12 +5516,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Create a Virtual Machine Scale Set that uses Availability Zones",
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones"
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones",
+        "name": "Create a Virtual Machine Scale Set that uses Availability Zones"
       },
       {
-        "name": "Update scale set to add availability zones",
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones?tabs=cli-1%2Cportal-2#update-scale-set-to-add-availability-zones"
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones?tabs=cli-1%2Cportal-2#update-scale-set-to-add-availability-zones",
+        "name": "Update scale set to add availability zones"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5543,12 +5543,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Automatic VM Guest Patching for Azure VMs",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/automatic-vm-guest-patching"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/automatic-vm-guest-patching",
+        "name": "Automatic VM Guest Patching for Azure VMs"
       },
       {
-        "name": "Auto OS Image Upgrades",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-upgrade"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-upgrade",
+        "name": "Auto OS Image Upgrades"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -5570,8 +5570,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Deprecated Azure Marketplace images",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/deprecated-images"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/deprecated-images",
+        "name": "Deprecated Azure Marketplace images"
       }
     ],
     "recommendationControl": "Governance",
@@ -5593,12 +5593,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "What has changed with Flexible orchestration mode",
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-orchestration-modes#what-has-changed-with-flexible-orchestration-mode"
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-orchestration-modes#what-has-changed-with-flexible-orchestration-mode",
+        "name": "What has changed with Flexible orchestration mode"
       },
       {
-        "name": "Attach or detach a Virtual Machine to or from a Virtual Machine Scale Set",
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-attach-detach-vm?branch=main&tabs=portal-1%2Cportal-2%2Cportal-3"
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-attach-detach-vm?branch=main&tabs=portal-1%2Cportal-2%2Cportal-3",
+        "name": "Attach or detach a Virtual Machine to or from a Virtual Machine Scale Set"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5620,8 +5620,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Create virtual machines in an availability zone using the Azure portal",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/create-portal-availability-zone?tabs=standard"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/create-portal-availability-zone?tabs=standard",
+        "name": "Create virtual machines in an availability zone using the Azure portal"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5643,8 +5643,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Migrate deployments and resources to Virtual Machine Scale Sets in Flexible orchestration",
-        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/flexible-virtual-machine-scale-sets-migration-resources"
+        "url": "https://learn.microsoft.com/azure/virtual-machine-scale-sets/flexible-virtual-machine-scale-sets-migration-resources",
+        "name": "Migrate deployments and resources to Virtual Machine Scale Sets in Flexible orchestration"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5666,12 +5666,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Resiliency checklist for Virtual Machines",
-        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#virtual-machines"
+        "url": "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#virtual-machines",
+        "name": "Resiliency checklist for Virtual Machines"
       },
       {
-        "name": "Run a test failover (disaster recovery drill) to Azure",
-        "url": "https://learn.microsoft.com/azure/site-recovery/site-recovery-test-failover-to-azure"
+        "url": "https://learn.microsoft.com/azure/site-recovery/site-recovery-test-failover-to-azure",
+        "name": "Run a test failover (disaster recovery drill) to Azure"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -5693,16 +5693,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Migrate your Azure unmanaged disks by Sep 30, 2025",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation",
+        "name": "Migrate your Azure unmanaged disks by Sep 30, 2025"
       },
       {
-        "name": "Migrate Windows VM from unmanaged disks to managed disks",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/windows/convert-unmanaged-to-managed-disks"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/windows/convert-unmanaged-to-managed-disks",
+        "name": "Migrate Windows VM from unmanaged disks to managed disks"
       },
       {
-        "name": "Migrate Linux VM from unmanaged disks to managed disks",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/linux/convert-unmanaged-to-managed-disks"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/linux/convert-unmanaged-to-managed-disks",
+        "name": "Migrate Linux VM from unmanaged disks to managed disks"
       }
     ],
     "recommendationControl": "High Availability",
@@ -5724,12 +5724,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Introduction to Azure managed disks - Data disks",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/managed-disks-overview#data-disk"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/managed-disks-overview#data-disk",
+        "name": "Introduction to Azure managed disks - Data disks"
       },
       {
-        "name": "Azure managed disk types",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-types"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-types",
+        "name": "Azure managed disk types"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5751,8 +5751,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "What is the Azure Backup service?",
-        "url": "https://learn.microsoft.com/azure/backup/backup-overview"
+        "url": "https://learn.microsoft.com/azure/backup/backup-overview",
+        "name": "What is the Azure Backup service?"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -5774,8 +5774,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "States and billing status of Azure Virtual Machines",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/states-billing?context=%2Ftroubleshoot%2Fazure%2Fvirtual-machines%2Fcontext%2Fcontext#power-states-and-billing"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/states-billing?context=%2Ftroubleshoot%2Fazure%2Fvirtual-machines%2Fcontext%2Fcontext#power-states-and-billing",
+        "name": "States and billing status of Azure Virtual Machines"
       }
     ],
     "recommendationControl": "Governance",
@@ -5797,8 +5797,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Accelerated Networking (AccelNet) overview",
-        "url": "https://learn.microsoft.com/azure/virtual-network/accelerated-networking-overview"
+        "url": "https://learn.microsoft.com/azure/virtual-network/accelerated-networking-overview",
+        "name": "Accelerated Networking (AccelNet) overview"
       }
     ],
     "recommendationControl": "Scalability",
@@ -5820,8 +5820,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Accelerated Networking (AccelNet) overview",
-        "url": "https://learn.microsoft.com/azure/virtual-network/accelerated-networking-overview"
+        "url": "https://learn.microsoft.com/azure/virtual-network/accelerated-networking-overview",
+        "name": "Accelerated Networking (AccelNet) overview"
       }
     ],
     "recommendationControl": "Governance",
@@ -5843,8 +5843,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Use Source Network Address Translation (SNAT) for outbound connections",
-        "url": "https://learn.microsoft.com/azure/load-balancer/load-balancer-outbound-connections"
+        "url": "https://learn.microsoft.com/azure/load-balancer/load-balancer-outbound-connections",
+        "name": "Use Source Network Address Translation (SNAT) for outbound connections"
       }
     ],
     "recommendationControl": "Security",
@@ -5866,8 +5866,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "How network security groups filter network traffic",
-        "url": "https://learn.microsoft.com/azure/virtual-network/network-security-group-how-it-works#intra-subnet-traffic"
+        "url": "https://learn.microsoft.com/azure/virtual-network/network-security-group-how-it-works#intra-subnet-traffic",
+        "name": "How network security groups filter network traffic"
       }
     ],
     "recommendationControl": "Security",
@@ -5889,8 +5889,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Enable or disable IP forwarding",
-        "url": "https://learn.microsoft.com/azure/virtual-network/virtual-network-network-interface?tabs=network-interface-portal#enable-or-disable-ip-forwarding"
+        "url": "https://learn.microsoft.com/azure/virtual-network/virtual-network-network-interface?tabs=network-interface-portal#enable-or-disable-ip-forwarding",
+        "name": "Enable or disable IP forwarding"
       }
     ],
     "recommendationControl": "Security",
@@ -5912,8 +5912,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Name resolution for resources in Azure virtual networks",
-        "url": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances"
+        "url": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances",
+        "name": "Name resolution for resources in Azure virtual networks"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -5935,12 +5935,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Shared Disk Introduction",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-shared"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-shared",
+        "name": "Azure Shared Disk Introduction"
       },
       {
-        "name": "Enable Shared Disks",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-shared-enable?tabs=azure-portal"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-shared-enable?tabs=azure-portal",
+        "name": "Enable Shared Disks"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -5962,8 +5962,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Restrict import/export access for managed disks using Azure Private Link",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-enable-private-links-for-import-export-portal"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disks-enable-private-links-for-import-export-portal",
+        "name": "Restrict import/export access for managed disks using Azure Private Link"
       }
     ],
     "recommendationControl": "Security",
@@ -5985,12 +5985,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Policy-driven governance",
-        "url": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-principles#policy-driven-governance"
+        "url": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-principles#policy-driven-governance",
+        "name": "Policy-driven governance"
       },
       {
-        "name": "Azure Policy Regulatory Compliance controls for Azure Virtual Machines",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/security-policy"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/security-policy",
+        "name": "Azure Policy Regulatory Compliance controls for Azure Virtual Machines"
       }
     ],
     "recommendationControl": "Governance",
@@ -6012,8 +6012,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Overview of managed disk encryption options",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/disk-encryption-overview"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/disk-encryption-overview",
+        "name": "Overview of managed disk encryption options"
       }
     ],
     "recommendationControl": "Security",
@@ -6035,12 +6035,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Overview of VM insights",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/vm/vminsights-overview"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/vm/vminsights-overview",
+        "name": "Overview of VM insights"
       },
       {
-        "name": "Did the extension install properly?",
-        "url": "https://learn.microsoft.com/azure/azure-monitor/vm/vminsights-troubleshoot#did-the-extension-install-properly"
+        "url": "https://learn.microsoft.com/azure/azure-monitor/vm/vminsights-troubleshoot#did-the-extension-install-properly",
+        "name": "Did the extension install properly?"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6062,8 +6062,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Monitor Agent overview",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/agents/agents-overview"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/agents/agents-overview",
+        "name": "Azure Monitor Agent overview"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6085,8 +6085,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Use maintenance configurations to control and manage the VM updates",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/maintenance-configurations"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/maintenance-configurations",
+        "name": "Use maintenance configurations to control and manage the VM updates"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6108,8 +6108,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "B-series burstable virtual machine sizes",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/sizes-b-series-burstable"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/sizes-b-series-burstable",
+        "name": "B-series burstable virtual machine sizes"
       }
     ],
     "recommendationControl": "Scalability",
@@ -6131,8 +6131,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Disk type comparison and decision tree",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison",
+        "name": "Disk type comparison and decision tree"
       }
     ],
     "recommendationControl": "Scalability",
@@ -6154,12 +6154,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Microsoft Azure Boost",
-        "url": "https://learn.microsoft.com/azure/azure-boost/overview"
+        "url": "https://learn.microsoft.com/azure/azure-boost/overview",
+        "name": "Microsoft Azure Boost"
       },
       {
-        "name": "Announcing the general availability of Azure Boost",
-        "url": "https://aka.ms/AzureBoostGABlog"
+        "url": "https://aka.ms/AzureBoostGABlog",
+        "name": "Announcing the general availability of Azure Boost"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6181,16 +6181,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Monitor scheduled events for your Azure VMs",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/windows/scheduled-event-service"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/windows/scheduled-event-service",
+        "name": "Monitor scheduled events for your Azure VMs"
       },
       {
-        "name": "Azure Metadata Service Scheduled Events for Linux VMs",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/linux/scheduled-events"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/linux/scheduled-events",
+        "name": "Azure Metadata Service Scheduled Events for Linux VMs"
       },
       {
-        "name": "Azure Metadata Service Scheduled Events for Windows VMs",
-        "url": "https://learn.microsoft.com/azure/virtual-machines/windows/scheduled-events"
+        "url": "https://learn.microsoft.com/azure/virtual-machines/windows/scheduled-events",
+        "name": "Azure Metadata Service Scheduled Events for Windows VMs"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6212,8 +6212,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Redundancy options for managed disks",
-        "url": "https://aka.ms/zrsdisksdoc"
+        "url": "https://aka.ms/zrsdisksdoc",
+        "name": "Redundancy options for managed disks"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6235,8 +6235,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "On-demand Capacity Reservation",
-        "url": "https://aka.ms/on-demand-capacity-reservations-docs"
+        "url": "https://aka.ms/on-demand-capacity-reservations-docs",
+        "name": "On-demand Capacity Reservation"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6258,8 +6258,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "How to update the Azure Linux Agent on a VM",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/update-linux-agent?tabs=ubuntu"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/update-linux-agent?tabs=ubuntu",
+        "name": "How to update the Azure Linux Agent on a VM"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6281,8 +6281,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Compute Gallery best practices",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices",
+        "name": "Compute Gallery best practices"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6304,12 +6304,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Compute Gallery best practices",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices",
+        "name": "Compute Gallery best practices"
       },
       {
-        "name": "Zone-redundant storage",
-        "url": "https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy#zone-redundant-storage"
+        "url": "https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy#zone-redundant-storage",
+        "name": "Zone-redundant storage"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6331,16 +6331,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Compute Gallery best practices",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices",
+        "name": "Compute Gallery best practices"
       },
       {
-        "name": "Generation 1 vs Generation 2 in Hyper-V",
-        "url": "https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/plan/should-i-create-a-generation-1-or-2-virtual-machine-in-hyper-v"
+        "url": "https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/plan/should-i-create-a-generation-1-or-2-virtual-machine-in-hyper-v",
+        "name": "Generation 1 vs Generation 2 in Hyper-V"
       },
       {
-        "name": "Images in Compute gallery",
-        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries?tabs=azure-cli"
+        "url": "https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries?tabs=azure-cli",
+        "name": "Images in Compute gallery"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6362,8 +6362,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure Azure Service Health alerts",
-        "url": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring#design-recommendations"
+        "url": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring#design-recommendations",
+        "name": "Configure Azure Service Health alerts"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6385,8 +6385,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure and streamline alerts",
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts",
+        "name": "Configure and streamline alerts"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6408,8 +6408,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure and streamline alerts",
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts",
+        "name": "Configure and streamline alerts"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6431,12 +6431,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Implement high availability",
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/infrastructure#implement-high-availability"
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/infrastructure#implement-high-availability",
+        "name": "Implement high availability"
       },
       {
-        "name": "Stretched Clusters",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/deploy-vsan-stretched-clusters"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/deploy-vsan-stretched-clusters",
+        "name": "Stretched Clusters"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6458,8 +6458,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Supported metrics and activities",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-alerts-for-azure-vmware-solution#supported-metrics-and-activities"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-alerts-for-azure-vmware-solution#supported-metrics-and-activities",
+        "name": "Supported metrics and activities"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6481,8 +6481,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Manage logs and archives",
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#manage-logs-and-archives"
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#manage-logs-and-archives",
+        "name": "Manage logs and archives"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6504,8 +6504,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure and streamline alerts",
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts",
+        "name": "Configure and streamline alerts"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6516,7 +6516,7 @@
     "publishedToLearn": false,
     "tags": null,
     "recommendationResourceType": "Microsoft.AVS/privateClouds",
-    "recommendationImpact": "Medium",
+    "recommendationImpact": "High",
     "automationAvailable": true,
     "query": "// Azure Resource Graph Query\n// Provides a list of Azure VMware Solution resources that don't have a Cluster CPU capacity critical alert with a threshold of 95%.\nresources\n| where ['type'] == \"microsoft.avs/privateclouds\"\n| extend scopeId = tolower(tostring(id))\n| project ['scopeId'], name, id, tags\n| join kind=leftouter (\nresources\n| where type == \"microsoft.insights/metricalerts\"\n| extend alertProperties = todynamic(properties)\n| mv-expand alertProperties.scopes\n| mv-expand alertProperties.criteria.allOf\n| extend scopeId = tolower(tostring(alertProperties_scopes))\n| extend metric = alertProperties_criteria_allOf.metricName\n| extend threshold = alertProperties_criteria_allOf.threshold\n| project scopeId, tostring(metric), toint(['threshold'])\n| where metric == \"EffectiveCpuAverage\"\n| where threshold == 95\n) on scopeId\n| where isnull(['threshold'])\n| project recommendationId = \"4ee5d535-c47b-470a-9557-4a3dd297d62f\", name, id, tags, param1 = \"hostCpuCriticalAlert: isNull or threshold != 95\"\n\n"
   },
@@ -6527,8 +6527,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure and streamline alerts",
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts",
+        "name": "Configure and streamline alerts"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6539,7 +6539,7 @@
     "publishedToLearn": false,
     "tags": null,
     "recommendationResourceType": "Microsoft.AVS/privateClouds",
-    "recommendationImpact": "Medium",
+    "recommendationImpact": "High",
     "automationAvailable": true,
     "query": "// Azure Resource Graph Query\n// Provides a list of Azure VMware Solution resources that don't have a cluster host memory critical alert with a threshold of 95%.\nresources\n| where ['type'] == \"microsoft.avs/privateclouds\"\n| extend scopeId = tolower(tostring(id))\n| project ['scopeId'], name, id, tags\n| join kind=leftouter (\nresources\n| where type == \"microsoft.insights/metricalerts\"\n| extend alertProperties = todynamic(properties)\n| mv-expand alertProperties.scopes\n| mv-expand alertProperties.criteria.allOf\n| extend scopeId = tolower(tostring(alertProperties_scopes))\n| extend metric = alertProperties_criteria_allOf.metricName\n| extend threshold = alertProperties_criteria_allOf.threshold\n| project scopeId, tostring(metric), toint(['threshold'])\n| where metric == \"UsageAverage\"\n| where threshold == 95\n) on scopeId\n| where isnull(['threshold'])\n| project recommendationId = \"029208c8-5186-4a76-8ee8-6e3445fef4dd\", name, id, tags, param1 = \"hostMemoryCriticalAlert: isNull or threshold != 95\"\n\n"
   },
@@ -6550,8 +6550,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Lock your resources to protect your infrastructure",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources",
+        "name": "Lock your resources to protect your infrastructure"
       }
     ],
     "recommendationControl": "Governance",
@@ -6573,8 +6573,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure Customer Managed Keys",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-customer-managed-keys?tabs=azure-portal"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-customer-managed-keys?tabs=azure-portal",
+        "name": "Configure Customer Managed Keys"
       }
     ],
     "recommendationControl": "Security",
@@ -6596,8 +6596,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure DNS forwarder",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-dns-azure-vmware-solution#configure-dns-forwarder"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-dns-azure-vmware-solution#configure-dns-forwarder",
+        "name": "Configure DNS forwarder"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6619,8 +6619,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Overview of Azure Stream Analytics Cluster",
-        "url": "https://learn.microsoft.com/azure/stream-analytics/cluster-overview"
+        "url": "https://learn.microsoft.com/azure/stream-analytics/cluster-overview",
+        "name": "Overview of Azure Stream Analytics Cluster"
       }
     ],
     "recommendationControl": "Scalability",
@@ -6642,8 +6642,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Understand and adjust streaming units",
-        "url": "https://learn.microsoft.com/azure/stream-analytics/stream-analytics-streaming-unit-consumption"
+        "url": "https://learn.microsoft.com/azure/stream-analytics/stream-analytics-streaming-unit-consumption",
+        "name": "Understand and adjust streaming units"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6665,8 +6665,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Event Hubs - Geo-disaster recovery",
-        "url": "https://learn.microsoft.com/azure/event-hubs/event-hubs-geo-dr?tabs=portal#availability-zones"
+        "url": "https://learn.microsoft.com/azure/event-hubs/event-hubs-geo-dr?tabs=portal#availability-zones",
+        "name": "Azure Event Hubs - Geo-disaster recovery"
       }
     ],
     "recommendationControl": "High Availability",
@@ -6688,8 +6688,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Event Hubs - Automatically scale throughput units",
-        "url": "https://learn.microsoft.com/azure/event-hubs/event-hubs-auto-inflate"
+        "url": "https://learn.microsoft.com/azure/event-hubs/event-hubs-auto-inflate",
+        "name": "Azure Event Hubs - Automatically scale throughput units"
       }
     ],
     "recommendationControl": "Scalability",
@@ -6711,8 +6711,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Create and assign an autoscale scaling plan",
-        "url": "https://learn.microsoft.com/azure/virtual-desktop/autoscale-scaling-plan?tabs=portal"
+        "url": "https://learn.microsoft.com/azure/virtual-desktop/autoscale-scaling-plan?tabs=portal",
+        "name": "Create and assign an autoscale scaling plan"
       }
     ],
     "recommendationControl": "Scalability",
@@ -6734,8 +6734,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure a host pool as a validation environment",
-        "url": "https://learn.microsoft.com/azure/virtual-desktop/configure-validation-environment?tabs=azure-portal"
+        "url": "https://learn.microsoft.com/azure/virtual-desktop/configure-validation-environment?tabs=azure-portal",
+        "name": "Configure a host pool as a validation environment"
       }
     ],
     "recommendationControl": "Governance",
@@ -6757,8 +6757,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Scheduled Agent Updates for Azure Virtual Desktop host pools",
-        "url": "https://learn.microsoft.com/azure/virtual-desktop/scheduled-agent-updates"
+        "url": "https://learn.microsoft.com/azure/virtual-desktop/scheduled-agent-updates",
+        "name": "Scheduled Agent Updates for Azure Virtual Desktop host pools"
       }
     ],
     "recommendationControl": "Governance",
@@ -6780,8 +6780,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure the VMs and install Active Directory Domain Services",
-        "url": "https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/deploy/virtual-dc/adds-on-azure-vm#configure-the-vms-and-install-active-directory-domain-services"
+        "url": "https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/deploy/virtual-dc/adds-on-azure-vm#configure-the-vms-and-install-active-directory-domain-services",
+        "name": "Configure the VMs and install Active Directory Domain Services"
       }
     ],
     "recommendationControl": "Governance",
@@ -6803,8 +6803,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "About Site Recovery",
-        "url": "https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-overview"
+        "url": "https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-overview",
+        "name": "About Site Recovery"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -6826,20 +6826,20 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Load Balancing Options",
-        "url": "https://learn.microsoft.com/azure/architecture/guide/technology-choices/load-balancing-overview"
+        "url": "https://learn.microsoft.com/azure/architecture/guide/technology-choices/load-balancing-overview",
+        "name": "Azure Load Balancing Options"
       },
       {
-        "name": "Azure Traffic Manager",
-        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-overview"
+        "url": "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-overview",
+        "name": "Azure Traffic Manager"
       },
       {
-        "name": "Azure Front Door",
-        "url": "https://learn.microsoft.com/azure/frontdoor/front-door-overview"
+        "url": "https://learn.microsoft.com/azure/frontdoor/front-door-overview",
+        "name": "Azure Front Door"
       },
       {
-        "name": "Mission-critical global content delivery",
-        "url": "https://learn.microsoft.com/en-us/azure/architecture/guide/networking/global-web-applications/mission-critical-content-delivery"
+        "url": "https://learn.microsoft.com/en-us/azure/architecture/guide/networking/global-web-applications/mission-critical-content-delivery",
+        "name": "Mission-critical global content delivery"
       }
     ],
     "recommendationControl": "Business Continuity",
@@ -6861,8 +6861,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Secure traffic to Azure Front Door origins",
-        "url": "https://learn.microsoft.com/azure/frontdoor/origin-security?tabs=app-service-functions&pivots=front-door-standard-premium"
+        "url": "https://learn.microsoft.com/azure/frontdoor/origin-security?tabs=app-service-functions&pivots=front-door-standard-premium",
+        "name": "Secure traffic to Azure Front Door origins"
       }
     ],
     "recommendationControl": "Security",
@@ -6884,16 +6884,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "REST API Reference",
-        "url": "https://learn.microsoft.com/rest/api/frontdoor/"
+        "url": "https://learn.microsoft.com/rest/api/frontdoor/",
+        "name": "REST API Reference"
       },
       {
-        "name": "Client library for Java",
-        "url": "https://learn.microsoft.com/java/api/overview/azure/resourcemanager-frontdoor-readme?view=azure-java-preview"
+        "url": "https://learn.microsoft.com/java/api/overview/azure/resourcemanager-frontdoor-readme?view=azure-java-preview",
+        "name": "Client library for Java"
       },
       {
-        "name": "SDK for Python",
-        "url": "https://learn.microsoft.com/python/api/overview/azure/front-door?view=azure-python"
+        "url": "https://learn.microsoft.com/python/api/overview/azure/front-door?view=azure-python",
+        "name": "SDK for Python"
       }
     ],
     "recommendationControl": "Scalability",
@@ -6915,16 +6915,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Monitor metrics and logs in Azure Front Door",
-        "url": "https://learn.microsoft.com/azure/frontdoor/front-door-diagnostics?pivots=front-door-standard-premium"
+        "url": "https://learn.microsoft.com/azure/frontdoor/front-door-diagnostics?pivots=front-door-standard-premium",
+        "name": "Monitor metrics and logs in Azure Front Door"
       },
       {
-        "name": "WAF logs",
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-monitor?pivots=front-door-standard-premium#waf-logs"
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-monitor?pivots=front-door-standard-premium#waf-logs",
+        "name": "WAF logs"
       },
       {
-        "name": "Configure Azure Front Door logs",
-        "url": "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-logs"
+        "url": "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-logs",
+        "name": "Configure Azure Front Door logs"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -6946,8 +6946,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "End-to-end TLS with Azure Front Door",
-        "url": "https://learn.microsoft.com/azure/frontdoor/end-to-end-tls?pivots=front-door-standard-premium"
+        "url": "https://learn.microsoft.com/azure/frontdoor/end-to-end-tls?pivots=front-door-standard-premium",
+        "name": "End-to-end TLS with Azure Front Door"
       }
     ],
     "recommendationControl": "Security",
@@ -6969,8 +6969,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Create HTTP to HTTPS redirect rule",
-        "url": "https://learn.microsoft.com/azure/frontdoor/front-door-how-to-redirect-https#create-http-to-https-redirect-rule"
+        "url": "https://learn.microsoft.com/azure/frontdoor/front-door-how-to-redirect-https#create-http-to-https-redirect-rule",
+        "name": "Create HTTP to HTTPS redirect rule"
       }
     ],
     "recommendationControl": "Security",
@@ -6992,8 +6992,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure HTTPS on an Azure Front Door custom domain using the Azure portal",
-        "url": "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-configure-https-custom-domain?tabs=powershell"
+        "url": "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-configure-https-custom-domain?tabs=powershell",
+        "name": "Configure HTTPS on an Azure Front Door custom domain using the Azure portal"
       }
     ],
     "recommendationControl": "Security",
@@ -7015,8 +7015,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Select the certificate for Azure Front Door to deploy",
-        "url": "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-configure-https-custom-domain?tabs=powershell#select-the-certificate-for-azure-front-door-to-deploy"
+        "url": "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-configure-https-custom-domain?tabs=powershell#select-the-certificate-for-azure-front-door-to-deploy",
+        "name": "Select the certificate for Azure Front Door to deploy"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7038,8 +7038,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Preserve the original HTTP host name between a reverse proxy and its back-end web application",
-        "url": "https://learn.microsoft.com/azure/architecture/best-practices/host-name-preservation"
+        "url": "https://learn.microsoft.com/azure/architecture/best-practices/host-name-preservation",
+        "name": "Preserve the original HTTP host name between a reverse proxy and its back-end web application"
       }
     ],
     "recommendationControl": "Governance",
@@ -7061,8 +7061,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Web Application Firewall on Azure Front Door",
-        "url": "https://learn.microsoft.com/azure/frontdoor/web-application-firewall"
+        "url": "https://learn.microsoft.com/azure/frontdoor/web-application-firewall",
+        "name": "Web Application Firewall on Azure Front Door"
       }
     ],
     "recommendationControl": "Security",
@@ -7084,8 +7084,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Health probes",
-        "url": "https://learn.microsoft.com/azure/frontdoor/health-probes"
+        "url": "https://learn.microsoft.com/azure/frontdoor/health-probes",
+        "name": "Health probes"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7107,8 +7107,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Health Endpoint Monitoring pattern",
-        "url": "https://learn.microsoft.com/azure/architecture/patterns/health-endpoint-monitoring"
+        "url": "https://learn.microsoft.com/azure/architecture/patterns/health-endpoint-monitoring",
+        "name": "Health Endpoint Monitoring pattern"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7130,8 +7130,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Supported HTTP methods for health probes",
-        "url": "https://learn.microsoft.com/azure/frontdoor/health-probes#supported-http-methods-for-health-probes"
+        "url": "https://learn.microsoft.com/azure/frontdoor/health-probes#supported-http-methods-for-health-probes",
+        "name": "Supported HTTP methods for health probes"
       }
     ],
     "recommendationControl": "Scalability",
@@ -7153,8 +7153,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Geo filter WAF policy - GeoMatch",
-        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-geo-filtering"
+        "url": "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-geo-filtering",
+        "name": "Geo filter WAF policy - GeoMatch"
       }
     ],
     "recommendationControl": "Security",
@@ -7176,8 +7176,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Private link for Azure Front Door",
-        "url": "https://learn.microsoft.com/azure/frontdoor/private-link"
+        "url": "https://learn.microsoft.com/azure/frontdoor/private-link",
+        "name": "Private link for Azure Front Door"
       }
     ],
     "recommendationControl": "Security",
@@ -7199,8 +7199,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Compare pricing between Azure Front Door tiers",
-        "url": "https://learn.microsoft.com/en-us/azure/frontdoor/understanding-pricing"
+        "url": "https://learn.microsoft.com/en-us/azure/frontdoor/understanding-pricing",
+        "name": "Compare pricing between Azure Front Door tiers"
       }
     ],
     "recommendationControl": "Service Upgrade and Retirement",
@@ -7222,16 +7222,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Service Bus and reliability",
-        "url": "https://learn.microsoft.com/en-us/azure/well-architected/services/messaging/service-bus/reliability"
+        "url": "https://learn.microsoft.com/en-us/azure/well-architected/services/messaging/service-bus/reliability",
+        "name": "Service Bus and reliability"
       },
       {
-        "name": "Azure Service Bus Geo-disaster recovery",
-        "url": "https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-geo-dr#availability-zones"
+        "url": "https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-geo-dr#availability-zones",
+        "name": "Azure Service Bus Geo-disaster recovery"
       },
       {
-        "name": "Insulate Azure Service Bus applications against outages and disasters",
-        "url": "https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-outages-disasters"
+        "url": "https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-outages-disasters",
+        "name": "Insulate Azure Service Bus applications against outages and disasters"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7253,8 +7253,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Service Bus auto-scaling",
-        "url": "https://learn.microsoft.com/azure/service-bus-messaging/automate-update-messaging-units"
+        "url": "https://learn.microsoft.com/azure/service-bus-messaging/automate-update-messaging-units",
+        "name": "Service Bus auto-scaling"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7276,8 +7276,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Health probes for Azure Container Apps",
-        "url": "https://learn.microsoft.com/azure/container-apps/health-probes?tabs=arm-template"
+        "url": "https://learn.microsoft.com/azure/container-apps/health-probes?tabs=arm-template",
+        "name": "Health probes for Azure Container Apps"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7299,8 +7299,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Reliability in Azure Container Apps",
-        "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-azure-container-apps"
+        "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-azure-container-apps",
+        "name": "Reliability in Azure Container Apps"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7322,8 +7322,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "High availability through zone-redundancy",
-        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/high-availability-sla-local-zone-redundancy?view=azuresql-mi#zone-redundant-availability"
+        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/high-availability-sla-local-zone-redundancy?view=azuresql-mi#zone-redundant-availability",
+        "name": "High availability through zone-redundancy"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7345,8 +7345,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Backup storage redundancy",
-        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/automated-backups-overview?view=azuresql-mi&preserve-view=true#backup-storage-redundancy"
+        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/automated-backups-overview?view=azuresql-mi&preserve-view=true#backup-storage-redundancy",
+        "name": "Backup storage redundancy"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7368,8 +7368,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Connection types",
-        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/connection-types-overview?view=azuresql#connection-types"
+        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/connection-types-overview?view=azuresql#connection-types",
+        "name": "Connection types"
       }
     ],
     "recommendationControl": "Scalability",
@@ -7391,8 +7391,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Failover groups overview and best practices",
-        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/failover-group-sql-mi?view=azuresql"
+        "url": "https://learn.microsoft.com/azure/azure-sql/managed-instance/failover-group-sql-mi?view=azuresql",
+        "name": "Failover groups overview and best practices"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7414,8 +7414,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure SQL Managed Instance monitoring options",
-        "url": "https://techcommunity.microsoft.com/t5/azure-sql/monitoring-options-available-for-azure-sql-managed-instance/ba-p/1065416"
+        "url": "https://techcommunity.microsoft.com/t5/azure-sql/monitoring-options-available-for-azure-sql-managed-instance/ba-p/1065416",
+        "name": "Azure SQL Managed Instance monitoring options"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -7437,8 +7437,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Overview of Always Encrypted",
-        "url": "https://learn.microsoft.com/azure/azure-sql/database/always-encrypted-landing?view=azuresql"
+        "url": "https://learn.microsoft.com/azure/azure-sql/database/always-encrypted-landing?view=azuresql",
+        "name": "Overview of Always Encrypted"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7460,8 +7460,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Active Geo Replication",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/active-geo-replication-overview"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/active-geo-replication-overview",
+        "name": "Active Geo Replication"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7483,12 +7483,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "AutoFailover Groups",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/auto-failover-group-overview?tabs=azure-powershell"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/auto-failover-group-overview?tabs=azure-powershell",
+        "name": "AutoFailover Groups"
       },
       {
-        "name": "DR Design",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/designing-cloud-solutions-for-disaster-recovery"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/designing-cloud-solutions-for-disaster-recovery",
+        "name": "DR Design"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7510,8 +7510,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Zone Redundant Databases",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/high-availability-sla"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/high-availability-sla",
+        "name": "Zone Redundant Databases"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7533,8 +7533,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "How to Implement Retry Logic",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/troubleshoot-common-connectivity-issues"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/troubleshoot-common-connectivity-issues",
+        "name": "How to Implement Retry Logic"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7556,16 +7556,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Monitor",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/insights/azure-sql#analyze-data-and-create-alerts"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-monitor/insights/azure-sql#analyze-data-and-create-alerts",
+        "name": "Azure Monitor"
       },
       {
-        "name": "Azure SQL Database Monitoring",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/monitoring-sql-database-azure-monitor"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/monitoring-sql-database-azure-monitor",
+        "name": "Azure SQL Database Monitoring"
       },
       {
-        "name": "Monitoring SQL Database Reference",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/monitoring-sql-database-azure-monitor-reference"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/monitoring-sql-database-azure-monitor-reference",
+        "name": "Monitoring SQL Database Reference"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -7587,12 +7587,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Key Vault",
-        "url": "https://learn.microsoft.com/en-us/azure/key-vault/general/overview"
+        "url": "https://learn.microsoft.com/en-us/azure/key-vault/general/overview",
+        "name": "Azure Key Vault"
       },
       {
-        "name": "Getting Started with Always Encrypted",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/always-encrypted-landing?view=azuresql"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-sql/database/always-encrypted-landing?view=azuresql",
+        "name": "Getting Started with Always Encrypted"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7614,8 +7614,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Failover Group endpoint redirection",
-        "url": "https://learn.microsoft.com/azure/azure-sql/database/failover-group-sql-db?view=azuresql#endpoint-redirection"
+        "url": "https://learn.microsoft.com/azure/azure-sql/database/failover-group-sql-db?view=azuresql#endpoint-redirection",
+        "name": "Failover Group endpoint redirection"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7637,12 +7637,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Distribute data globally with Azure Cosmos DB",
-        "url": "https://learn.microsoft.com/azure/cosmos-db/distribute-data-globally"
+        "url": "https://learn.microsoft.com/azure/cosmos-db/distribute-data-globally",
+        "name": "Distribute data globally with Azure Cosmos DB"
       },
       {
-        "name": "Tips for building highly available applications",
-        "url": "https://learn.microsoft.com/azure/cosmos-db/high-availability#tips-for-building-highly-available-applications"
+        "url": "https://learn.microsoft.com/azure/cosmos-db/high-availability#tips-for-building-highly-available-applications",
+        "name": "Tips for building highly available applications"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7664,8 +7664,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Manage an Azure Cosmos DB account by using the Azure portal",
-        "url": "https://learn.microsoft.com/azure/cosmos-db/how-to-manage-database-account#automatic-failover"
+        "url": "https://learn.microsoft.com/azure/cosmos-db/how-to-manage-database-account#automatic-failover",
+        "name": "Manage an Azure Cosmos DB account by using the Azure portal"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7687,8 +7687,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "High availability in Azure Cosmos DB",
-        "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-cosmos-db-nosql"
+        "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-cosmos-db-nosql",
+        "name": "High availability in Azure Cosmos DB"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7710,12 +7710,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Distribute data globally with Azure Cosmos DB",
-        "url": "https://learn.microsoft.com/azure/cosmos-db/distribute-data-globally"
+        "url": "https://learn.microsoft.com/azure/cosmos-db/distribute-data-globally",
+        "name": "Distribute data globally with Azure Cosmos DB"
       },
       {
-        "name": "Conflict resolution types and resolution policies in Azure Cosmos DB",
-        "url": "https://learn.microsoft.com/azure/cosmos-db/conflict-resolution-policies"
+        "url": "https://learn.microsoft.com/azure/cosmos-db/conflict-resolution-policies",
+        "name": "Conflict resolution types and resolution policies in Azure Cosmos DB"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7737,8 +7737,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Continuous backup with point in time restore feature in Azure Cosmos DB",
-        "url": "https://learn.microsoft.com/azure/cosmos-db/continuous-backup-restore-introduction"
+        "url": "https://learn.microsoft.com/azure/cosmos-db/continuous-backup-restore-introduction",
+        "name": "Continuous backup with point in time restore feature in Azure Cosmos DB"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7760,8 +7760,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Pagination in Azure Cosmos DB",
-        "url": "https://learn.microsoft.com/azure/cosmos-db/nosql/query/pagination#handling-multiple-pages-of-results"
+        "url": "https://learn.microsoft.com/azure/cosmos-db/nosql/query/pagination#handling-multiple-pages-of-results",
+        "name": "Pagination in Azure Cosmos DB"
       }
     ],
     "recommendationControl": "Scalability",
@@ -7783,8 +7783,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Designing resilient applications with Azure Cosmos DB SDKs",
-        "url": "https://learn.microsoft.com/azure/cosmos-db/nosql/conceptual-resilient-sdk-applications"
+        "url": "https://learn.microsoft.com/azure/cosmos-db/nosql/conceptual-resilient-sdk-applications",
+        "name": "Designing resilient applications with Azure Cosmos DB SDKs"
       }
     ],
     "recommendationControl": "Scalability",
@@ -7806,8 +7806,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Designing resilient applications with Azure Cosmos DB SDKs",
-        "url": "https://learn.microsoft.com/azure/cosmos-db/nosql/conceptual-resilient-sdk-applications"
+        "url": "https://learn.microsoft.com/azure/cosmos-db/nosql/conceptual-resilient-sdk-applications",
+        "name": "Designing resilient applications with Azure Cosmos DB SDKs"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7829,8 +7829,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Create alerts for Azure Cosmos DB using Azure Monitor",
-        "url": "https://learn.microsoft.com/azure/cosmos-db/create-alerts"
+        "url": "https://learn.microsoft.com/azure/cosmos-db/create-alerts",
+        "name": "Create alerts for Azure Cosmos DB using Azure Monitor"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -7852,8 +7852,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Service levels for Azure NetApp Files | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-service-levels"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-service-levels",
+        "name": "Service levels for Azure NetApp Files | Microsoft Learn"
       }
     ],
     "recommendationControl": "Scalability",
@@ -7875,8 +7875,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Guidelines for Azure NetApp Files network planning | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-network-topologies"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-network-topologies",
+        "name": "Guidelines for Azure NetApp Files network planning | Microsoft Learn"
       }
     ],
     "recommendationControl": "Scalability",
@@ -7898,8 +7898,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Use availability zones for high availability in Azure NetApp Files | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/use-availability-zones"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/use-availability-zones",
+        "name": "Use availability zones for high availability in Azure NetApp Files | Microsoft Learn"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7921,8 +7921,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Manage availability zone volume placement for Azure NetApp Files | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/manage-availability-zone-volume-placement"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/manage-availability-zone-volume-placement",
+        "name": "Manage availability zone volume placement for Azure NetApp Files | Microsoft Learn"
       }
     ],
     "recommendationControl": "Other Best Practices",
@@ -7944,8 +7944,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "How Azure NetApp Files snapshots work | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/snapshots-introduction"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/snapshots-introduction",
+        "name": "How Azure NetApp Files snapshots work | Microsoft Learn"
       }
     ],
     "recommendationControl": "High Availability",
@@ -7967,8 +7967,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Understand Azure NetApp Files backup | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/backup-introduction"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/backup-introduction",
+        "name": "Understand Azure NetApp Files backup | Microsoft Learn"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -7990,8 +7990,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Cross-region replication of Azure NetApp Files volumes",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-netapp-files/cross-region-replication-introduction"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-netapp-files/cross-region-replication-introduction",
+        "name": "Cross-region replication of Azure NetApp Files volumes"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -8013,8 +8013,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Cross-zone replication of Azure NetApp Files volumes | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/cross-zone-replication-introduction"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/cross-zone-replication-introduction",
+        "name": "Cross-zone replication of Azure NetApp Files volumes | Microsoft Learn"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -8036,8 +8036,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Ways to monitor Azure NetApp Files | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/monitor-azure-netapp-files"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/monitor-azure-netapp-files",
+        "name": "Ways to monitor Azure NetApp Files | Microsoft Learn"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -8059,12 +8059,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Policy definitions for Azure NetApp Files | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-policy-definitions"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-policy-definitions",
+        "name": "Azure Policy definitions for Azure NetApp Files | Microsoft Learn"
       },
       {
-        "name": "Creating custom policy definitions | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/governance/policy/tutorials/create-custom-policy-definition"
+        "url": "https://learn.microsoft.com/azure/governance/policy/tutorials/create-custom-policy-definition",
+        "name": "Creating custom policy definitions | Microsoft Learn"
       }
     ],
     "recommendationControl": "Governance",
@@ -8086,24 +8086,24 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure network features for an Azure NetApp Files volume",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/configure-network-features"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/configure-network-features",
+        "name": "Configure network features for an Azure NetApp Files volume"
       },
       {
-        "name": "Manage SMB share ACLs in Azure NetApp Files",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/manage-smb-share-access-control-lists"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/manage-smb-share-access-control-lists",
+        "name": "Manage SMB share ACLs in Azure NetApp Files"
       },
       {
-        "name": "Configure export policy for NFS or dual-protocol volumes",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-configure-export-policy"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-configure-export-policy",
+        "name": "Configure export policy for NFS or dual-protocol volumes"
       },
       {
-        "name": "Configure access control lists on NFSv4.1 volumes for Azure NetApp Files",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/configure-access-control-lists"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/configure-access-control-lists",
+        "name": "Configure access control lists on NFSv4.1 volumes for Azure NetApp Files"
       },
       {
-        "name": "Configure Unix permissions and change ownership mode for NFS and dual-protocol volumes",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/configure-unix-permissions-change-ownership-mode"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/configure-unix-permissions-change-ownership-mode",
+        "name": "Configure Unix permissions and change ownership mode for NFS and dual-protocol volumes"
       }
     ],
     "recommendationControl": "Security",
@@ -8125,8 +8125,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Do I need to take special precautions for SMB-based applications? | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/faq-application-resilience#do-i-need-to-take-special-precautions-for-smb-based-applications"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/faq-application-resilience#do-i-need-to-take-special-precautions-for-smb-based-applications",
+        "name": "Do I need to take special precautions for SMB-based applications? | Microsoft Learn"
       }
     ],
     "recommendationControl": "High Availability",
@@ -8148,8 +8148,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "What do you recommend for handling potential application disruptions due to storage service maintenance events? | Microsoft Learn",
-        "url": "https://learn.microsoft.com/azure/azure-netapp-files/faq-application-resilience#what-do-you-recommend-for-handling-potential-application-disruptions-due-to-storage-service-maintenance-events"
+        "url": "https://learn.microsoft.com/azure/azure-netapp-files/faq-application-resilience#what-do-you-recommend-for-handling-potential-application-disruptions-due-to-storage-service-maintenance-events",
+        "name": "What do you recommend for handling potential application disruptions due to storage service maintenance events? | Microsoft Learn"
       }
     ],
     "recommendationControl": "High Availability",
@@ -8171,8 +8171,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Event Grid - Enable diagnostic logs for Event Grid resources",
-        "url": "https://learn.microsoft.com/en-us/azure/event-grid/enable-diagnostic-logs-topic"
+        "url": "https://learn.microsoft.com/en-us/azure/event-grid/enable-diagnostic-logs-topic",
+        "name": "Azure Event Grid - Enable diagnostic logs for Event Grid resources"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -8194,8 +8194,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Event Grid delivery and retry",
-        "url": "https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry#dead-letter-events"
+        "url": "https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry#dead-letter-events",
+        "name": "Azure Event Grid delivery and retry"
       }
     ],
     "recommendationControl": "Personalized",
@@ -8217,8 +8217,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Configure private endpoints for Azure Event Grid topics or domains",
-        "url": "https://learn.microsoft.com/en-us/azure/event-grid/configure-private-endpoints"
+        "url": "https://learn.microsoft.com/en-us/azure/event-grid/configure-private-endpoints",
+        "name": "Configure private endpoints for Azure Event Grid topics or domains"
       }
     ],
     "recommendationControl": "Security",
@@ -8240,8 +8240,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Citrix Limits",
-        "url": "https://docs.citrix.com/en-us/citrix-daas-azure/limits"
+        "url": "https://docs.citrix.com/en-us/citrix-daas-azure/limits",
+        "name": "Citrix Limits"
       }
     ],
     "recommendationControl": "Governance",
@@ -8263,12 +8263,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Management group recommendations",
-        "url": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-group-recommendations"
+        "url": "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-group-recommendations",
+        "name": "Management group recommendations"
       },
       {
-        "name": "Root management group for each directory",
-        "url": "https://learn.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory"
+        "url": "https://learn.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory",
+        "name": "Root management group for each directory"
       }
     ],
     "recommendationControl": "Governance",
@@ -8290,12 +8290,12 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Import and export IoT Hub device identities in bulk",
-        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-bulk-identity-mgmt"
+        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-bulk-identity-mgmt",
+        "name": "Import and export IoT Hub device identities in bulk"
       },
       {
-        "name": "IoT Hub high availability and disaster recovery",
-        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr#manual-failover"
+        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr#manual-failover",
+        "name": "IoT Hub high availability and disaster recovery"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -8317,8 +8317,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Choose the right IoT Hub tier and size for your solution",
-        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-scaling"
+        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-scaling",
+        "name": "Choose the right IoT Hub tier and size for your solution"
       }
     ],
     "recommendationControl": "High Availability",
@@ -8340,8 +8340,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure IoT Hub high availability and disaster recovery",
-        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr#availability-zones"
+        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr#availability-zones",
+        "name": "Azure IoT Hub high availability and disaster recovery"
       }
     ],
     "recommendationControl": "High Availability",
@@ -8363,16 +8363,16 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "IoT Hub Device Provisioning Service (DPS) terminology",
-        "url": "https://learn.microsoft.com/en-us/azure/iot-dps/concepts-service"
+        "url": "https://learn.microsoft.com/en-us/azure/iot-dps/concepts-service",
+        "name": "IoT Hub Device Provisioning Service (DPS) terminology"
       },
       {
-        "name": "Best practices for large-scale IoT device deployments",
-        "url": "https://learn.microsoft.com/en-us/azure/iot-dps/concepts-deploy-at-scale"
+        "url": "https://learn.microsoft.com/en-us/azure/iot-dps/concepts-deploy-at-scale",
+        "name": "Best practices for large-scale IoT device deployments"
       },
       {
-        "name": "IoT Hub Device Provisioning Service high availability and disaster recovery",
-        "url": "https://learn.microsoft.com/en-us/azure/iot-dps/iot-dps-ha-dr"
+        "url": "https://learn.microsoft.com/en-us/azure/iot-dps/iot-dps-ha-dr",
+        "name": "IoT Hub Device Provisioning Service high availability and disaster recovery"
       }
     ],
     "recommendationControl": "Scalability",
@@ -8394,8 +8394,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "IoT Hub high availability and disaster recovery",
-        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr"
+        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr",
+        "name": "IoT Hub high availability and disaster recovery"
       }
     ],
     "recommendationControl": "High Availability",
@@ -8417,8 +8417,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Use message routing - Fallback route",
-        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-d2c#fallback-route"
+        "url": "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-d2c#fallback-route",
+        "name": "Use message routing - Fallback route"
       }
     ],
     "recommendationControl": "Monitoring and Alerting",
@@ -8440,8 +8440,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Resource Manager Overview",
-        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-group-location-alignment"
+        "url": "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-group-location-alignment",
+        "name": "Azure Resource Manager Overview"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -8463,8 +8463,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "High availability concepts in Azure Database for MySQL - Flexible Server",
-        "url": "https://learn.microsoft.com/azure/mysql/flexible-server/concepts-high-availability"
+        "url": "https://learn.microsoft.com/azure/mysql/flexible-server/concepts-high-availability",
+        "name": "High availability concepts in Azure Database for MySQL - Flexible Server"
       }
     ],
     "recommendationControl": "High Availability",
@@ -8486,8 +8486,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Scheduled maintenance in Azure Database for MySQL - Flexible Server",
-        "url": "https://learn.microsoft.com/azure/mysql/flexible-server/concepts-maintenance"
+        "url": "https://learn.microsoft.com/azure/mysql/flexible-server/concepts-maintenance",
+        "name": "Scheduled maintenance in Azure Database for MySQL - Flexible Server"
       }
     ],
     "recommendationControl": "Scalability",
@@ -8509,8 +8509,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Backup and restore in Azure Database for MySQL - Flexible Server",
-        "url": "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-backup-restore"
+        "url": "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-backup-restore",
+        "name": "Backup and restore in Azure Database for MySQL - Flexible Server"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -8532,8 +8532,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Read replicas in Azure Database for MySQL - Flexible Server",
-        "url": "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-read-replicas"
+        "url": "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-read-replicas",
+        "name": "Read replicas in Azure Database for MySQL - Flexible Server"
       }
     ],
     "recommendationControl": "Disaster Recovery",
@@ -8555,8 +8555,8 @@
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
-        "name": "Azure Database for MySQL - Flexible Server service tiers - Storage auto grow",
-        "url": "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-service-tiers-storage#storage-auto-grow"
+        "url": "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-service-tiers-storage#storage-auto-grow",
+        "name": "Azure Database for MySQL - Flexible Server service tiers - Storage auto grow"
       }
     ],
     "recommendationControl": "Scalability",

--- a/tools/data/recommendations.json
+++ b/tools/data/recommendations.json
@@ -6516,7 +6516,7 @@
     "publishedToLearn": false,
     "tags": null,
     "recommendationResourceType": "Microsoft.AVS/privateClouds",
-    "recommendationImpact": "High",
+    "recommendationImpact": "Medium",
     "automationAvailable": true,
     "query": "// Azure Resource Graph Query\n// Provides a list of Azure VMware Solution resources that don't have a Cluster CPU capacity critical alert with a threshold of 95%.\nresources\n| where ['type'] == \"microsoft.avs/privateclouds\"\n| extend scopeId = tolower(tostring(id))\n| project ['scopeId'], name, id, tags\n| join kind=leftouter (\nresources\n| where type == \"microsoft.insights/metricalerts\"\n| extend alertProperties = todynamic(properties)\n| mv-expand alertProperties.scopes\n| mv-expand alertProperties.criteria.allOf\n| extend scopeId = tolower(tostring(alertProperties_scopes))\n| extend metric = alertProperties_criteria_allOf.metricName\n| extend threshold = alertProperties_criteria_allOf.threshold\n| project scopeId, tostring(metric), toint(['threshold'])\n| where metric == \"EffectiveCpuAverage\"\n| where threshold == 95\n) on scopeId\n| where isnull(['threshold'])\n| project recommendationId = \"4ee5d535-c47b-470a-9557-4a3dd297d62f\", name, id, tags, param1 = \"hostCpuCriticalAlert: isNull or threshold != 95\"\n\n"
   },
@@ -6539,7 +6539,7 @@
     "publishedToLearn": false,
     "tags": null,
     "recommendationResourceType": "Microsoft.AVS/privateClouds",
-    "recommendationImpact": "High",
+    "recommendationImpact": "Medium",
     "automationAvailable": true,
     "query": "// Azure Resource Graph Query\n// Provides a list of Azure VMware Solution resources that don't have a cluster host memory critical alert with a threshold of 95%.\nresources\n| where ['type'] == \"microsoft.avs/privateclouds\"\n| extend scopeId = tolower(tostring(id))\n| project ['scopeId'], name, id, tags\n| join kind=leftouter (\nresources\n| where type == \"microsoft.insights/metricalerts\"\n| extend alertProperties = todynamic(properties)\n| mv-expand alertProperties.scopes\n| mv-expand alertProperties.criteria.allOf\n| extend scopeId = tolower(tostring(alertProperties_scopes))\n| extend metric = alertProperties_criteria_allOf.metricName\n| extend threshold = alertProperties_criteria_allOf.threshold\n| project scopeId, tostring(metric), toint(['threshold'])\n| where metric == \"UsageAverage\"\n| where threshold == 95\n) on scopeId\n| where isnull(['threshold'])\n| project recommendationId = \"029208c8-5186-4a76-8ee8-6e3445fef4dd\", name, id, tags, param1 = \"hostMemoryCriticalAlert: isNull or threshold != 95\"\n\n"
   },


### PR DESCRIPTION
# Overview/Summary

Fixes the example value of **recommendationResourceType** in the [Create Recommendations](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing/create-content/create-recommendations/#recommendation-structure).

The current example value is **Storage Account**, but most recommendations have the value with the resource type format.

https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/blob/9cd5e4f6cf14fdcbf6a9b7ac89c31bde8dc94252/azure-resources/Storage/storageAccounts/recommendations.yaml#L6-L6

## Related Issues/Work Items

- None

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)

## Screenshot

![image](https://github.com/user-attachments/assets/aa4125b8-770c-4cc8-ba14-9e944ceff1e9)

