### PR TITLE
docs: added reference to availability zone for app service plans

### DIFF
--- a/azure-specialized-workloads/ai/_index.md
+++ b/azure-specialized-workloads/ai/_index.md
@@ -19,6 +19,7 @@ geekdocHidden: false
 | [Deploy Azure Machine learning workspace in secondary region](../../../Azure-Proactive-Resiliency-Library-v2/azure-resources/MachineLearningServices/workspaces/#deploy-azure-machine-learning-workspace-in-secondary-region)             | MachineLearningServices  |   workspaces    |
 | [Ensure to create Machine Learning Compute resources in secondary region](../../../Azure-Proactive-Resiliency-Library-v2/azure-resources/MachineLearningServices/workspaces/#ensure-to-create-machine-learning-compute-resources-in-secondary-region)             | MachineLearningServices  |   workspaces    |
 | [Configure API management service in multiple Azure regions](../../../Azure-Proactive-Resiliency-Library-v2/azure-resources/ApiManagement/service/#configure-api-management-service-in-multiple-azure-regions)             | ApiManagement  |   service    |
+| [Migrate App Service to availability Zone Support](../../../Azure-Proactive-Resiliency-Library-v2/azure-resources/Web/serverFarms/#migrate-app-service-to-availability-zone-support)             | Web            | serverFarms  |
 <br>
 
 ## General Workload Guidance

--- a/azure-specialized-workloads/ai/_index.md
+++ b/azure-specialized-workloads/ai/_index.md
@@ -19,7 +19,7 @@ geekdocHidden: false
 | [Deploy Azure Machine learning workspace in secondary region](../../../Azure-Proactive-Resiliency-Library-v2/azure-resources/MachineLearningServices/workspaces/#deploy-azure-machine-learning-workspace-in-secondary-region)             | MachineLearningServices  |   workspaces    |
 | [Ensure to create Machine Learning Compute resources in secondary region](../../../Azure-Proactive-Resiliency-Library-v2/azure-resources/MachineLearningServices/workspaces/#ensure-to-create-machine-learning-compute-resources-in-secondary-region)             | MachineLearningServices  |   workspaces    |
 | [Configure API management service in multiple Azure regions](../../../Azure-Proactive-Resiliency-Library-v2/azure-resources/ApiManagement/service/#configure-api-management-service-in-multiple-azure-regions)             | ApiManagement  |   service    |
-| [Migrate App Service to availability Zone Support](../../../Azure-Proactive-Resiliency-Library-v2/azure-resources/Web/serverFarms/#migrate-app-service-to-availability-zone-support)             | Web            | serverFarms  |
+| [Migrate App Service to Availability Zone Support](../../../Azure-Proactive-Resiliency-Library-v2/azure-resources/Web/serverFarms/#migrate-app-service-to-availability-zone-support)             | Web            | serverFarms  |
 <br>
 
 ## General Workload Guidance


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
 
# Overview/Summary
 
This PR adds a reference in the AI landing page in the specialized workloads section for App Service Availability Zone recommendation based on:

https://learn.microsoft.com/en-us/azure/architecture/ai-ml/architecture/azure-openai-baseline-landing-zone#workload-team-owned-resources
 
_"Azure App Service is used to host the example web application for the chat UI. In this architecture, it's also possible to use this service to host the containerized prompt flow for more control over the hosting environment that runs prompt flow. App Service has three instances, each in a different Azure zone."_
 
## Related Issues/Work Items
 
Fixes AB#38510
 
 
### Breaking Changes
 
None
 
## As part of this pull request I have
 
<!-- Use the checkboxes [x] on the options that are relevant. -->
 
- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
