### PR TITLE
fix: incomplete Service Health alert check points

### DIFF
--- a/azure-resources/Subscription/subscriptions/kql/9729c89d-8118-41b4-a39b-e12468fa872b.kql
+++ b/azure-resources/Subscription/subscriptions/kql/9729c89d-8118-41b4-a39b-e12468fa872b.kql
@@ -1,18 +1,24 @@
 // Azure Resource Graph Query
-// This resource graph query will return all subscriptions without Service Health alerts configured.
-
+// This resource graph query will return all subscriptions without Service Health alerts configured AND subscriptions with Service Health alerts configured with specific configuration (which requires manual verification regarding the workload being covered by this rule)
 resourcecontainers
 | where type == 'microsoft.resources/subscriptions'
-| project subscriptionAlerts=tostring(id),name,tags
+| project subscriptionId = id, subscriptionName = name, tags
 | join kind=leftouter (
   resources
   | where type == 'microsoft.insights/activitylogalerts' and properties.condition contains "ServiceHealth"
-  | extend subscriptions = properties.scopes
-  | project subscriptions
-  | mv-expand subscriptions
-  | project subscriptionAlerts = tostring(subscriptions)
-) on subscriptionAlerts
-| where isempty(subscriptionAlerts1)
-| project-away subscriptionAlerts1
-| project recommendationId = "9729c89d-8118-41b4-a39b-e12468fa872b",name,id=subscriptionAlerts,tags
-
+  | mv-expand scopes = properties.scopes
+  | project subscriptionId = tostring(scopes)
+) on subscriptionId
+| where isempty(subscriptionId1)
+| project recommendationId = "9729c89d-8118-41b4-a39b-e12468fa872b", name = subscriptionName, id= subscriptionId, tags, param1='Service Health alert rules not configured on subscription'
+| union (
+    resourcecontainers
+    | where type == 'microsoft.resources/subscriptions'
+    | project subscriptionId, subscriptionName = name, tags
+    | join kind=leftouter (
+        resources
+        | where type == 'microsoft.insights/activitylogalerts' and properties.condition contains "ServiceHealth" and array_length(properties.condition.allOf) > 1
+    ) on subscriptionId
+    | where isnotempty(id)
+    | project recommendationId = "9729c89d-8118-41b4-a39b-e12468fa872b", name = subscriptionName, id= strcat('/subscriptions/',subscriptionId), tags, param1=strcat('Service Health alert rule "',name,'" with a restricted configuration (please verify manually)')
+)

--- a/azure-resources/Subscription/subscriptions/kql/9729c89d-8118-41b4-a39b-e12468fa872b.kql
+++ b/azure-resources/Subscription/subscriptions/kql/9729c89d-8118-41b4-a39b-e12468fa872b.kql
@@ -1,24 +1,15 @@
 // Azure Resource Graph Query
-// This resource graph query will return all subscriptions without Service Health alerts configured AND subscriptions with Service Health alerts configured with specific configuration (which requires manual verification regarding the workload being covered by this rule)
+// This resource graph query will return all subscriptions without Service Health alerts configured AND subscriptions with Service Health alerts only configured with specific configuration (which requires manual verification regarding the scope being covered by this rule)
 resourcecontainers
 | where type == 'microsoft.resources/subscriptions'
 | project subscriptionId = id, subscriptionName = name, tags
 | join kind=leftouter (
-  resources
-  | where type == 'microsoft.insights/activitylogalerts' and properties.condition contains "ServiceHealth"
-  | mv-expand scopes = properties.scopes
-  | project subscriptionId = tostring(scopes)
+    resources
+    | where type == "microsoft.insights/activitylogalerts" and properties.condition contains "ServiceHealth"
+    | extend shaRuleType = iff(array_length(properties.condition.allOf) > 1, 'Explicit','All')
+    | project subscriptionId = strcat('/subscriptions/',subscriptionId), name, shaRuleType
+    | summarize shaAllRuleCount = countif(shaRuleType == 'All'), shaExplicitRuleCount = countif(shaRuleType == 'Explicit') by subscriptionId
 ) on subscriptionId
-| where isempty(subscriptionId1)
-| project recommendationId = "9729c89d-8118-41b4-a39b-e12468fa872b", name = subscriptionName, id= subscriptionId, tags, param1='Service Health alert rules not configured on subscription'
-| union (
-    resourcecontainers
-    | where type == 'microsoft.resources/subscriptions'
-    | project subscriptionId, subscriptionName = name, tags
-    | join kind=leftouter (
-        resources
-        | where type == 'microsoft.insights/activitylogalerts' and properties.condition contains "ServiceHealth" and array_length(properties.condition.allOf) > 1
-    ) on subscriptionId
-    | where isnotempty(id)
-    | project recommendationId = "9729c89d-8118-41b4-a39b-e12468fa872b", name = subscriptionName, id= strcat('/subscriptions/',subscriptionId), tags, param1=strcat('Service Health alert rule "',name,'" with a restricted configuration (please verify manually)')
-)
+| extend shaStatus = iff(isnull(shaAllRuleCount) and isnull(shaExplicitRuleCount), 'Not configured',iff(shaAllRuleCount >= 1, 'Configured', 'Explicit'))
+| where shaStatus != 'Configured'
+| project recommendationId = "9729c89d-8118-41b4-a39b-e12468fa872b", name = subscriptionName, id= subscriptionId, tags, param1 = iff(shaStatus == 'Explicit', 'Explicit only Service Health Alert Rule(s) found. Please verify that the expected scope is covered by these rule(s).','No Service Health Alert Rule found.')


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

We have detected a certain misalignment regarding the points of attention for this recommendation internally vs. APRL code. Indeed, the KQL code only *"return all subscriptions without Service Health alerts configured"* but we also need to materialize, in the “Impacted Resources” view of the action plan, all Service Health alert rules with a restricted configuration (specific services and/or regions and/or events). Let's take a look below:

## Before

Before, only subscriptions with non-existent Service Health rules were materialized. 

![before](https://github.com/user-attachments/assets/3bad8fe0-eadc-4ccc-9ee5-9a1827ea4da9)

## After 

Now, subscriptions with non-existent Service Health rules AND Service Health alert rules with restricted configuration are returned by the code. This will automatically create these entries in the action plan for manual verification, as for other recommendations requiring manual verification and/or special attention.

![after-v2](https://github.com/user-attachments/assets/fb48b11e-ec08-4aa8-9cd7-d2e4eca2f362)

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [X] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
