### PR TITLE
fix: bump version and update ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
 #APRL Specific Files
+/tools/Azure-Proactive-Resiliency-Library-v2/
 /tools/Azure-Proactive-Resiliency-Library/
 /tools/[Ww][Aa][Rr][Aa]*.json
 /tools/[Ww][Aa][Rr][Aa]*.xlsx

--- a/tools/3_wara_reports_generator.ps1
+++ b/tools/3_wara_reports_generator.ps1
@@ -2164,7 +2164,7 @@ https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2
 
     #Call the functions
     $Global:LogFile = ($PSScriptRoot + '\wara_reports_generator.log')
-    $Global:Version = "2.1.6"
+    $Global:Version = "2.1.7"
     Write-Host "Version: " -NoNewline
     Write-Host $Global:Version -ForegroundColor DarkBlue -NoNewline
     Write-Host " "

--- a/tools/Version.json
+++ b/tools/Version.json
@@ -2,6 +2,6 @@
   {
     "Collector": "2.1.18",
     "Analyzer": "2.1.17",
-    "Generator": "2.1.6"
+    "Generator": "2.1.7"
   }
 ]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Bumped the version in the `tools/3_wara_reports_generator.ps1` and `tools/Version.json` files to `2.1.7` for the `Generator` component.

Updated git ignore to exclude the APRL v2 directory.

### Breaking Changes
None

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
