### PR TITLE
docs: remove recommendationTypeId values for non-reliability Advisor recommendations

### DIFF
--- a/azure-resources/ApiManagement/service/recommendations.yaml
+++ b/azure-resources/ApiManagement/service/recommendations.yaml
@@ -38,7 +38,7 @@
 
 - description: Azure API Management platform version should be stv2
   aprlGuid: e35cf148-8eee-49d1-a1c9-956160f99e0b
-  recommendationTypeId: e5f60ef8-3fcc-4fb5-bee7-7aaeb44c1509
+  recommendationTypeId: null
   recommendationControl: HighAvailability
   recommendationImpact: High
   recommendationResourceType: Microsoft.ApiManagement/service

--- a/azure-resources/Cdn/profiles/recommendations.yaml
+++ b/azure-resources/Cdn/profiles/recommendations.yaml
@@ -17,7 +17,7 @@
 
 - description: Use the latest API version and SDK version
   aprlGuid: 52bc9a7b-23c8-bc4c-9d2a-7bc43b50104a
-  recommendationTypeId: e607041e-3194-42ad-9994-b6ea5ec12f5e
+  recommendationTypeId: null
   recommendationControl: Scalability
   recommendationImpact: Medium
   recommendationResourceType: Microsoft.Cdn/profiles

--- a/azure-resources/Compute/virtualMachines/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachines/recommendations.yaml
@@ -146,7 +146,7 @@
 
 - description: Enable Accelerated Networking (AccelNet)
   aprlGuid: dfedbeb1-1519-fc47-86a5-52f96cf07105
-  recommendationTypeId: 3a3c1a2a-8597-4d3a-981a-0a24a0ee9de4
+  recommendationTypeId: null
   recommendationControl: Scalability
   recommendationImpact: Medium
   recommendationResourceType: Microsoft.Compute/virtualMachines
@@ -214,7 +214,7 @@
 
 - description: IP Forwarding should only be enabled for Network Virtual Appliances
   aprlGuid: 41a22a5e-5e08-9647-92d0-2ffe9ef1bdad
-  recommendationTypeId: c3b51c94-588b-426b-a892-24696f9e54cc
+  recommendationTypeId: null
   recommendationControl: Security
   recommendationImpact: Medium
   recommendationResourceType: Microsoft.Compute/virtualMachines

--- a/azure-resources/DocumentDB/databaseAccounts/recommendations.yaml
+++ b/azure-resources/DocumentDB/databaseAccounts/recommendations.yaml
@@ -72,7 +72,7 @@
 
 - description: Configure continuous backup mode
   aprlGuid: e544520b-8505-7841-9e77-1f1974ee86ec
-  recommendationTypeId: 52fef986-5897-4359-8b92-0f22749f0d73
+  recommendationTypeId: null
   recommendationControl: DisasterRecovery
   recommendationImpact: High
   recommendationResourceType: Microsoft.DocumentDB/databaseAccounts

--- a/azure-resources/KeyVault/vaults/recommendations.yaml
+++ b/azure-resources/KeyVault/vaults/recommendations.yaml
@@ -1,6 +1,6 @@
 - description: Key vaults should have soft delete enabled
   aprlGuid: 1cca00d2-d9ab-8e42-a788-5d40f49405cb
-  recommendationTypeId: 78211c00-15a9-336e-17c4-0b48613dadf4
+  recommendationTypeId: null
   recommendationControl: DisasterRecovery
   recommendationImpact: High
   recommendationResourceType: Microsoft.KeyVault/vaults
@@ -17,7 +17,7 @@
 
 - description: Key vaults should have purge protection enabled
   aprlGuid: 70fcfe6d-00e9-5544-a63a-fff42b9f2edb
-  recommendationTypeId: 4ed62ae4-5072-f9e7-8d94-51c76c48159a
+  recommendationTypeId: null
   recommendationControl: DisasterRecovery
   recommendationImpact: Medium
   recommendationResourceType: Microsoft.KeyVault/vaults
@@ -68,7 +68,7 @@
 
 - description: Diagnostic logs in Key Vault should be enabled
   aprlGuid: 1dc0821d-4f14-7644-bab4-ba208ff5f7fa
-  recommendationTypeId: 88bbc99c-e5af-ddd7-6105-6150b2bfa519
+  recommendationTypeId: null
   recommendationControl: MonitoringAndAlerting
   recommendationImpact: Low
   recommendationResourceType: Microsoft.KeyVault/vaults

--- a/azure-resources/Network/applicationGateways/recommendations.yaml
+++ b/azure-resources/Network/applicationGateways/recommendations.yaml
@@ -61,7 +61,7 @@
 
 - description: Migrate to Application Gateway v2
   aprlGuid: 7893f0b3-8622-1d47-beed-4b50a19f7895
-  recommendationTypeId: 0e19257e-dcef-4d00-8de1-5fe1ae0fd948
+  recommendationTypeId: null
   recommendationControl: Scalability
   recommendationImpact: High
   recommendationResourceType: Microsoft.Network/applicationGateways
@@ -158,7 +158,7 @@
 
 - description: Ensure Application Gateway Subnet is using a /24 subnet mask
   aprlGuid: 8364fd0a-7c0e-e240-9d95-4bf965aec243
-  recommendationTypeId: ef4da732-f541-4109-bc0e-465c68b6c7eb
+  recommendationTypeId: null
   recommendationControl: OtherBestPractices
   recommendationImpact: High
   recommendationResourceType: Microsoft.Network/applicationGateways

--- a/azure-resources/RecoveryServices/vaults/recommendations.yaml
+++ b/azure-resources/RecoveryServices/vaults/recommendations.yaml
@@ -34,7 +34,7 @@
 
 - description: Migrate from classic alerts to built-in Azure Monitor alerts for Azure Recovery Services Vaults
   aprlGuid: 2912472d-0198-4bdc-aa90-37f145790edc
-  recommendationTypeId: 06578866-1877-41e6-9d22-3ea5122e8048
+  recommendationTypeId: null
   recommendationControl: MonitoringAndAlerting
   recommendationImpact: Medium
   recommendationResourceType: Microsoft.RecoveryServices/vaults

--- a/azure-resources/Storage/storageAccounts/recommendations.yaml
+++ b/azure-resources/Storage/storageAccounts/recommendations.yaml
@@ -19,7 +19,7 @@
 
 - description: Use premium performance block blob storage for high performance workloads
   aprlGuid: 5587ef77-7a05-a74d-9c6e-449547a12f27
-  recommendationTypeId: c6b94711-f1f5-4e7e-9c89-c17ed4190969
+  recommendationTypeId: null
   recommendationControl: Scalability
   recommendationImpact: Medium
   recommendationResourceType: Microsoft.Storage/storageAccounts

--- a/azure-resources/Web/sites/recommendations.yaml
+++ b/azure-resources/Web/sites/recommendations.yaml
@@ -70,7 +70,7 @@
 
 - description: Deploy to a staging slot
   aprlGuid: a1d91661-32d4-430b-b3b6-5adeb0975df7
-  recommendationTypeId: 1d3b5a51-62d4-4b77-96f6-40ed0a3aa21f
+  recommendationTypeId: null
   recommendationControl: Governance
   recommendationImpact: Low
   recommendationResourceType: Microsoft.Web/sites


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Remove recommendationTypeId values for Advisor recommendations not in the reliability category.

## Related Issues/Work Items

None

### Breaking Changes

1. None

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
