### PR TITLE
fix: Fix issue #574

### DIFF
--- a/tools/1_wara_collector.ps1
+++ b/tools/1_wara_collector.ps1
@@ -1675,7 +1675,7 @@ $Script:Runtime = Measure-Command -Expression {
 
 
   #Call the functions
-  $Script:Version = '2.1.18'
+  $Script:Version = '2.1.19'
   Write-Host 'Version: ' -NoNewline
   Write-Host $Script:Version -ForegroundColor DarkBlue
 

--- a/tools/1_wara_collector.ps1
+++ b/tools/1_wara_collector.ps1
@@ -389,6 +389,7 @@ $Script:Runtime = Measure-Command -Expression {
     $Script:SupportedResTypes = @()
     $Script:AllResourceTypesOrdered = @()
     $Script:AllAdvisories = @()
+    $Script:Advisories = @()
     $Script:AllRetirements = @()
     $Script:AllServiceHealth = @()
     $Script:results = @()
@@ -1330,7 +1331,7 @@ $Script:Runtime = Measure-Command -Expression {
     $Script:ImpactedResources = $Script:ImpactedResources | Sort-Object -Unique -Property validationAction, recommendationId, name, Type, id, param1, param2, param3, param4, param5, checkName, selector
 
     Write-Host 'Filtering Advisor Resources..' -ForegroundColor Cyan
-    $Script:Advisories = foreach ($adv in $Script:AllAdvisories) {
+    $Script:Advisories += foreach ($adv in $Script:AllAdvisories) {
       if ($adv.id -in $Script:InScope.id) {
         $adv
       }

--- a/tools/Version.json
+++ b/tools/Version.json
@@ -1,6 +1,6 @@
 [
   {
-    "Collector": "2.1.18",
+    "Collector": "2.1.19",
     "Analyzer": "2.1.17",
     "Generator": "2.1.7"
   }


### PR DESCRIPTION
# Overview/Summary

- Fixed the issue #574 
    - The exception occurred when there is only a single recommendation from Advisor in the specified scope. In that case, `$Script:Advisories` is not an array, it's a scalar. So, `+=` operator does not work. Fixed the issue by `$Script:Advisories` to as an array always even if only a single recommendation from Advisor.
- Bump collector script version to 2.1.19

## Related Issues/Work Items

- Fixes #574

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
