### PR TITLE
fix: Collector 2.1.18 & Analyzer 2.1.17

### DIFF
--- a/tools/2_wara_data_analyzer.ps1
+++ b/tools/2_wara_data_analyzer.ps1
@@ -139,7 +139,7 @@ $Script:Runtime = Measure-Command -Expression {
       # Define script path as the default path to save files
       $workingFolderPath = $PSScriptRoot
       Set-Location -Path $workingFolderPath;
-      $Script:clonePath = "$workingFolderPath\Azure-Proactive-Resiliency-Library"
+      $Script:clonePath = "$workingFolderPath\Azure-Proactive-Resiliency-Library-v2"
       Write-Debug 'Checking default folder'
       if ((Get-ChildItem -Path $Script:clonePath -Force | Measure-Object).Count -gt 0) {
         Write-Debug 'APRL Folder does exist. Reseting it...'
@@ -309,7 +309,7 @@ $Script:Runtime = Measure-Command -Expression {
               param3                                                                            = $Recom.param3;
               param4                                                                            = $Recom.param4;
               param5                                                                            = $Recom.param5;
-              supportTicketId                                                                   = '';
+              supportTicketId                                                                   = $Tickets;
               source                                                                            = $Recom.selector;
               checkName                                                                         = $Recom.checkName;
               'WAF Pillar'                                                                      = 'Reliability';
@@ -781,7 +781,7 @@ $Script:Runtime = Measure-Command -Expression {
 
       # Build the APRL Recommendations
       foreach ($Service in $Script:ServicesYAMLContent) {
-        if (($Service.recommendationResourceType -like 'Specialized.Workload/*' -or $Service.recommendationResourceType -in $Script:AllResourceTypesOrdered.'Resource Type' -or $Script:FilterRecommendations -eq $false) -and ([string]::IsNullOrEmpty($Service.recommendationTypeId) -or (![string]::IsNullOrEmpty($Service.recommendationTypeId) -and $Service.recommendationTypeId -notin $Script:RecommendedAdv))) {
+        if (($Service.recommendationResourceType -like 'Specialized.Workload/*' -or $Service.recommendationResourceType -eq 'Microsoft.Subscription/Subscriptions' -or $Service.recommendationResourceType -in $Script:AllResourceTypesOrdered.'Resource Type' -or $Script:FilterRecommendations -eq $false) -and ([string]::IsNullOrEmpty($Service.recommendationTypeId) -or (![string]::IsNullOrEmpty($Service.recommendationTypeId) -and $Service.recommendationTypeId -notin $Script:RecommendedAdv))) {
           $ID = $Service.aprlGuid
           $resourceType = $Service.recommendationResourceType
 
@@ -1056,7 +1056,7 @@ $Script:Runtime = Measure-Command -Expression {
   }
 
   #Call the functions
-  $Script:Version = '2.1.16'
+  $Script:Version = '2.1.17'
   Write-Host 'Version: ' -NoNewline
   Write-Host $Script:Version -ForegroundColor DarkBlue
 

--- a/tools/2_wara_data_analyzer.ps1
+++ b/tools/2_wara_data_analyzer.ps1
@@ -781,7 +781,7 @@ $Script:Runtime = Measure-Command -Expression {
 
       # Build the APRL Recommendations
       foreach ($Service in $Script:ServicesYAMLContent) {
-        if (($Service.recommendationResourceType -like 'Specialized.Workload/*' -or $Service.recommendationResourceType -eq 'Microsoft.Subscription/Subscriptions' -or $Service.recommendationResourceType -in $Script:AllResourceTypesOrdered.'Resource Type' -or $Script:FilterRecommendations -eq $false) -and ([string]::IsNullOrEmpty($Service.recommendationTypeId) -or (![string]::IsNullOrEmpty($Service.recommendationTypeId) -and $Service.recommendationTypeId -notin $Script:RecommendedAdv))) {
+        if (($Service.recommendationResourceType -like 'Specialized.Workload/*' -or $Service.recommendationResourceType -eq 'Microsoft.Resources/subscriptions' -or $Service.recommendationResourceType -in $Script:AllResourceTypesOrdered.'Resource Type' -or $Script:FilterRecommendations -eq $false) -and ([string]::IsNullOrEmpty($Service.recommendationTypeId) -or (![string]::IsNullOrEmpty($Service.recommendationTypeId) -and $Service.recommendationTypeId -notin $Script:RecommendedAdv))) {
           $ID = $Service.aprlGuid
           $resourceType = $Service.recommendationResourceType
 

--- a/tools/Version.json
+++ b/tools/Version.json
@@ -1,7 +1,7 @@
 [
   {
-    "Collector": "2.1.17",
-    "Analyzer": "2.1.16",
+    "Collector": "2.1.18",
+    "Analyzer": "2.1.17",
     "Generator": "2.1.6"
   }
 ]


### PR DESCRIPTION
# Overview/Summary

Updates for Collector and Analyzer script

The updates include:

- Including support for "Get-AzAccessToken -AsSecureString" 
- Bugfix on ResourceType sheet not considering the filtering attributes passed to the script
- Including support for "Specialized Workload" to support upcoming changes
- Include more than 15 Outages

## Related Issues/Work Items

Fixes #568 

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [X] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
