### PR TITLE
docs: Fixed collector documentation

### DIFF
--- a/docs/content/tools/collector/_index.md
+++ b/docs/content/tools/collector/_index.md
@@ -232,7 +232,7 @@ Provide parameters in command line:
 Provide parameters via ConfigFile:
 
 ```powershell
-.\Wara_Collector.ps1 -configFile config.txt
+.\1_Wara_Collector.ps1 -configFile config.txt
 ```
 
 config.txt


### PR DESCRIPTION

# Overview/Summary

The https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/tools/collector/ page was referencing .\Wara_Collector.ps1 -configFile config.txt instead of .\1_Wara_Collector.ps1 -configFile config.txt

Old documentation
![image](https://github.com/user-attachments/assets/dc44af1a-c7c3-42bf-aeca-577da49e5e5e)


New documentation
![image](https://github.com/user-attachments/assets/9f8dd75a-2f2d-47a6-9f6f-c87f81e5153d)



## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [X] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
