### PR TITLE
fix: Fixing a query from Service Health Alert and temporary removing an APRL x Advisor overlap 

### DIFF
--- a/azure-resources/Insights/activityLogAlerts/kql/9729c89d-8118-41b4-a39b-e12468fa872b.kql
+++ b/azure-resources/Insights/activityLogAlerts/kql/9729c89d-8118-41b4-a39b-e12468fa872b.kql
@@ -1,6 +1,5 @@
 // Azure Resource Graph Query
 // This resource graph query will return all subscriptions without Service Health alerts configured.
-
 resourcecontainers
 | where type == 'microsoft.resources/subscriptions'
 | project subscriptionAlerts=tostring(id),name,tags
@@ -14,5 +13,5 @@ resourcecontainers
 ) on subscriptionAlerts
 | where isempty(subscriptionAlerts1)
 | project-away subscriptionAlerts1
-| project recommendationId = "9729c89d-8118-41b4-a39b-e12468fa872b",id=subscriptionAlerts,name,tags
+| project recommendationId = "9729c89d-8118-41b4-a39b-e12468fa872b",name,id=subscriptionAlerts,tags
 

--- a/azure-resources/Network/applicationGateways/recommendations.yaml
+++ b/azure-resources/Network/applicationGateways/recommendations.yaml
@@ -159,7 +159,7 @@
 - description: Ensure Application Gateway Subnet is using a /24 subnet mask
   aprlGuid: 8364fd0a-7c0e-e240-9d95-4bf965aec243
   recommendationTypeId: null
-  recommendationControl: Performance
+  recommendationControl: Other Best Practices
   recommendationImpact: High
   recommendationResourceType: Microsoft.Network/applicationGateways
   recommendationMetadataState: Active

--- a/azure-resources/Network/applicationGateways/recommendations.yaml
+++ b/azure-resources/Network/applicationGateways/recommendations.yaml
@@ -158,8 +158,8 @@
 
 - description: Ensure Application Gateway Subnet is using a /24 subnet mask
   aprlGuid: 8364fd0a-7c0e-e240-9d95-4bf965aec243
-  recommendationTypeId: ef4da732-f541-4109-bc0e-465c68b6c7eb
-  recommendationControl: Other Best Practices
+  recommendationTypeId: null
+  recommendationControl: Performance
   recommendationImpact: High
   recommendationResourceType: Microsoft.Network/applicationGateways
   recommendationMetadataState: Active

--- a/tools/data/recommendations.json
+++ b/tools/data/recommendations.json
@@ -1608,7 +1608,7 @@
     "recommendationResourceType": "Microsoft.Insights/activityLogAlerts",
     "recommendationImpact": "High",
     "automationAvailable": true,
-    "query": "// Azure Resource Graph Query\n// This resource graph query will return all subscriptions without Service Health alerts configured.\n\nresourcecontainers\n| where type == 'microsoft.resources/subscriptions'\n| project subscriptionAlerts=tostring(id),name,tags\n| join kind=leftouter (\n  resources\n  | where type == 'microsoft.insights/activitylogalerts' and properties.condition contains \"ServiceHealth\"\n  | extend subscriptions = properties.scopes\n  | project subscriptions\n  | mv-expand subscriptions\n  | project subscriptionAlerts = tostring(subscriptions)\n) on subscriptionAlerts\n| where isempty(subscriptionAlerts1)\n| project-away subscriptionAlerts1\n| project recommendationId = \"9729c89d-8118-41b4-a39b-e12468fa872b\",id=subscriptionAlerts,name,tags\n\n"
+    "query": "// Azure Resource Graph Query\n// This resource graph query will return all subscriptions without Service Health alerts configured.\nresourcecontainers\n| where type == 'microsoft.resources/subscriptions'\n| project subscriptionAlerts=tostring(id),name,tags\n| join kind=leftouter (\n  resources\n  | where type == 'microsoft.insights/activitylogalerts' and properties.condition contains \"ServiceHealth\"\n  | extend subscriptions = properties.scopes\n  | project subscriptions\n  | mv-expand subscriptions\n  | project subscriptionAlerts = tostring(subscriptions)\n) on subscriptionAlerts\n| where isempty(subscriptionAlerts1)\n| project-away subscriptionAlerts1\n| project recommendationId = \"9729c89d-8118-41b4-a39b-e12468fa872b\",name,id=subscriptionAlerts,tags\n\n"
   },
   {
     "aprlGuid": "e48a7227-5ec7-463a-b955-ee7cb598ded4",
@@ -4539,7 +4539,7 @@
   },
   {
     "aprlGuid": "8364fd0a-7c0e-e240-9d95-4bf965aec243",
-    "recommendationTypeId": "ef4da732-f541-4109-bc0e-465c68b6c7eb",
+    "recommendationTypeId": null,
     "recommendationMetadataState": "Active",
     "learnMoreLink": [
       {
@@ -4547,7 +4547,7 @@
         "url": "https://learn.microsoft.com/en-us/azure/application-gateway/configuration-infrastructure#size-of-the-subnet"
       }
     ],
-    "recommendationControl": "Other Best Practices",
+    "recommendationControl": "Performance",
     "longDescription": "Application Gateway v2 (Standard_v2 or WAF_v2 SKU) can support up to 125 instances. A /24 subnet isn't mandatory for deployment but is advised to provide enough space for autoscaling and maintenance upgrades.\n",
     "pgVerified": true,
     "description": "Ensure Application Gateway Subnet is using a /24 subnet mask",


### PR DESCRIPTION
# Overview/Summary

fix: Fixing a query from Service Health Alert that was projecting incorrectly the ID before the NAME.

fix: temporary removing an APRL x Advisor overlap for the recommendation "Ensure Application Gateway Subnet is using a /24 subnet mask" - APRL GUID: "8364fd0a-7c0e-e240-9d95-4bf965aec243", until Advisor ARG Table is fixed. The table is showing the SubscriptionID as the Impacted Resource instead of the App GW. This fix will force the use of our APRL query which is working correctly. 