### PR TITLE
fix: exclude master DB from failover group recommendation

### DIFF
--- a/azure-resources/Sql/servers/kql/943c168a-2ec2-a94c-8015-85732a1b4859.kql
+++ b/azure-resources/Sql/servers/kql/943c168a-2ec2-a94c-8015-85732a1b4859.kql
@@ -1,6 +1,6 @@
 // Azure Resource Graph Query
 // Provides a list of SQL databases that are not configured to use a failover-group.
 resources
-| where type =~'microsoft.sql/servers/databases'
+| where type =~'microsoft.sql/servers/databases' and name !~ "master"
 | where isnull(properties['failoverGroupId'])
 | project recommendationId = "943c168a-2ec2-a94c-8015-85732a1b4859", name, id, tags, param1= strcat("databaseId=", properties['databaseId'])


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

<!-- Thank you for your contribution! Please add a brief description of what this Pull Request fixes, changes, etc. -->

Master database should be excluded from "Auto Failover Groups can encompass one or multiple databases, usually used by the same app." recommendation result.

Before my fix 👇

![before](https://github.com/user-attachments/assets/52c5b4ad-08c6-4c96-a6ef-9d983f922541)

After my fix 👇

![after](https://github.com/user-attachments/assets/940733c3-8b15-4e6e-bc68-6be1d321b786)

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)