### PR TITLE
refactor: Reconfigure Validate ARG Query Workflow to be Manually Triggered

### DIFF
--- a/.github/workflows/validate-queries.yml
+++ b/.github/workflows/validate-queries.yml
@@ -1,17 +1,6 @@
 name: Validate ARG Queries
 
 on:
-  pull_request_target:
-    branches:
-      - main
-      - dev-tools
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-    paths:
-    - '**/*.kql'
   workflow_dispatch: {}
 
 permissions:
@@ -22,25 +11,6 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     runs-on: ubuntu-latest
-    if: |
-      (
-        github.event.pull_request.head.repo.full_name == 'Azure/Azure-Proactive-Resiliency-Library-v2'
-      )
-      ||
-      (
-        github.event.pull_request.head.repo.full_name != 'Azure/Azure-Proactive-Resiliency-Library-v2'
-        &&
-        contains(github.event.pull_request.labels.*.name, 'PR: Safe to Test ARG Queries :test_tube:')
-      )
-      ||
-      (
-        github.event_name == 'workflow_dispatch'
-      )
-      ||
-      (
-        github.event_name == 'merge_group'
-      )
-
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -50,7 +20,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
+          ref: "refs/pull/${{ inputs.pr_number }}/merge"
           fetch-depth: 2
 
       - name: Sanity Check


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Refactoring the ARG Query Workflow to be manually triggered.

## Related Issues/Work Items

N/A

### Breaking Changes

1. None

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
