### PR TITLE
fix: Adjust workflow to require environment approval of PR before running specific workflows

### DIFF
--- a/.github/workflows/build-recommendation-object.yml
+++ b/.github/workflows/build-recommendation-object.yml
@@ -31,6 +31,24 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    if: |
+      (
+        github.event.pull_request.head.repo.full_name == 'Azure/Azure-Proactive-Resiliency-Library-v2'
+      )
+      ||
+      (
+        github.event.pull_request.head.repo.full_name != 'Azure/Azure-Proactive-Resiliency-Library-v2'
+        &&
+        contains(github.event.pull_request.labels.*.name, 'PR: Safe to Build Recommendation Object :white_check_mark:')
+      )
+      ||
+      (
+        github.event_name == 'workflow_dispatch'
+      )
+      ||
+      (
+        github.event_name == 'merge_group'
+      )
 
     steps:
     - name: Harden Runner
@@ -96,3 +114,24 @@ jobs:
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  remove_label:
+    if: ${{ always()}}
+    needs: update-json-object
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: 'Checkout Repository'
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "PR: Safe to Build Recommendation Object :white_check_mark:"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-recommendation-object.yml
+++ b/.github/workflows/build-recommendation-object.yml
@@ -31,6 +31,25 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    if: |
+      (
+        github.event.pull_request.head.repo.full_name == 'Azure/Azure-Proactive-Resiliency-Library-v2'
+      )
+      ||
+      (
+        github.event.pull_request.head.repo.full_name != 'Azure/Azure-Proactive-Resiliency-Library-v2'
+        &&
+        contains(github.event.pull_request.labels.*.name, 'PR: Safe to Build Recommendation Object :mag:')
+      )
+      ||
+      (
+        github.event_name == 'workflow_dispatch'
+      )
+      ||
+      (
+        github.event_name == 'merge_group'
+      )
+
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -95,3 +114,24 @@ jobs:
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  remove_label:
+    if: ${{ always()}}
+    needs: update-json-object
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: 'Checkout Repository'
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "PR: Safe to Build Recommendation Object :mag:"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-recommendation-object.yml
+++ b/.github/workflows/build-recommendation-object.yml
@@ -28,28 +28,10 @@ permissions:
 
 jobs:
   update-json-object:
