### PR TITLE
fix: fix on filtering ImpactedResources

### DIFF
--- a/azure-resources/Web/serverFarms/recommendations.yaml
+++ b/azure-resources/Web/serverFarms/recommendations.yaml
@@ -84,5 +84,22 @@
   learnMoreLink:
     - name: Automatic scaling in Azure App Service
       url: "https://learn.microsoft.com/en-us/azure/app-service/manage-automatic-scaling?tabs=azure-portal"
+
+- description: Set minimum instance count to 2 for app service
+  aprlGuid: 855ca19a-6518-4f2e-9e5a-01796fbca9f8
+  recommendationTypeId: null
+  recommendationControl: Scalability
+  recommendationImpact: High
+  recommendationResourceType: Microsoft.Web/serverFarms
+  recommendationMetadataState: Active
+  longDescription: |
+    App Service should be configured with a minimum of two instances for production workloads. If apps have a longer warmup time a minimum of three instances should be used.
+  potentialBenefits: Improves app performance
+  pgVerified: true
+  automationAvailable: true
+  tags: null
+  learnMoreLink:
+    - name: Ultimate guide to running healthy apps in the cloud
+      url: "https://azure.github.io/AppService/2020/05/15/Robust-Apps-for-the-cloud.html"
     - name: Auto Scale Web Apps
       url: "https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-get-started"

--- a/azure-resources/Web/serverFarms/recommendations.yaml
+++ b/azure-resources/Web/serverFarms/recommendations.yaml
@@ -86,20 +86,3 @@
       url: "https://learn.microsoft.com/en-us/azure/app-service/manage-automatic-scaling?tabs=azure-portal"
     - name: Auto Scale Web Apps
       url: "https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-get-started"
-
-- description: Set minimum instance count to 2 for app service
-  aprlGuid: 855ca19a-6518-4f2e-9e5a-01796fbca9f8
-  recommendationTypeId: null
-  recommendationControl: Scalability
-  recommendationImpact: High
-  recommendationResourceType: Microsoft.Web/sites
-  recommendationMetadataState: Active
-  longDescription: |
-    App Service should be configured with a minimum of two instances for production workloads. If apps have a longer warmup time a minimum of three instances should be used.
-  potentialBenefits: Improves app performance
-  pgVerified: true
-  automationAvailable: true
-  tags: null
-  learnMoreLink:
-    - name: Ultimate guide to running healthy apps in the cloud
-      url: "https://azure.github.io/AppService/2020/05/15/Robust-Apps-for-the-cloud.html"

--- a/tools/2_wara_data_analyzer.ps1
+++ b/tools/2_wara_data_analyzer.ps1
@@ -322,7 +322,7 @@ $Script:Runtime = Measure-Command -Expression {
                 tagged                                                                            = $Recom.tagged
               }
               $Script:MergedRecommendation += $tmp
