### PR TITLE
fix: Script file version of 3_wara_reports_generator.ps1 to 2.1.6

### DIFF
--- a/tools/3_wara_reports_generator.ps1
+++ b/tools/3_wara_reports_generator.ps1
@@ -2152,7 +2152,7 @@ https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2
 
     #Call the functions
     $Global:LogFile = ($PSScriptRoot + '\wara_reports_generator.log')
-    $Global:Version = "2.1.5"
+    $Global:Version = "2.1.6"
     Write-Host "Version: " -NoNewline
     Write-Host $Global:Version -ForegroundColor DarkBlue -NoNewline
     Write-Host " "

--- a/tools/Version.json
+++ b/tools/Version.json
@@ -2,6 +2,6 @@
   {
     "Collector": "2.1.16",
     "Analyzer": "2.1.12",
-    "Generator": "2.1.5"
+    "Generator": "2.1.6"
   }
 ]


### PR DESCRIPTION
# Overview/Summary

Fix the script file version of 3_wara_reports_generator.ps1 to 2.1.6.

## Related Issues/Work Items

- #488

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