+    environment: BuildObject
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    if: |
-      (
-        github.event.pull_request.head.repo.full_name == 'Azure/Azure-Proactive-Resiliency-Library-v2'
-      )
-      ||
-      (
-        github.event.pull_request.head.repo.full_name != 'Azure/Azure-Proactive-Resiliency-Library-v2'
-        &&
-        contains(github.event.pull_request.labels.*.name, 'PR: Safe to Build Recommendation Object :mag:')
-      )
-      ||
-      (
-        github.event_name == 'workflow_dispatch'
-      )
-      ||
-      (
-        github.event_name == 'merge_group'
-      )
-
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -114,24 +96,3 @@ jobs:
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  remove_label:
-    if: ${{ always()}}
-    needs: update-json-object
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
-        with:
-          egress-policy: audit
-
-      - name: 'Checkout Repository'
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-
-      - run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "PR: Safe to Build Recommendation Object :mag:"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-recommendation-object.yml
+++ b/.github/workflows/build-recommendation-object.yml
@@ -39,7 +39,7 @@ jobs:
       (
         github.event.pull_request.head.repo.full_name != 'Azure/Azure-Proactive-Resiliency-Library-v2'
         &&
-        contains(github.event.pull_request.labels.*.name, 'PR: Safe to Build Recommendation Object :white_check_mark:')
+        contains(github.event.pull_request.labels.*.name, 'PR: Safe to Build Recommendation Object :mag:')
       )
       ||
       (
@@ -132,6 +132,6 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "PR: Safe to Build Recommendation Object :white_check_mark:"
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "PR: Safe to Build Recommendation Object :mag:"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-recommendation-object.yml
+++ b/.github/workflows/build-recommendation-object.yml
@@ -31,25 +31,6 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    if: |
-      (
-        github.event.pull_request.head.repo.full_name == 'Azure/Azure-Proactive-Resiliency-Library-v2'
-      )
-      ||
-      (
-        github.event.pull_request.head.repo.full_name != 'Azure/Azure-Proactive-Resiliency-Library-v2'
-        &&
-        contains(github.event.pull_request.labels.*.name, 'PR: Safe to Build Recommendation Object :mag:')
-      )
-      ||
-      (
-        github.event_name == 'workflow_dispatch'
-      )
-      ||
-      (
-        github.event_name == 'merge_group'
-      )
-
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -114,24 +95,3 @@ jobs:
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  remove_label:
-    if: ${{ always()}}
-    needs: update-json-object
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
-        with:
-          egress-policy: audit
-
-      - name: 'Checkout Repository'
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-
-      - run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "PR: Safe to Build Recommendation Object :mag:"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-queries.yml
+++ b/.github/workflows/validate-queries.yml
@@ -23,6 +23,25 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     runs-on: ubuntu-latest
+    if: |
+      (
+        github.event.pull_request.head.repo.full_name == 'Azure/Azure-Proactive-Resiliency-Library-v2'
+      )
+      ||
+      (
+        github.event.pull_request.head.repo.full_name != 'Azure/Azure-Proactive-Resiliency-Library-v2'
+        &&
+        contains(github.event.pull_request.labels.*.name, 'PR: Safe to Test ARG Queries :test_tube:')
+      )
+      ||
+      (
+        github.event_name == 'workflow_dispatch'
+      )
+      ||
+      (
+        github.event_name == 'merge_group'
+      )
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -50,3 +69,24 @@ jobs:
       - name: Run KQL Syntax Check
         run: |
           pwsh .github/scripts/validate-kql-syntax.ps1
+
+  remove_label:
+    if: ${{ always()}}
+    needs: kql_file_check
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: 'Checkout Repository'
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "PR: Safe to Test ARG Queries :test_tube:"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-queries.yml
+++ b/.github/workflows/validate-queries.yml
@@ -23,25 +23,6 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     runs-on: ubuntu-latest
-    if: |
-      (
-        github.event.pull_request.head.repo.full_name == 'Azure/Azure-Proactive-Resiliency-Library-v2'
-      )
-      ||
-      (
-        github.event.pull_request.head.repo.full_name != 'Azure/Azure-Proactive-Resiliency-Library-v2'
-        &&
-        contains(github.event.pull_request.labels.*.name, 'PR: Safe to Test ARG Queries :test_tube:')
-      )
-      ||
-      (
-        github.event_name == 'workflow_dispatch'
-      )
-      ||
-      (
-        github.event_name == 'merge_group'
-      )
-
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -69,24 +50,3 @@ jobs:
       - name: Run KQL Syntax Check
         run: |
           pwsh .github/scripts/validate-kql-syntax.ps1
-
-  remove_label:
-    if: ${{ always()}}
-    needs: kql_file_check
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
-        with:
-          egress-policy: audit
-
-      - name: 'Checkout Repository'
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-
-      - run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "PR: Safe to Test ARG Queries :test_tube:"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-queries.yml
+++ b/.github/workflows/validate-queries.yml
@@ -52,7 +52,6 @@ jobs:
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
-          fetch-depth: 2
 
       - name: Azure login (OIDC)
         uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
@@ -72,6 +71,8 @@ jobs:
           pwsh .github/scripts/validate-kql-syntax.ps1
 
   remove_label:
+    if: ${{ always()}}
+    needs: kql_file_check
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/validate-queries.yml
+++ b/.github/workflows/validate-queries.yml
@@ -23,25 +23,6 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     runs-on: ubuntu-latest
-    if: |
-      (
-        github.event.pull_request.head.repo.full_name == 'Azure/Azure-Proactive-Resiliency-Library-v2'
-      )
-      ||
-      (
-        github.event.pull_request.head.repo.full_name != 'Azure/Azure-Proactive-Resiliency-Library-v2'
-        &&
-        contains(github.event.pull_request.labels.*.name, 'PR: Safe to Test ARG Queries :test_tube:')
-      )
-      ||
-      (
-        github.event_name == 'workflow_dispatch'
-      )
-      ||
-      (
-        github.event_name == 'merge_group'
-      )
-
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -69,27 +50,3 @@ jobs:
       - name: Run KQL Syntax Check
         run: |
           pwsh .github/scripts/validate-kql-syntax.ps1
-
-  remove_label:
-    if: ${{ always()}}
-    needs: kql_file_check
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
-        with:
-          egress-policy: audit
-
-      - name: 'Checkout Repository'
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-
-      - run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "PR: Safe to Test ARG Queries :test_tube:"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
-


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary


This pull request includes several changes to the GitHub Actions workflows, primarily focusing on making sure that all workflows that can check out forked branches have an environment approval. 

### Breaking Changes

None

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
