### PR TITLE
fix:  Virtual Network Gateway (bbe668b7-eb5c-c746-8b82-70afdedf0cae.kql) returns resId instead of id

### DIFF
--- a/azure-resources/Network/virtualNetworkGateways/kql/bbe668b7-eb5c-c746-8b82-70afdedf0cae.kql
+++ b/azure-resources/Network/virtualNetworkGateways/kql/bbe668b7-eb5c-c746-8b82-70afdedf0cae.kql
@@ -10,4 +10,4 @@ advisorresources
     | extend id = tostring(id)
     | project id, name, tags, location, properties
 ) on $left.resId == $right.id
-| project recommendationId = "bbe668b7-eb5c-c746-8b82-70afdedf0cae", name , resId, tags, param1 = strcat("sku-tier: ", properties.sku.tier), param2 = location,param3 = "Non Zone-Redundant GW"
+| project recommendationId = "bbe668b7-eb5c-c746-8b82-70afdedf0cae", name , id = resId, tags, param1 = strcat("sku-tier: ", properties.sku.tier), param2 = location,param3 = "Non Zone-Redundant GW"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Query now returns `id` instead of `resId`

## Related Issues/Work Items

Fixes #605

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
