### PR TITLE
fix: appservice query to return resourceid that is searchable

### DIFF
--- a/azure-resources/Web/sites/kql/0b80b67c-afbe-4988-ad58-a85a146b681e.kql
+++ b/azure-resources/Web/sites/kql/0b80b67c-afbe-4988-ad58-a85a146b681e.kql
@@ -5,5 +5,5 @@ appserviceresources
 | where type == "microsoft.web/sites/config"
 | extend AppSettings = iif(isempty(properties.AppSettings), true, false)
 | where AppSettings == false
+| extend id = replace(@"/config/web$", "", id)
 | project  recommendationId="0b80b67c-afbe-4988-ad58-a85a146b681e", id, name, tags="", param1="AppSettings is not configured"
-


### PR DESCRIPTION


# Overview/Summary

Updates query for 0b80b67c-afbe-4988-ad58-a85a146b681e to return a resourceid instead of a /config/web which we can't search in the WARA tooling.

## Related Issues/Work Items

Fixes #549 

### Breaking Changes

No breaking changes.

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