-            } 
+            }
             # Populating resource types without recommendations
             else {
               $tmp = @{

--- a/tools/2_wara_data_analyzer.ps1
+++ b/tools/2_wara_data_analyzer.ps1
@@ -285,61 +285,70 @@ $Script:Runtime = Measure-Command -Expression {
 
       } else {
         # This isn't a runbook recommendation...
+        # Getting the recommendation details from the YAML file...
         $RecomTitle = $Script:ServicesYAMLContent | Where-Object { $_.aprlGuid -eq $Recom.recommendationId }
 
+        # Filtering recommendations not superceded or present in Advisor...
         if ([string]::IsNullOrEmpty($RecomTitle.recommendationTypeId) -or (![string]::IsNullOrEmpty($RecomTitle.recommendationTypeId) -and $RecomTitle.recommendationTypeId -notin $CoreAdvisories.recommendationId)) {
+          # Getting tickets related to the Impacted resource...
           $Ticket = $Script:SupportTickets | Where-Object { $_.'Related Resource' -eq $Recom.id }
-          if (($RecomTitle.recommendationMetadataState -eq 'Active') -or $Recom.validationAction -eq 'IMPORTANT - Recommendation cannot be validated with ARGs - Validate Resources manually' -or $Recom.validationAction -eq 'IMPORTANT - Query under development - Validate Resources manually' ) {
-            $Tickets = if ($Ticket.'Ticket ID'.count -gt 1) { $Ticket.'Ticket ID' | ForEach-Object { $_ + ' /' } }else { $Ticket.'Ticket ID' }
-            $Tickets = [string]$Tickets
-            $Tickets = if ($Tickets -like '* /*') { $Tickets -replace '.$' }else { $Tickets }
-            $tmp = @{
-              'How was the resource/recommendation validated or what actions need to be taken?' = $Recom.validationAction;
-              recommendationId                                                                  = $Recom.recommendationId;
-              recommendationTitle                                                               = $RecomTitle.description;
-              resourceType                                                                      = $RecomTitle.recommendationResourceType;
-              impact                                                                            = $RecomTitle.recommendationImpact;
-              subscriptionId                                                                    = $Recom.subscriptionId;
-              resourceGroup                                                                     = $Recom.resourceGroup;
-              name                                                                              = $Recom.name;
-              id                                                                                = $Recom.id;
-              location                                                                          = $Recom.location;
-              param1                                                                            = $Recom.param1;
-              param2                                                                            = $Recom.param2;
-              param3                                                                            = $Recom.param3;
-              param4                                                                            = $Recom.param4;
-              param5                                                                            = $Recom.param5;
-              supportTicketId                                                                   = $Tickets;
-              source                                                                            = $Recom.selector;
-              checkName                                                                         = $Recom.checkName;
-              'WAF Pillar'                                                                      = 'Reliability';
-              tagged                                                                            = $Recom.tagged
+          # Filtering only active recommendations...
+          if ($RecomTitle.recommendationMetadataState -eq 'Active'){
+            # Filtering only recommendations, generic resource types without recommendations will be populated next
+            if ( $Recom.validationAction -ne 'IMPORTANT - Resource Type is not available in either APRL or Advisor - Validate Resources manually if Applicable, if not Delete this line') {
+              $Tickets = if ($Ticket.'Ticket ID'.count -gt 1) { $Ticket.'Ticket ID' | ForEach-Object { $_ + ' /' } }else { $Ticket.'Ticket ID' }
+              $Tickets = [string]$Tickets
+              $Tickets = if ($Tickets -like '* /*') { $Tickets -replace '.$' }else { $Tickets }
+              $tmp = @{
+                'How was the resource/recommendation validated or what actions need to be taken?' = $Recom.validationAction;
+                recommendationId                                                                  = $Recom.recommendationId;
+                recommendationTitle                                                               = $RecomTitle.description;
+                resourceType                                                                      = $RecomTitle.recommendationResourceType;
+                impact                                                                            = $RecomTitle.recommendationImpact;
+                subscriptionId                                                                    = $Recom.subscriptionId;
+                resourceGroup                                                                     = $Recom.resourceGroup;
+                name                                                                              = $Recom.name;
+                id                                                                                = $Recom.id;
+                location                                                                          = $Recom.location;
+                param1                                                                            = $Recom.param1;
+                param2                                                                            = $Recom.param2;
+                param3                                                                            = $Recom.param3;
+                param4                                                                            = $Recom.param4;
+                param5                                                                            = $Recom.param5;
+                supportTicketId                                                                   = $Tickets;
+                source                                                                            = $Recom.selector;
+                checkName                                                                         = $Recom.checkName;
+                'WAF Pillar'                                                                      = 'Reliability';
+                tagged                                                                            = $Recom.tagged
+              }
+              $Script:MergedRecommendation += $tmp
+            } 
+            # Populating resource types without recommendations
+            else {
+              $tmp = @{
+                'How was the resource/recommendation validated or what actions need to be taken?' = $Recom.validationAction;
+                recommendationId                                                                  = '';
+                recommendationTitle                                                               = $RecomTitle.description;
+                resourceType                                                                      = $Recom.recommendationId;
+                impact                                                                            = '';
+                subscriptionId                                                                    = $Recom.subscriptionId;
+                resourceGroup                                                                     = $Recom.resourceGroup;
+                name                                                                              = $Recom.name;
+                id                                                                                = $Recom.id;
+                location                                                                          = $Recom.location;
+                param1                                                                            = $Recom.param1;
+                param2                                                                            = $Recom.param2;
+                param3                                                                            = $Recom.param3;
+                param4                                                                            = $Recom.param4;
+                param5                                                                            = $Recom.param5;
+                supportTicketId                                                                   = $Tickets;
+                source                                                                            = $Recom.selector;
+                checkName                                                                         = $Recom.checkName;
+                'WAF Pillar'                                                                      = 'Reliability';
+                tagged                                                                            = $Recom.tagged
+              }
+              $Script:MergedRecommendation += $tmp
             }
-            $Script:MergedRecommendation += $tmp
-          } elseif ($Recom.validationAction -eq 'IMPORTANT - Resource Type is not available in either APRL or Advisor - Validate Resources manually if Applicable, if not Delete this line' ) {
-            $tmp = @{
-              'How was the resource/recommendation validated or what actions need to be taken?' = $Recom.validationAction;
-              recommendationId                                                                  = '';
-              recommendationTitle                                                               = $RecomTitle.description;
-              resourceType                                                                      = $Recom.recommendationId;
-              impact                                                                            = '';
-              subscriptionId                                                                    = $Recom.subscriptionId;
-              resourceGroup                                                                     = $Recom.resourceGroup;
-              name                                                                              = $Recom.name;
-              id                                                                                = $Recom.id;
-              location                                                                          = $Recom.location;
-              param1                                                                            = $Recom.param1;
-              param2                                                                            = $Recom.param2;
-              param3                                                                            = $Recom.param3;
-              param4                                                                            = $Recom.param4;
-              param5                                                                            = $Recom.param5;
-              supportTicketId                                                                   = $Tickets;
-              source                                                                            = $Recom.selector;
-              checkName                                                                         = $Recom.checkName;
-              'WAF Pillar'                                                                      = 'Reliability';
-              tagged                                                                            = $Recom.tagged
-            }
-            $Script:MergedRecommendation += $tmp
           }
         }
       }
@@ -1059,7 +1068,7 @@ $Script:Runtime = Measure-Command -Expression {
   }
 
   #Call the functions
-  $Script:Version = '2.1.18'
+  $Script:Version = '2.1.19'
   Write-Host 'Version: ' -NoNewline
   Write-Host $Script:Version -ForegroundColor DarkBlue
 

--- a/tools/Version.json
+++ b/tools/Version.json
@@ -2,7 +2,7 @@
   {
 
     "Collector": "2.1.19",
-    "Analyzer": "2.1.18",
+    "Analyzer": "2.1.19",
     "Generator": "2.1.7"
   }
 ]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Fix disabled recommendations Recommendations unexpected appearing under ImpactedResources of Generated Action Plan.

Also fix an incorrect reference of the recommendation 855ca19a-6518-4f2e-9e5a-01796fbca9f8 for "serverFarm" instead of "sites"

## Related Issues/Work Items

Resolves #610 

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [X] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
