### PR TITLE
refactor: Limit learnmorelink to one link per recommendation

### DIFF
--- a/.github/scripts/schemas/aprl-schema.yaml
+++ b/.github/scripts/schemas/aprl-schema.yaml
@@ -17,7 +17,7 @@ recommendation:
   pgVerified: bool()
   automationAvailable: bool()
   tags: any(enum('AI','AVD', 'AVS', 'HPC', 'SAP'), null())
-  learnMoreLink: list(include('linkItem'), required=False, min=1)
+  learnMoreLink: list(include('linkItem'), required=False, max=1)
 
 linkItem:
   name: str()

--- a/azure-resources/AVS/privateClouds/recommendations.yaml
+++ b/azure-resources/AVS/privateClouds/recommendations.yaml
@@ -63,8 +63,6 @@
   automationAvailable: true
   tags: null
   learnMoreLink:
-    - name: Implement high availability
-      url: "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/infrastructure#implement-high-availability"
     - name: Stretched Clusters
       url: "https://learn.microsoft.com/en-us/azure/azure-vmware/deploy-vsan-stretched-clusters"
 

--- a/azure-resources/ApiManagement/service/recommendations.yaml
+++ b/azure-resources/ApiManagement/service/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: Change your API Management service tier
       url: "https://learn.microsoft.com/en-us/azure/api-management/upgrade-and-scale#change-your-api-management-service-tier"
-    - name: Migrate Azure API Management to availability zone support
-      url: "https://learn.microsoft.com/en-us/azure/reliability/migrate-api-mgt"
 
 - description: Enable Availability Zones on Premium API Management instances
   aprlGuid: 740f2c1c-8857-4648-80eb-47d2c56d5a50
@@ -33,8 +31,6 @@
   learnMoreLink:
     - name: Ensure API Management availability and reliability
       url: "https://learn.microsoft.com/en-us/azure/api-management/high-availability#availability-zones"
-    - name: Migrate Azure API Management to availability zone support
-      url: "https://learn.microsoft.com/en-us/azure/reliability/migrate-api-mgt"
 
 - description: Azure API Management platform version should be stv2
   aprlGuid: e35cf148-8eee-49d1-a1c9-956160f99e0b
@@ -52,8 +48,6 @@
   learnMoreLink:
     - name: Azure API Management - stv1 platform retirement (August 2024)
       url: "https://learn.microsoft.com/en-us/azure/api-management/breaking-changes/stv1-platform-retirement-august-2024"
-    - name: Azure API Management compute platform
-      url: "https://learn.microsoft.com/en-us/azure/api-management/compute-infrastructure"
 
 - description: Enable auto-scale for production workloads on API Management services
   aprlGuid: c79680ea-de85-44fa-a596-f31fa17a952f
@@ -105,5 +99,3 @@
   learnMoreLink:
     - name: Add caching to improve performance in Azure API Management
       url: "https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-cache"
-    - name: Use an external cache in Azure API Management
-      url: "https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-cache-external"

--- a/azure-resources/Automation/automationAccounts/recommendations.yaml
+++ b/azure-resources/Automation/automationAccounts/recommendations.yaml
@@ -14,5 +14,3 @@
   learnMoreLink:
     - name: Disaster recovery for Automation accounts
       url: "https://learn.microsoft.com/en-us/azure/automation/automation-disaster-recovery?tabs=win-hrw%2Cps-script%2Coption-one"
-    - name: Disaster recovery scenarios for cloud and hybrid jobs
-      url: "https://learn.microsoft.com/en-us/azure/automation/automation-disaster-recovery?tabs=win-hrw%2Cps-script%2Coption-one#scenarios-for-cloud-and-hybrid-jobs"

--- a/azure-resources/Cdn/profiles/recommendations.yaml
+++ b/azure-resources/Cdn/profiles/recommendations.yaml
@@ -31,10 +31,6 @@
   learnMoreLink:
     - name: REST API Reference
       url: "https://learn.microsoft.com/rest/api/frontdoor/"
-    - name: Client library for Java
-      url: "https://learn.microsoft.com/java/api/overview/azure/resourcemanager-frontdoor-readme?view=azure-java-preview"
-    - name: SDK for Python
-      url: "https://learn.microsoft.com/python/api/overview/azure/front-door?view=azure-python"
 
 - description: Configure logs
   aprlGuid: 1ad74c3c-e3d7-0046-b83f-a2199974ef15
@@ -52,10 +48,6 @@
   learnMoreLink:
     - name: Monitor metrics and logs in Azure Front Door
       url: "https://learn.microsoft.com/azure/frontdoor/front-door-diagnostics?pivots=front-door-standard-premium"
-    - name: WAF logs
-      url: "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-monitor?pivots=front-door-standard-premium#waf-logs"
-    - name: Configure Azure Front Door logs
-      url: "https://learn.microsoft.com/azure/frontdoor/standard-premium/how-to-logs"
 
 - description: Use end-to-end TLS
   aprlGuid: d9bd6780-0d6f-cd4c-bc66-8ddcab12f3d1
@@ -259,4 +251,4 @@
   tags: null
   learnMoreLink:
     - name: Compare pricing between Azure Front Door tiers
-      url: https://learn.microsoft.com/en-us/azure/frontdoor/understanding-pricing
+      url: "https://learn.microsoft.com/en-us/azure/frontdoor/understanding-pricing"

--- a/azure-resources/Compute/disks/recommendations.yaml
+++ b/azure-resources/Compute/disks/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: Azure Shared Disk Introduction
       url: "https://learn.microsoft.com/azure/virtual-machines/disks-shared"
-    - name: Enable Shared Disks
-      url: "https://learn.microsoft.com/azure/virtual-machines/disks-shared-enable?tabs=azure-portal"
 
 - description: Use Azure Disks with Zone Redundant Storage for higher resiliency and availability
   aprlGuid: fa0cf4f5-0b21-47b7-89a9-ee936f193ce1

--- a/azure-resources/Compute/galleries/recommendations.yaml
+++ b/azure-resources/Compute/galleries/recommendations.yaml
@@ -31,8 +31,6 @@
   learnMoreLink:
     - name: Compute Gallery best practices
       url: "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices"
-    - name: Zone-redundant storage
-      url: "https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy#zone-redundant-storage"
 
 - description: Consider creating TrustedLaunchSupported images where possible
   aprlGuid: 1c5e1e58-4e56-491c-8529-10f37af9d4ed
@@ -50,10 +48,6 @@
   learnMoreLink:
     - name: Compute Gallery best practices
       url: "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices"
-    - name: Generation 1 vs Generation 2 in Hyper-V
-      url: "https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/plan/should-i-create-a-generation-1-or-2-virtual-machine-in-hyper-v"
-    - name: Images in Compute gallery
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/shared-image-galleries?tabs=azure-cli"
 
 - description: Create Image Versions replicas in secondary region
   aprlGuid: b14ee8ed-7d27-447b-b6fb-6472cb5f4b75

--- a/azure-resources/Compute/virtualMachineScaleSets/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachineScaleSets/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: When to use VMSS instead of VMs
       url: "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-design-overview#when-to-use-scale-sets-instead-of-virtual-machines"
-    - name: Azure Well-Architected Framework review - Virtual Machines and Scale Sets
-      url: "https://learn.microsoft.com/azure/well-architected/services/compute/virtual-machines/virtual-machines-review"
 
 - description: Enable Azure Virtual Machine Scale Set Application Health Monitoring
   aprlGuid: 94794d2a-eff0-2345-9b67-6f9349d0a627
@@ -67,8 +65,6 @@
   learnMoreLink:
     - name: Get started with autoscale in Azure
       url: "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-get-started?WT.mc_id=Portal-Microsoft_Azure_Monitoring"
-    - name: Overview of autoscale in Azure
-      url: "https://learn.microsoft.com/azure/azure-monitor/autoscale/autoscale-overview"
 
 - description: Enable Predictive autoscale and configure at least for Forecast Only
   aprlGuid: 3f85a51c-e286-9f44-b4dc-51d00768696c
@@ -120,8 +116,6 @@
   learnMoreLink:
     - name: Create a Virtual Machine Scale Set that uses Availability Zones
       url: "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones"
-    - name: Update scale set to add availability zones
-      url: "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones?tabs=cli-1%2Cportal-2#update-scale-set-to-add-availability-zones"
 
 - description: Set Patch orchestration options to Azure-orchestrated
   aprlGuid: e4ffd7b0-ba24-c84e-9352-ba4819f908c0
@@ -139,8 +133,6 @@
   learnMoreLink:
     - name: Automatic VM Guest Patching for Azure VMs
       url: "https://learn.microsoft.com/azure/virtual-machines/automatic-vm-guest-patching"
-    - name: Auto OS Image Upgrades
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-upgrade"
 
 - description: Upgrade VMSS Image versions scheduled to be deprecated or already retired
   aprlGuid: 83d61669-7bd6-9642-a305-175db8adcdf4

--- a/azure-resources/Compute/virtualMachines/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachines/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: What has changed with Flexible orchestration mode
       url: "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-orchestration-modes#what-has-changed-with-flexible-orchestration-mode"
-    - name: Attach or detach a Virtual Machine to or from a Virtual Machine Scale Set
-      url: "https://learn.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-attach-detach-vm?branch=main&tabs=portal-1%2Cportal-2%2Cportal-3"
 
 - description: Deploy VMs across Availability Zones
   aprlGuid: 2bd0be95-a825-6f47-a8c6-3db1fb5eb387
@@ -67,8 +65,6 @@
   learnMoreLink:
     - name: Resiliency checklist for Virtual Machines
       url: "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#virtual-machines"
-    - name: Run a test failover (disaster recovery drill) to Azure
-      url: "https://learn.microsoft.com/azure/site-recovery/site-recovery-test-failover-to-azure"
 
 - description: Use Managed Disks for VM disks
   aprlGuid: 122d11d7-b91f-8747-a562-f56b79bcfbdc
@@ -86,10 +82,6 @@
   learnMoreLink:
     - name: Migrate your Azure unmanaged disks by Sep 30, 2025
       url: "https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation"
-    - name: Migrate Windows VM from unmanaged disks to managed disks
-      url: "https://learn.microsoft.com/azure/virtual-machines/windows/convert-unmanaged-to-managed-disks"
-    - name: Migrate Linux VM from unmanaged disks to managed disks
-      url: "https://learn.microsoft.com/azure/virtual-machines/linux/convert-unmanaged-to-managed-disks"
 
 - description: Host database data on a data disk
   aprlGuid: 4ea2878f-0d69-8d4a-b715-afc10d1e538e
@@ -107,8 +99,6 @@
   learnMoreLink:
     - name: Introduction to Azure managed disks - Data disks
       url: "https://learn.microsoft.com/azure/virtual-machines/managed-disks-overview#data-disk"
-    - name: Azure managed disk types
-      url: "https://learn.microsoft.com/azure/virtual-machines/disks-types"
 
 - description: Backup VMs with Azure Backup service
   aprlGuid: 1981f704-97b9-b645-9c57-33f8ded9261a
@@ -279,8 +269,6 @@
   learnMoreLink:
     - name: Policy-driven governance
       url: "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-principles#policy-driven-governance"
-    - name: Azure Policy Regulatory Compliance controls for Azure Virtual Machines
-      url: "https://learn.microsoft.com/azure/virtual-machines/security-policy"
 
 - description: Virtual Machines should have Azure Disk Encryption or EncryptionAtHost enabled
   aprlGuid: f0a97179-133a-6e4f-8a49-8a44da73ffce
@@ -315,8 +303,6 @@
   learnMoreLink:
     - name: Overview of VM insights
       url: "https://learn.microsoft.com/azure/azure-monitor/vm/vminsights-overview"
-    - name: Did the extension install properly?
-      url: "https://learn.microsoft.com/azure/azure-monitor/vm/vminsights-troubleshoot#did-the-extension-install-properly"
 
 - description: Configure monitoring for all Azure Virtual Machines
   aprlGuid: 4a9d8973-6dba-0042-b3aa-07924877ebd5
@@ -402,8 +388,6 @@
   learnMoreLink:
     - name: Microsoft Azure Boost
       url: "https://learn.microsoft.com/azure/azure-boost/overview"
-    - name: Announcing the general availability of Azure Boost
-      url: "https://aka.ms/AzureBoostGABlog"
 
 - description: Enable Scheduled Events for Maintenance sensitive workload VMs
   aprlGuid: 2de8fa5e-14f4-4c4c-857f-1520f87a629f
@@ -421,10 +405,6 @@
   learnMoreLink:
     - name: Monitor scheduled events for your Azure VMs
       url: "https://learn.microsoft.com/azure/virtual-machines/windows/scheduled-event-service"
-    - name: Azure Metadata Service Scheduled Events for Linux VMs
-      url: "https://learn.microsoft.com/azure/virtual-machines/linux/scheduled-events"
-    - name: Azure Metadata Service Scheduled Events for Windows VMs
-      url: "https://learn.microsoft.com/azure/virtual-machines/windows/scheduled-events"
 
 - description: Reserve Compute Capacity for critical workloads
   aprlGuid: 302fda08-ee65-4fbe-a916-6dc0b33169c4

--- a/azure-resources/ContainerRegistry/registries/recommendations.yaml
+++ b/azure-resources/ContainerRegistry/registries/recommendations.yaml
@@ -48,8 +48,6 @@
   learnMoreLink:
     - name: Registry best practices - Enable geo-replication
       url: "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#geo-replicate-multi-region-deployments"
-    - name: Geo-Replicate Container Registry
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-geo-replication"
 
 - description: Use Repository namespaces
   aprlGuid: a5a0101a-a240-8742-90ba-81dbde9a0c0c
@@ -101,8 +99,6 @@
   learnMoreLink:
     - name: Registry best practices - Manage registry size
       url: "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#manage-registry-size"
-    - name: Retention Policy
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-retention-policy#about-the-retention-policy"
 
 - description: Disable anonymous pull access
   aprlGuid: 03f4a7d8-c5b4-7842-8e6e-14997a34842b
@@ -135,8 +131,6 @@
   automationAvailable: false
   tags: null
   learnMoreLink:
-    - name: Monitoring Azure Container Registry data reference - Resource Logs
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service-reference#resource-logs"
     - name: Monitor Azure Container Registry - Enable diagnostic logs
       url: "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service#collection-and-routing"
 
@@ -154,8 +148,6 @@
   automationAvailable: false
   tags: null
   learnMoreLink:
-    - name: Monitoring Azure Container Registry data reference
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service-reference#metrics"
     - name: Monitor Azure Container Registry
       url: "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service"
 

--- a/azure-resources/ContainerService/managedClusters/recommendations.yaml
+++ b/azure-resources/ContainerService/managedClusters/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: AKS Availability Zones
       url: "https://learn.microsoft.com/en-us/azure/aks/availability-zones"
-    - name: Zone Balancing
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones#zone-balancing"
 
 - description: Isolate system and application pods
   aprlGuid: 5ee083cd-6ac3-4a83-8913-9549dd36cf56
@@ -50,10 +48,6 @@
   learnMoreLink:
     - name: Entra integration
       url: "https://learn.microsoft.com/en-us/azure/aks/concepts-identity#azure-ad-integration"
-    - name: Use Azure role-based access control for AKS
-      url: "https://learn.microsoft.com/en-us/azure/aks/manage-azure-rbac?source=recommendations"
-    - name: Manage AKS local accounts
-      url: "https://learn.microsoft.com/en-us/azure/aks/manage-local-accounts-managed-azure-ad?source=recommendations"
 
 - description: Configure Azure CNI networking for dynamic allocation of IPs or use CNI overlay
   aprlGuid: c22db132-399b-4e7c-995d-577a60881be8
@@ -71,8 +65,6 @@
   learnMoreLink:
     - name: Configure Azure CNI networking
       url: "https://learn.microsoft.com/en-us/azure/aks/configure-azure-cni-dynamic-ip-allocation"
-    - name: Configure Azure CNI Overlay networking
-      url: "https://learn.microsoft.com/en-us/azure/aks/azure-cni-overlay"
 
 - description: Enable the cluster auto-scaler on an existing cluster
   aprlGuid: 902c82ff-4910-4b61-942d-0d6ef7f39b67
@@ -90,12 +82,6 @@
   learnMoreLink:
     - name: Use the Cluster Autoscaler on AKS
       url: "https://learn.microsoft.com/azure/aks/cluster-autoscaler?tabs=azure-cli"
-    - name: Best practices for advanced scheduler features
-      url: "https://learn.microsoft.com/azure/aks/operator-best-practices-advanced-scheduler"
-    - name: Node pool scaling considerations and best practices
-      url: "https://learn.microsoft.com/azure/aks/best-practices-performance-scale-large#node-pool-scaling"
-    - name: Best practices for basic scheduler features
-      url: "https://learn.microsoft.com/azure/aks/operator-best-practices-scheduler"
 
 - description: Back up Azure Kubernetes Service
   aprlGuid: 269a9f1a-6675-460a-831e-b05a887a8c4b
@@ -113,8 +99,6 @@
   learnMoreLink:
     - name: AKS Backups
       url: "https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-cluster-backup"
-    - name: Best Practices for AKS Backups
-      url: "https://learn.microsoft.com/en-us/azure/aks/operator-best-practices-storage"
 
 - description: Use zone-redundant storage for persistent volumes when running multi-zone AKS
   aprlGuid: d3111036-355d-431b-ab49-8ddad042800b
@@ -132,14 +116,6 @@
   learnMoreLink:
     - name: Availability zones overview
       url: "https://learn.microsoft.com/azure/reliability/availability-zones-overview?tabs=azure-cli"
-    - name: Zone-redundant storage
-      url: "https://learn.microsoft.com/azure/storage/common/storage-redundancy#zone-redundant-storage"
-    - name: ZRS disks
-      url: "https://learn.microsoft.com/azure/virtual-machines/disks-redundancy#zone-redundant-storage-for-managed-disks"
-    - name: Convert a disk from LRS to ZRS
-      url: "https://learn.microsoft.com/azure/virtual-machines/disks-migrate-lrs-zrs"
-    - name: Enable multi-zone storage redundancy in Azure Container Storage
-      url: "https://learn.microsoft.com/azure/storage/container-storage/enable-multi-zone-redundancy"
 
 - description: Upgrade Persistent Volumes using in-tree drivers to Azure CSI drivers
   aprlGuid: b002c030-72e6-4a37-8217-1cb276c43169
@@ -157,8 +133,6 @@
   learnMoreLink:
     - name: CSI Storage Drivers
       url: "https://learn.microsoft.com/azure/aks/csi-storage-drivers"
-    - name: CSI Migrate in Tree Volumes
-      url: "https://learn.microsoft.com/azure/aks/csi-migrate-in-tree-volumes"
 
 - description: Implement Resource Quota to ensure that Kubernetes resources do not exceed hard resource limits
   aprlGuid: 9a1c17e5-c9a0-43db-b920-adaf54d1bcb7
@@ -193,8 +167,6 @@
   learnMoreLink:
     - name: Virtual Nodes
       url: "https://learn.microsoft.com/azure/aks/virtual-nodes"
-    - name: Azure Container Instances
-      url: "https://learn.microsoft.com/azure/container-instances/container-instances-overview"
 
 - description: Update AKS tier to Standard or Premium
   aprlGuid: 0611251f-e70f-4243-8ddd-cfe894bec2e7
@@ -212,8 +184,6 @@
   learnMoreLink:
     - name: Pricing Tiers
       url: "https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers"
-    - name: AKS Baseline Architecture
-      url: "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks?toc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Faks%2Ftoc.json&bc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#kubernetes-api-server-sla"
 
 - description: Enable AKS Monitoring
   aprlGuid: dcaf8128-94bd-4d53-9235-3a0371df6b74
@@ -248,10 +218,6 @@
   learnMoreLink:
     - name: Ephemeral OS disk
       url: "https://learn.microsoft.com/azure/aks/concepts-storage#ephemeral-os-disk"
-    - name: Configure an AKS cluster
-      url: "https://learn.microsoft.com/azure/aks/cluster-configuration"
-    - name: Everything you want to know about ephemeral OS disks and AKS
-      url: "https://learn.microsoft.com/samples/azure-samples/aks-ephemeral-os-disk/aks-ephemeral-os-disk/"
 
 - description: Enable and remediate Azure Policies configured for AKS
   aprlGuid: 26ebaf1f-c70d-4ebd-8641-4b60a0ce0094
@@ -269,8 +235,6 @@
   learnMoreLink:
     - name: AKS Baseline - Policy Management
       url: "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks?toc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Faks%2Ftoc.json&bc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#policy-management"
-    - name: Built-in Policy Definitions for AKS
-      url: "https://learn.microsoft.com/en-us/azure/aks/policy-reference"
 
 - description: Enable GitOps when using DevOps frameworks
   aprlGuid: 5f3cbd68-692a-4121-988c-9770914859a9
@@ -288,8 +252,6 @@
   learnMoreLink:
     - name: GitOps with AKS
       url: "https://learn.microsoft.com/en-us/azure/architecture/guide/aks/aks-cicd-github-actions-and-gitops"
-    - name: GitOps for AKS - Reference Architecture
-      url: "https://learn.microsoft.com/en-us/azure/architecture/example-scenario/gitops-aks/gitops-blueprint-aks"
 
 - description: Use pod topology spread constraints to ensure that pods are spread across different nodes or zones
   aprlGuid: 928fcc6f-5e9a-42d9-9bd4-260af42de2e5
@@ -307,8 +269,6 @@
   learnMoreLink:
     - name: Topology Spread Constraints
       url: "https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/"
-    - name: Assign Pod Node
-      url: "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/"
 
 - description: Configures Pods Liveness, Readiness, and Startup Probes
   aprlGuid: cd6791b1-c60e-4b37-ac98-9897b1e6f4b8
@@ -326,8 +286,6 @@
   learnMoreLink:
     - name: Configure probes
       url: "https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/"
-    - name: Assign Pod Node
-      url: "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/"
 
 - description: Use deployments with multiple replicas in production applications to guarantee availability
   aprlGuid: bcfe71f1-ebed-49e5-a84a-193b81ad5d27
@@ -396,8 +354,6 @@
   learnMoreLink:
     - name: Configure PDBs
       url: "https://kubernetes.io/docs/tasks/run-application/configure-pdb/"
-    - name: Plan availability using PDBs
-      url: "https://learn.microsoft.com/azure/aks/operator-best-practices-scheduler#plan-for-availability-using-pod-disruption-budgets"
 
 - description: Nodepool subnet size needs to accommodate maximum auto-scale settings
   aprlGuid: e620fa98-7a40-41a0-bfc9-b4407297fb58

--- a/azure-resources/Dashboard/grafana/recommendations.yaml
+++ b/azure-resources/Dashboard/grafana/recommendations.yaml
@@ -12,7 +12,5 @@
   automationAvailable: true
   tags: null
   learnMoreLink:
-    - name: Azure Managed Grafana service reliability
-      url: "https://learn.microsoft.com/azure/managed-grafana/high-availability"
     - name: Enable zone redundancy in Azure Managed Grafana
       url: "https://learn.microsoft.com/Azure/managed-grafana/how-to-enable-zone-redundancy"

--- a/azure-resources/Databricks/workspaces/recommendations.yaml
+++ b/azure-resources/Databricks/workspaces/recommendations.yaml
@@ -80,8 +80,6 @@
   automationAvailable: false
   tags: null
   learnMoreLink:
-    - name: Best practices for reliability
-      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices"
     - name: Databricks enhanced autoscaling
       url: "https://learn.microsoft.com/azure/databricks/delta-live-tables/settings#use-autoscaling-to-increase-efficiency-and-reduce-resource-usage"
 
@@ -460,10 +458,6 @@
   learnMoreLink:
     - name: Azure Databricks control plane addresses
       url: "https://learn.microsoft.com/azure/databricks/resources/supported-regions#--azure-databricks-control-plane-addresses"
-    - name: Migrate - maintained by Databricks Inc.
-      url: "https://github.com/databrickslabs/migrate"
-    - name: Databricks Terraform Exporter - maintained by Databricks Inc. (Experimental)
-      url: "https://registry.terraform.io/providers/databricks/databricks/latest/docs/guides/experimental-exporter"
 
 - description: Define alternate VM SKUs
   aprlGuid: 028593be-956e-4736-bccf-074cb10b92f4
@@ -481,8 +475,6 @@
   learnMoreLink:
     - name: Compute configuration best practices
       url: "https://learn.microsoft.com/azure/databricks/compute/cluster-config-best-practices"
-    - name: GPU-enabled compute
-      url: "https://learn.microsoft.com/azure/databricks/compute/gpu"
 
 - description: Use managed services where possible
   aprlGuid: e94da1f8-33e7-48a6-b301-72f19a53bc29

--- a/azure-resources/Devices/iotHubs/recommendations.yaml
+++ b/azure-resources/Devices/iotHubs/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: Import and export IoT Hub device identities in bulk
       url: "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-bulk-identity-mgmt"
-    - name: IoT Hub high availability and disaster recovery
-      url: "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr#manual-failover"
 
 - description: Do not use free tier
   aprlGuid: eeba3a49-fef0-481f-a471-7ff01139b474
@@ -67,10 +65,6 @@
   learnMoreLink:
     - name: IoT Hub Device Provisioning Service (DPS) terminology
       url: "https://learn.microsoft.com/en-us/azure/iot-dps/concepts-service"
-    - name: Best practices for large-scale IoT device deployments
-      url: "https://learn.microsoft.com/en-us/azure/iot-dps/concepts-deploy-at-scale"
-    - name: IoT Hub Device Provisioning Service high availability and disaster recovery
-      url: "https://learn.microsoft.com/en-us/azure/iot-dps/iot-dps-ha-dr"
 
 - description: Define Failover Guidelines
   aprlGuid: 02568a5d-335e-4e51-9f7c-fe2ada977300

--- a/azure-resources/DocumentDB/databaseAccounts/recommendations.yaml
+++ b/azure-resources/DocumentDB/databaseAccounts/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: Distribute data globally with Azure Cosmos DB
       url: "https://learn.microsoft.com/azure/cosmos-db/distribute-data-globally"
-    - name: Tips for building highly available applications
-      url: "https://learn.microsoft.com/azure/cosmos-db/high-availability#tips-for-building-highly-available-applications"
 
 - description: Enable service-managed failover for multi-region accounts with single write region
   aprlGuid: 9cabded7-a1fc-6e4a-944b-d7dd98ea31a2
@@ -67,8 +65,6 @@
   learnMoreLink:
     - name: Distribute data globally with Azure Cosmos DB
       url: "https://learn.microsoft.com/azure/cosmos-db/distribute-data-globally"
-    - name: Conflict resolution types and resolution policies in Azure Cosmos DB
-      url: "https://learn.microsoft.com/azure/cosmos-db/conflict-resolution-policies"
 
 - description: Configure continuous backup mode
   aprlGuid: e544520b-8505-7841-9e77-1f1974ee86ec

--- a/azure-resources/Insights/activityLogAlerts/recommendations.yaml
+++ b/azure-resources/Insights/activityLogAlerts/recommendations.yaml
@@ -14,7 +14,3 @@
   learnMoreLink:
     - name: Resource Health
       url: "https://learn.microsoft.com/en-us/azure/service-health/resource-health-overview"
-    - name: Configure Resource Health alerts in the Azure portal
-      url: "https://learn.microsoft.com/en-us/azure/service-health/resource-health-alert-monitor-guide#create-a-resource-health-alert-rule-in-the-azure-portal"
-    - name: Alerts Health
-      url: "https://learn.microsoft.com/en-us/azure/service-health/alerts-activity-log-service-notifications-portal"

--- a/azure-resources/MachineLearningServices/workspaces/recommendations.yaml
+++ b/azure-resources/MachineLearningServices/workspaces/recommendations.yaml
@@ -48,8 +48,6 @@
   learnMoreLink:
     - name: Failover for business continuity and disaster recovery
       url: "https://learn.microsoft.com/en-us/azure/machine-learning/how-to-high-availability-machine-learning?view=azureml-api-2"
-    - name: Compute targets in Azure Machine Learning
-      url: "https://learn.microsoft.com/en-us/azure/machine-learning/concept-compute-target?view=azureml-api-2"
 
 - description: Ensure checkpoints are used for AI training models
   aprlGuid: 98f15850-f31e-4fb2-8874-74f5aabbcf91
@@ -116,8 +114,6 @@
   automationAvailable: false
   tags: null
   learnMoreLink:
-    - name: NC sizes series
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nc-series?tabs=sizebasic"
     - name: Migration Guide for GPU Compute Workloads in Azure
       url: "https://learn.microsoft.com/en-us/azure/virtual-machines/n-series-migration"
 

--- a/azure-resources/NetApp/netAppAccounts/recommendations.yaml
+++ b/azure-resources/NetApp/netAppAccounts/recommendations.yaml
@@ -167,8 +167,6 @@
   learnMoreLink:
     - name: Azure Policy definitions for Azure NetApp Files | Microsoft Learn
       url: "https://learn.microsoft.com/azure/azure-netapp-files/azure-policy-definitions"
-    - name: Creating custom policy definitions | Microsoft Learn
-      url: "https://learn.microsoft.com/azure/governance/policy/tutorials/create-custom-policy-definition"
 
 - description: Restrict default access to Azure NetApp Files volumes
   aprlGuid: cfa2244b-5436-47de-8287-b217875d3b0a
@@ -186,14 +184,6 @@
   learnMoreLink:
     - name: Configure network features for an Azure NetApp Files volume
       url: "https://learn.microsoft.com/azure/azure-netapp-files/configure-network-features"
-    - name: Manage SMB share ACLs in Azure NetApp Files
-      url: "https://learn.microsoft.com/azure/azure-netapp-files/manage-smb-share-access-control-lists"
-    - name: Configure export policy for NFS or dual-protocol volumes
-      url: "https://learn.microsoft.com/azure/azure-netapp-files/azure-netapp-files-configure-export-policy"
-    - name: Configure access control lists on NFSv4.1 volumes for Azure NetApp Files
-      url: "https://learn.microsoft.com/azure/azure-netapp-files/configure-access-control-lists"
-    - name: Configure Unix permissions and change ownership mode for NFS and dual-protocol volumes
-      url: "https://learn.microsoft.com/azure/azure-netapp-files/configure-unix-permissions-change-ownership-mode"
 
 - description: Make use of SMB continuous availability for supported applications
   aprlGuid: d1e7ccc3-e6c1-40e9-a36e-fd134711c808

--- a/azure-resources/Network/applicationGateways/recommendations.yaml
+++ b/azure-resources/Network/applicationGateways/recommendations.yaml
@@ -31,14 +31,6 @@
   learnMoreLink:
     - name: Application Gateway Security
       url: "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway#security"
-    - name: Application Gateway SSL Overview
-      url: "https://learn.microsoft.com/azure/application-gateway/ssl-overview"
-    - name: Application Gateway SSL Policy Overview
-      url: "https://learn.microsoft.com/azure/application-gateway/application-gateway-ssl-policy-overview"
-    - name: Application Gateway KeyVault Certs
-      url: "https://learn.microsoft.com/azure/application-gateway/key-vault-certs"
-    - name: Application Gateway SSL Cert Management
-      url: "https://learn.microsoft.com/azure/application-gateway/ssl-certificate-management"
 
 - description: Enable Web Application Firewall policies
   aprlGuid: 8d9223c4-730d-ca47-af88-a9a024c37270
@@ -54,8 +46,6 @@
   automationAvailable: true
   tags: null
   learnMoreLink:
-    - name: Well-Architected Framework Application Gateway Overview
-      url: "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway"
     - name: Application Gateway - Web Application Firewall
       url: "https://learn.microsoft.com/azure/application-gateway/features#web-application-firewall"
 
@@ -75,10 +65,6 @@
   learnMoreLink:
     - name: Application Gateway Overview V2
       url: "https://learn.microsoft.com/azure/application-gateway/overview-v2"
-    - name: Application Gateway Feature Comparison Between V1 and V2
-      url: "https://learn.microsoft.com/azure/application-gateway/overview-v2#feature-comparison-between-v1-sku-and-v2-sku"
-    - name: Application Gateway V1 Retirement
-      url: "https://azure.microsoft.com/updates/application-gateway-v1-will-be-retired-on-28-april-2026-transition-to-application-gateway-v2/"
 
 - description: Monitor and Log the configurations and traffic
   aprlGuid: 5d035919-898d-a047-8d5d-454e199692e5
@@ -96,8 +82,6 @@
   learnMoreLink:
     - name: Application Gateway Metrics
       url: "https://learn.microsoft.com/azure/application-gateway/application-gateway-metrics"
-    - name: Application Gateway Diagnostics
-      url: "https://learn.microsoft.com/azure/application-gateway/application-gateway-diagnostics"
 
 - description: Use Health Probes to detect backend availability
   aprlGuid: 847a8d88-21c4-bc48-a94e-562206edd767
@@ -115,8 +99,6 @@
   learnMoreLink:
     - name: Application Gateway Probe Overview
       url: "https://learn.microsoft.com/azure/application-gateway/application-gateway-probe-overview"
-    - name: Well-Architected Framework Application Gateway Overview
-      url: "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway"
 
 - description: Deploy Application Gateway in a zone-redundant configuration
   aprlGuid: c9c00f2a-3888-714b-a72b-b4c9e8fcffb2
@@ -134,8 +116,6 @@
   learnMoreLink:
     - name: Well-Architected Framework Application Gateway Reliability
       url: "https://learn.microsoft.com/azure/well-architected/services/networking/azure-application-gateway#reliability"
-    - name: Application Gateway V2 Overview
-      url: "https://learn.microsoft.com/azure/application-gateway/overview-v2"
 
 - description: Plan for backend maintenance by using connection draining
   aprlGuid: 10f02bc6-e2e7-004d-a2c2-f9bf9f16b915
@@ -153,8 +133,6 @@
   learnMoreLink:
     - name: Application Gateway Connection Draining
       url: "https://learn.microsoft.com/azure/application-gateway/features#connection-draining"
-    - name: Application Gateway Connection Draining HTTP Settings
-      url: "https://learn.microsoft.com/azure/application-gateway/configuration-http-settings#connection-draining"
 
 - description: Ensure Application Gateway Subnet is using a /24 subnet mask
   aprlGuid: 8364fd0a-7c0e-e240-9d95-4bf965aec243

--- a/azure-resources/Network/azureFirewalls/recommendations.yaml
+++ b/azure-resources/Network/azureFirewalls/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: Azure Well Architected Framework - Azure Firewall
       url: "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-firewall"
-    - name: Deploy Azure Firewall across multiple availability zones
-      url: "https://learn.microsoft.com/azure/firewall/deploy-availability-zone-powershell"
 
 - description: Monitor Azure Firewall metrics
   aprlGuid: 3c8fa7c6-6b78-a24a-a63f-348a7c71acb9
@@ -33,8 +31,6 @@
   learnMoreLink:
     - name: Azure Firewall metrics supported in Azure Monitor
       url: "https://learn.microsoft.com/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkazurefirewalls"
-    - name: Azure Firewall performance
-      url: "https://learn.microsoft.com/azure/firewall/firewall-performance"
 
 - description: Configure DDoS Protection on the Azure Firewall VNet
   aprlGuid: 1b2dbf4a-8a0b-5e4b-8f4e-3f758188910d
@@ -103,5 +99,3 @@
   learnMoreLink:
     - name: Azure Well-Architected Framework review - Azure Firewall
       url: "https://learn.microsoft.com/azure/well-architected/service-guides/azure-firewall#recommendations"
-    - name: Azure Firewall metrics overview
-      url: "https://learn.microsoft.com/azure/firewall/metrics"

--- a/azure-resources/Network/expressRouteCircuits/recommendations.yaml
+++ b/azure-resources/Network/expressRouteCircuits/recommendations.yaml
@@ -31,8 +31,6 @@
   learnMoreLink:
     - name: Designing for high availability with ExpressRoute
       url: "https://learn.microsoft.com/en-us/azure/expressroute/designing-for-high-availability-with-expressroute"
-    - name: Azure Well-Architected Framework review - Azure ExpressRoute - Design Checklist
-      url: "https://learn.microsoft.com/azure/well-architected/services/networking/azure-expressroute#recommendations"
 
 - description: Ensure both connections of an ExpressRoute are configured in active-active mode
   aprlGuid: f06a2bbe-5839-d447-9f39-fc3d20562d88

--- a/azure-resources/Network/expressRoutePorts/recommendations.yaml
+++ b/azure-resources/Network/expressRoutePorts/recommendations.yaml
@@ -82,8 +82,6 @@
   learnMoreLink:
     - name: Designing for high availability with ExpressRoute
       url: "https://learn.microsoft.com/en-us/azure/expressroute/designing-for-high-availability-with-expressroute"
-    - name: Azure Well-Architected Framework review - Azure ExpressRoute - Design Checklist
-      url: "https://learn.microsoft.com/azure/well-architected/services/networking/azure-expressroute#recommendations"
 
 - description: Ensure both connections of an ExpressRoute are configured in active-active mode
   aprlGuid: 859886df-3996-4eab-8439-c1a38c416e0e

--- a/azure-resources/Network/frontDoorWebApplicationFirewallPolicies/recommendations.yaml
+++ b/azure-resources/Network/frontDoorWebApplicationFirewallPolicies/recommendations.yaml
@@ -14,12 +14,6 @@
   learnMoreLink:
     - name: Azure Web Application Firewall monitoring and logging - Access Log
       url: "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-monitor?pivots=front-door-standard-premium#access-logs"
-    - name: Understanding WAF logs
-      url: "https://learn.microsoft.com/azure/web-application-firewall/afds/waf-front-door-tuning?pivots=front-door-standard-premium#understanding-waf-logs"
-    - name: Web Application Firewall exclusion lists
-      url: "https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-configuration?tabs=portal"
-    - name: Fixing a false positive
-      url: "https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-troubleshoot#fixing-false-positives"
 
 - description: Check Azure Application Gateway WAF logs for mistakenly blocked valid requests
   aprlGuid: 537b4d94-edd1-4041-b13d-8217dfa485f0
@@ -37,8 +31,6 @@
   learnMoreLink:
     - name: Azure Web Application Firewall Monitoring and Logging
       url: "https://learn.microsoft.com/azure/web-application-firewall/ag/application-gateway-waf-metrics#logs-and-diagnostics"
-    - name: Diagnostic logs
-      url: "https://learn.microsoft.com/azure/web-application-firewall/ag/web-application-firewall-logs#diagnostic-logs"
 
 - description: Monitor Web Application Firewall
   aprlGuid: 5357ae22-0f52-1a49-9fd4-1f00ace6add0
@@ -56,5 +48,3 @@
   learnMoreLink:
     - name: WAF monitoring
       url: "https://learn.microsoft.com/azure/web-application-firewall/ag/ag-overview#waf-monitoring"
-    - name: Azure Monitor Workbook for WAF
-      url: "https://github.com/Azure/Azure-Network-Security/tree/master/Azure%20WAF/Workbook%20-%20WAF%20Monitor%20Workbook"

--- a/azure-resources/Network/loadBalancers/recommendations.yaml
+++ b/azure-resources/Network/loadBalancers/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: Reliability and Azure Load Balancer
       url: "https://learn.microsoft.com/azure/architecture/framework/services/networking/azure-load-balancer/reliability"
-    - name: Resiliency checklist for specific Azure services- Azure Load Balancer
-      url: "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#azure-load-balancer"
 
 - description: Ensure the Backend Pool contains at least two instances
   aprlGuid: 6d82d042-6d61-ad49-86f0-6a5455398081

--- a/azure-resources/Network/natGateways/recommendations.yaml
+++ b/azure-resources/Network/natGateways/recommendations.yaml
@@ -14,5 +14,3 @@
   learnMoreLink:
     - name: What is Azure NAT Gateway metrics and alerts?
       url: "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-metrics"
-    - name: AMBA - NAT Gateway
-      url: "https://azure.github.io/azure-monitor-baseline-alerts/services/Network/natGateways/"

--- a/azure-resources/Network/publicIPAddresses/recommendations.yaml
+++ b/azure-resources/Network/publicIPAddresses/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: Public IP addresses - Availability Zones
       url: "https://learn.microsoft.com/azure/virtual-network/ip-services/public-ip-addresses#availability-zone"
-    - name: Upgrading a basic public IP address to Standard SKU
-      url: "https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance#steps-to-complete-the-upgrade"
 
 - description: Use NAT gateway for outbound connectivity to avoid SNAT Exhaustion
   aprlGuid: 1adba190-5c4c-e646-8527-dd1b2a6d8b15
@@ -33,8 +31,6 @@
   learnMoreLink:
     - name: Use NAT GW for outbound connectivity
       url: "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#use-nat-gateway-for-outbound-connectivity"
-    - name: TCP and SNAT Ports
-      url: "https://learn.microsoft.com/azure/architecture/framework/services/compute/azure-app-service/reliability#tcp-and-snat-ports"
 
 - description: Upgrade Basic SKU public IP addresses to Standard SKU
   aprlGuid: 5cea1501-6fe4-4ec4-ac8f-f72320eb18d3
@@ -52,8 +48,6 @@
   learnMoreLink:
     - name: Upgrading a basic public IP address to Standard SKU - Guidance
       url: "https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance"
-    - name: Upgrade to Standard SKU public IP addresses in Azure by 30 September 2025 as Basic SKU will be retired
-      url: "https://azure.microsoft.com/en-us/updates/upgrade-to-standard-sku-public-ip-addresses-in-azure-by-30-september-2025-basic-sku-will-be-retired/"
 
 - description: Public IP addresses should have DDoS protection enabled
   aprlGuid: c4254c66-b8a5-47aa-82f6-e7d7fb418f47

--- a/azure-resources/Network/trafficManagerProfiles/recommendations.yaml
+++ b/azure-resources/Network/trafficManagerProfiles/recommendations.yaml
@@ -14,10 +14,6 @@
   learnMoreLink:
     - name: Azure Traffic Manager endpoint monitoring
       url: "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-monitoring"
-    - name: Enable or disable health checks
-      url: "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-monitoring#enable-or-disable-health-checks-preview"
-    - name: Troubleshooting degraded state on Azure Traffic Manager
-      url: "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-troubleshooting-degraded"
 
 - description: Traffic manager profiles should have more than one endpoint
   aprlGuid: 5b422a7f-8caa-3d48-becb-511599e5bba9
@@ -69,8 +65,6 @@
   learnMoreLink:
     - name: Add an endpoint configured to "All (World)"
       url: "https://learn.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations#add-an-endpoint-configured-to-all-world"
-    - name: Traffic Manager profile - GeographicProfile (Add an endpoint configured to ""All (World)"").
-      url: "https://aka.ms/Rf7vc5"
 
 - description: Avoid combining Traffic Manager and Front Door
   aprlGuid: 9437634c-d69e-2747-b13e-631c13182150
@@ -88,9 +82,3 @@
   learnMoreLink:
     - name: Azure Load Balancing Options
       url: "https://learn.microsoft.com/azure/architecture/guide/technology-choices/load-balancing-overview"
-    - name: Azure Traffic Manager
-      url: "https://learn.microsoft.com/azure/traffic-manager/traffic-manager-overview"
-    - name: Azure Front Door
-      url: "https://learn.microsoft.com/azure/frontdoor/front-door-overview"
-    - name: Mission-critical global content delivery
-      url: "https://learn.microsoft.com/en-us/azure/architecture/guide/networking/global-web-applications/mission-critical-content-delivery"

--- a/azure-resources/Network/virtualNetworkGateways/recommendations.yaml
+++ b/azure-resources/Network/virtualNetworkGateways/recommendations.yaml
@@ -31,10 +31,6 @@
   learnMoreLink:
     - name: About ExpressRoute virtual network gateways - Zone-redundant gateway SKUs
       url: "https://learn.microsoft.com/azure/expressroute/expressroute-about-virtual-network-gateways#zrgw"
-    - name: About zone-redundant virtual network gateway in Azure availability zones
-      url: "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways"
-    - name: Create a zone-redundant virtual network gateway in Azure Availability Zones
-      url: "https://learn.microsoft.com/azure/vpn-gateway/create-zone-redundant-vnet-gateway"
 
 - description: Configure an Azure Resource lock for ExpressRoute gateway to prevent accidental deletion
   aprlGuid: c0f23a92-d322-4d4d-97e9-a238b5e3bbb8
@@ -69,8 +65,6 @@
   learnMoreLink:
     - name: ExpressRoute monitoring, metrics, and alerts | ExpressRoute gateways
       url: "https://learn.microsoft.com/azure/expressroute/expressroute-monitoring-metrics-alerts#expressroute-gateways"
-    - name: Azure ExpressRoute Insights using Network Insights
-      url: "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-network-insights"
 
 - description: Avoid using ExpressRoute circuits for VNet to VNet communication
   aprlGuid: 194c14ac-0d7a-5a48-ae32-75fa450ee564
@@ -122,10 +116,6 @@
   learnMoreLink:
     - name: Zone redundant Virtual network gateway in availability zone
       url: "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways"
-    - name: Gateway SKU
-      url: "https://learn.microsoft.com/azure/vpn-gateway/about-zone-redundant-vnet-gateways#gwskus"
-    - name: SLA summary for Azure services
-      url: "https://www.microsoft.com/licensing/docs/view/Service-Level-Agreements-SLA-for-Online-Services?lang=1"
 
 - description: Enable Active-Active VPN Gateways for redundancy
   aprlGuid: 281a2713-c0e0-3c48-b596-19f590c46671
@@ -143,8 +133,6 @@
   learnMoreLink:
     - name: Active-active VPN gateway
       url: "https://learn.microsoft.com/azure/vpn-gateway/active-active-portal#gateway"
-    - name: Gateway SKU
-      url: "https://learn.microsoft.com/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsku"
 
 - description: Deploy active-active VPN concentrators on your premises
   aprlGuid: af11fc4c-c06c-4f4c-b98d-6eee6d5c4c70
@@ -194,8 +182,6 @@
   automationAvailable: false
   tags: null
   learnMoreLink:
-    - name: Getting started with Azure Metrics Explorer
-      url: "https://learn.microsoft.com/azure/azure-monitor/essentials/metrics-getting-started"
     - name: Monitor VPN gateway
       url: "https://learn.microsoft.com/azure/vpn-gateway/monitor-vpn-gateway-reference#metrics"
 

--- a/azure-resources/Network/virtualNetworks/recommendations.yaml
+++ b/azure-resources/Network/virtualNetworks/recommendations.yaml
@@ -14,12 +14,6 @@
   learnMoreLink:
     - name: Azure Virtual Network - Concepts and best practices | Microsoft Learn
       url: "https://learn.microsoft.com/azure/virtual-network/concepts-and-best-practices"
-    - name: GatewaySUbnet
-      url: "https://learn.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsub"
-    - name: Can I associate a network security group (NSG) to the RouteServerSubnet?
-      url: "https://learn.microsoft.com/en-us/azure/route-server/route-server-faq#can-i-associate-a-network-security-group-nsg-to-the-routeserversubnet"
-    - name: Are Network Security Groups (NSGs) supported on the AzureFirewallSubnet?
-      url: "https://learn.microsoft.com/en-us/azure/firewall/firewall-faq#are-network-security-groups--nsgs--supported-on-the-azurefirewallsubnet"
 
 - description: Shield public endpoints in Azure VNets with Azure DDoS Standard Protection Plans
   aprlGuid: 69ea1185-19b7-de40-9da1-9e8493547a5c
@@ -54,10 +48,6 @@
   learnMoreLink:
     - name: Azure Virtual Network FAQ | Microsoft Learn
       url: "https://learn.microsoft.com/azure/virtual-network/virtual-networks-faq"
-    - name: Reliability and Network connectivity - Microsoft Azure Well-Architected Framework | Microsoft LearnNetworking Reliability
-      url: "https://learn.microsoft.com/azure/architecture/framework/services/networking/network-connectivity/reliability"
-    - name: Azure Private Link availability
-      url: "https://learn.microsoft.com/en-us/azure/private-link/availability"
 
 - description: Enable Virtual Network Flow Logs
   aprlGuid: 06b77be9-56a3-4d41-b362-8b295c5a283d

--- a/azure-resources/OperationalInsights/workspaces/recommendations.yaml
+++ b/azure-resources/OperationalInsights/workspaces/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: Log Analytics workspace data export in Azure Monitor
       url: "https://learn.microsoft.com/azure/azure-monitor/logs/logs-data-export"
-    - name: Azure Monitor configuration recommendations
-      url: "https://learn.microsoft.com/azure/azure-monitor/best-practices-logs#configuration-recommendations"
 
 - description: Create a health status alert rule for your Log Analytics workspace
   aprlGuid: 4b77191c-cc3c-8c4e-844b-0f56d0927890
@@ -33,5 +31,3 @@
   learnMoreLink:
     - name: Monitor Log Analytics workspace health
       url: "https://learn.microsoft.com/azure/azure-monitor/logs/log-analytics-workspace-health"
-    - name: Azure Monitor configuration recommendations
-      url: "https://learn.microsoft.com/azure/azure-monitor/best-practices-logs#configuration-recommendations"

--- a/azure-resources/RecoveryServices/vaults/recommendations.yaml
+++ b/azure-resources/RecoveryServices/vaults/recommendations.yaml
@@ -48,8 +48,6 @@
   learnMoreLink:
     - name: Move to Azure monitor Alerts
       url: "https://learn.microsoft.com/azure/backup/move-to-azure-monitor-alerts"
-    - name: Classic alerts retirement announcement
-      url: "https://azure.microsoft.com/updates/transition-to-builtin-azure-monitor-alerts-for-recovery-services-vaults-in-azure-backup-by-31-march-2026/"
 
 - description: Enable Cross Region Restore for your GRS Recovery Services Vault
   aprlGuid: 1549b91f-2ea0-4d4f-ba2a-4596becbe3de
@@ -67,12 +65,6 @@
   learnMoreLink:
     - name: Set Cross Region Restore
       url: "https://learn.microsoft.com/azure/backup/backup-create-recovery-services-vault#set-cross-region-restore"
-    - name: Azure Backup Best Practices
-      url: "https://learn.microsoft.com/azure/backup/guidance-best-practices"
-    - name: Minimum Role Requirements for Cross Region Restore
-      url: "https://learn.microsoft.com/azure/backup/backup-rbac-rs-vault#minimum-role-requirements-for-azure-vm-backup"
-    - name: Recovery Services Vault
-      url: "https://learn.microsoft.com/azure/backup/backup-azure-arm-vms-prepare"
 
 - description: Enable Soft Delete for Recovery Services Vaults in Azure Backup
   aprlGuid: 9e39919b-78af-4a0b-b70f-c548dae97c25

--- a/azure-resources/ServiceBus/namespaces/recommendations.yaml
+++ b/azure-resources/ServiceBus/namespaces/recommendations.yaml
@@ -14,10 +14,6 @@
   learnMoreLink:
     - name: Service Bus and reliability
       url: "https://learn.microsoft.com/en-us/azure/well-architected/services/messaging/service-bus/reliability"
-    - name: Azure Service Bus Geo-disaster recovery
-      url: "https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-geo-dr#availability-zones"
-    - name: Insulate Azure Service Bus applications against outages and disasters
-      url: "https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-outages-disasters"
 
 - description: Enable auto-scale for production workloads on Service Bus namespaces
   aprlGuid: d810e3a8-600f-4be1-895b-1a93e61d37fd
@@ -50,7 +46,5 @@
   automationAvailable: true
   tags: null
   learnMoreLink:
-    - name: Azure support for TLS 1.0 and TLS 1.1 will end by 31 October 2024
-      url: "https://azure.microsoft.com/updates/azure-support-tls-will-end-by-31-october-2024-2/"
     - name: Configure the minimum TLS version for a Service Bus namespace
       url: "https://learn.microsoft.com/azure/service-bus-messaging/transport-layer-security-configure-minimum-version"

--- a/azure-resources/Sql/servers/recommendations.yaml
+++ b/azure-resources/Sql/servers/recommendations.yaml
@@ -31,8 +31,6 @@
   learnMoreLink:
     - name: AutoFailover Groups
       url: "https://learn.microsoft.com/en-us/azure/azure-sql/database/auto-failover-group-overview?tabs=azure-powershell"
-    - name: DR Design
-      url: "https://learn.microsoft.com/en-us/azure/azure-sql/database/designing-cloud-solutions-for-disaster-recovery"
 
 - description: Enable zone redundancy for Azure SQL Database to achieve high availability and resiliency
   aprlGuid: c0085c32-84c0-c247-bfa9-e70977cbf108
@@ -84,10 +82,6 @@
   learnMoreLink:
     - name: Azure Monitor
       url: "https://learn.microsoft.com/en-us/azure/azure-monitor/insights/azure-sql#analyze-data-and-create-alerts"
-    - name: Azure SQL Database Monitoring
-      url: "https://learn.microsoft.com/en-us/azure/azure-sql/database/monitoring-sql-database-azure-monitor"
-    - name: Monitoring SQL Database Reference
-      url: "https://learn.microsoft.com/en-us/azure/azure-sql/database/monitoring-sql-database-azure-monitor-reference"
 
 - description: Back Up Your Keys
   aprlGuid: d6ef87aa-574e-584e-a955-3e6bb8b5425b
@@ -105,8 +99,6 @@
   learnMoreLink:
     - name: Azure Key Vault
       url: "https://learn.microsoft.com/en-us/azure/key-vault/general/overview"
-    - name: Getting Started with Always Encrypted
-      url: "https://learn.microsoft.com/en-us/azure/azure-sql/database/always-encrypted-landing?view=azuresql"
 
 - description: Use Failover Group endpoints for database connections
   aprlGuid: de266d8a-a9f3-4cb9-be95-9306001fceea

--- a/azure-resources/Storage/storageAccounts/recommendations.yaml
+++ b/azure-resources/Storage/storageAccounts/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: Azure Storage redundancy
       url: "https://learn.microsoft.com/azure/storage/common/storage-redundancy"
-    - name: Change the redundancy configuration for a storage account
-      url: "https://learn.microsoft.com/azure/storage/common/redundancy-migration"
 
 - description: Use premium performance block blob storage for high performance workloads
   aprlGuid: 5587ef77-7a05-a74d-9c6e-449547a12f27
@@ -31,14 +29,6 @@
   automationAvailable: false
   tags: null
   learnMoreLink:
-    - name: Types of storage accounts
-      url: "https://learn.microsoft.com/azure/storage/common/storage-account-overview#types-of-storage-accounts"
-    - name: Scalability and performance targets for standard storage accounts
-      url: "https://learn.microsoft.com/azure/storage/common/scalability-targets-standard-account"
-    - name: Performance and scalability checklist for Blob storage
-      url: "https://learn.microsoft.com/azure/storage/blobs/storage-performance-checklist"
-    - name: Scalability and performance targets for Blob storage
-      url: "https://learn.microsoft.com/azure/storage/blobs/scalability-targets"
     - name: Premium block blob storage accounts
       url: "https://learn.microsoft.com/azure/storage/blobs/storage-blob-block-blob-premium"
 
@@ -57,7 +47,7 @@
   tags: null
   learnMoreLink:
     - name: Soft delete detail docs
-      url: "https://learn.microsoft.com//azure/storage/blobs/soft-delete-blob-enable?tabs=azure-portal "
+      url: "https://learn.microsoft.com//azure/storage/blobs/soft-delete-blob-enable?tabs=azure-portal"
 
 - description: Enable versioning for accidental modification and keep the number of versions below 1000
   aprlGuid: 8ebda7c0-e0e1-ed45-af59-2d7ea9a1c05d
@@ -74,7 +64,7 @@
   tags: null
   learnMoreLink:
     - name: Blob versioning
-      url: "https://learn.microsoft.com/azure/storage/blobs/versioning-overview "
+      url: "https://learn.microsoft.com/azure/storage/blobs/versioning-overview"
 
 - description: Enable point-in-time restore for GPv2 accounts to safeguard against data loss
   aprlGuid: 1b965cb9-7629-214e-b682-6bf6e450a100
@@ -92,8 +82,6 @@
   learnMoreLink:
     - name: Point-in-time restore for block blobs
       url: "https://learn.microsoft.com/azure/storage/blobs/point-in-time-restore-overview"
-    - name: Perform a point-in-time restore on block blob data
-      url: "https://learn.microsoft.com/azure/storage/blobs/point-in-time-restore-manage?tabs=portal"
 
 - description: Monitor all blob storage accounts
   aprlGuid: 96cb8331-6b06-8242-8ce8-4e2f665dc679
@@ -111,8 +99,6 @@
   learnMoreLink:
     - name: Monitor Azure Blob Storage
       url: "https://learn.microsoft.com/azure/storage/blobs/monitor-blob-storage"
-    - name: Best practices for monitoring Azure Blob Storage
-      url: "https://learn.microsoft.com/azure/storage/blobs/blob-storage-monitoring-scenarios"
 
 - description: Consider upgrading legacy storage accounts to v2 storage accounts
   aprlGuid: 2ad78dec-5a4d-4a30-8fd1-8584335ad781
@@ -128,8 +114,6 @@
   automationAvailable: true
   tags: null
   learnMoreLink:
-    - name: Legacy storage account types
-      url: "https://learn.microsoft.com/azure/storage/common/storage-account-overview#legacy-storage-account-types"
     - name: Upgrade to a general-purpose v2 storage account
       url: "https://learn.microsoft.com/azure/storage/common/storage-account-upgrade"
 
@@ -147,7 +131,5 @@
   automationAvailable: true
   tags: null
   learnMoreLink:
-    - name: Learn More
-      url: "https://learn.microsoft.com/en-us/azure/architecture/example-scenario/wvd/windows-virtual-desktop#azure-virtual-desktop-limitations"
     - name: Private Link
       url: "https://learn.microsoft.com/en-us/azure/well-architected/azure-virtual-desktop/networking#private-endpoints-private-link"

--- a/azure-resources/Subscription/subscriptions/recommendations.yaml
+++ b/azure-resources/Subscription/subscriptions/recommendations.yaml
@@ -31,8 +31,6 @@
   learnMoreLink:
     - name: Management group recommendations
       url: "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-group-recommendations"
-    - name: Root management group for each directory
-      url: "https://learn.microsoft.com/en-us/azure/governance/management-groups/overview#root-management-group-for-each-directory"
 
 - description: Configure Service Health Alerts
   aprlGuid: 9729c89d-8118-41b4-a39b-e12468fa872b
@@ -48,8 +46,6 @@
   automationAvailable: true
   tags: null
   learnMoreLink:
-    - name: What is Azure Service Health?
-      url: "https://learn.microsoft.com/azure/service-health/overview"
     - name: Configure alerts for service health events
       url: "https://learn.microsoft.com/azure/service-health/alerts-activity-log-service-notifications-portal"
 

--- a/azure-resources/VirtualMachineImages/imageTemplates/recommendations.yaml
+++ b/azure-resources/VirtualMachineImages/imageTemplates/recommendations.yaml
@@ -31,5 +31,3 @@
   learnMoreLink:
     - name: Image Template resiliency
       url: "https://learn.microsoft.com/en-us/azure/reliability/reliability-image-builder?toc=%2Fazure%2Fvirtual-machines%2Ftoc.json&bc=%2Fazure%2Fvirtual-machines%2Fbreadcrumb%2Ftoc.json&tabs=graph#disaster-recovery"
-    - name: Azure Image Builder Supported Regions
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/image-builder-overview?tabs=azure-powershell#regions"

--- a/azure-resources/Web/serverFarms/recommendations.yaml
+++ b/azure-resources/Web/serverFarms/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: Migrate App Service to availability zone support
       url: "https://learn.microsoft.com/en-us/azure/reliability/migrate-app-service"
-    - name: High availability enterprise deployment using App Service Environment
-      url: "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/enterprise-integration/ase-high-availability-deployment"
 
 - description: Use Standard or Premium tier
   aprlGuid: b2113023-a553-2e41-9789-597e2fb54c31
@@ -101,5 +99,3 @@
   learnMoreLink:
     - name: Ultimate guide to running healthy apps in the cloud
       url: "https://azure.github.io/AppService/2020/05/15/Robust-Apps-for-the-cloud.html"
-    - name: Auto Scale Web Apps
-      url: "https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-get-started"

--- a/azure-resources/Web/sites/recommendations.yaml
+++ b/azure-resources/Web/sites/recommendations.yaml
@@ -31,8 +31,6 @@
   learnMoreLink:
     - name: Application Insights
       url: "https://learn.microsoft.com/azure/application-insights/app-insights-overview"
-    - name: Application monitoring for Azure App Service
-      url: "https://learn.microsoft.com/azure/azure-monitor/app/azure-web-apps"
 
 - description: Separate web apps from web APIs
   aprlGuid: 78a5c033-ff51-4332-8a71-83464c34494b

--- a/azure-specialized-workloads/ai/recommendations.yaml
+++ b/azure-specialized-workloads/ai/recommendations.yaml
@@ -31,5 +31,3 @@
   learnMoreLink:
     - name: Data collection, retention, and storage in Application Insights
       url: "https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-retention-configure?tabs=portal-3%2Cportal-1%2Cportal-2"
-    - name: Failover for business continuity and disaster recovery
-      url: "https://learn.microsoft.com/en-us/azure/machine-learning/how-to-high-availability-machine-learning?view=azureml-api-2"

--- a/azure-specialized-workloads/avd/recommendations.yaml
+++ b/azure-specialized-workloads/avd/recommendations.yaml
@@ -83,8 +83,6 @@
   learnMoreLink:
     - name: Capacity Planning
       url: "https://learn.microsoft.com/azure/well-architected/azure-virtual-desktop/business-continuity#capacity-planning"
-    - name: Learn More
-      url: "https://learn.microsoft.com/azure/architecture/example-scenario/wvd/windows-virtual-desktop#azure-virtual-desktop-limitations"
 
 - description: Ensure DNS regions are replicated to avoid single point of failure
   aprlGuid: e1a34ac6-8761-4020-b537-d60c0be7514e
@@ -119,8 +117,6 @@
   learnMoreLink:
     - name: Multi-region BCDR
       url: "https://learn.microsoft.com/azure/architecture/example-scenario/wvd/azure-virtual-desktop-multi-region-bcdr"
-    - name: Learn More
-      url: "https://learn.microsoft.com/azure/well-architected/azure-virtual-desktop/business-continuity#active-active-scenarios"
 
 - description: Create only one FSLogix file share per Storage Account
   aprlGuid: ed1f0327-0914-49e8-9518-16acb0d6b8d6
@@ -172,8 +168,6 @@
   learnMoreLink:
     - name: FSLogix
       url: "https://learn.microsoft.com/fslogix/overview-what-is-fslogix"
-    - name: Backup Storage Account
-      url: https://learn.microsoft.com/azure/backup/blob-backup-configure-manage?tabs=operational-backup
 
 - description: Implement RDP shortpath for public or managed networks
   aprlGuid: 3835b4b3-0479-4be8-9ffd-34ae29fa33b9
@@ -208,8 +202,6 @@
   learnMoreLink:
     - name: Learn More
       url: "https://learn.microsoft.com/azure/virtual-desktop/troubleshoot-rdp-shortpath"
-    - name: Learn More
-      url: "https://learn.microsoft.com/azure/virtual-desktop/check-access-validate-required-fqdn-endpoint"
 
 - description: Ensure secondary Entra ID connect synchronization server
   aprlGuid: d984eaf9-0fa1-4f8d-a326-bda751993c6f
@@ -279,8 +271,6 @@
   learnMoreLink:
     - name: Learn More
       url: "https://learn.microsoft.com/azure/virtual-network/service-tags-overview"
-    - name: Learn More
-      url: "https://learn.microsoft.com/azure/virtual-network/virtual-networks-udr-overview"
 
 - description: Create updated image version and replace session hosts rather than updating host directly
   aprlGuid: 2831dab9-6a43-44a1-8aec-90a8e84894bc
@@ -328,7 +318,7 @@
   potentialBenefits: Enhanced security & disaster recovery
   pgVerified: true
   automationAvailable: false
-  tags:
+  tags: AVD
   learnMoreLink:
     - name: Learn More
       url: "https://learn.microsoft.com/fslogix/how-to-configure-storage-permissions"
@@ -349,8 +339,6 @@
   learnMoreLink:
     - name: Learn More
       url: "https://learn.microsoft.com/fslogix/troubleshooting-events-logs-diagnostics"
-    - name: Learn More
-      url: "https://learn.microsoft.com/azure/storage/files/storage-files-monitoring"
 
 - description: Manually install FSLogix updates
   aprlGuid: d51e0a70-8b50-4be3-af8a-7c9065e47360

--- a/azure-specialized-workloads/avs/recommendations.yaml
+++ b/azure-specialized-workloads/avs/recommendations.yaml
@@ -31,8 +31,6 @@
   learnMoreLink:
     - name: Set an external identity source for vCenter
       url: "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-identity-source-vcenter"
-    - name: Set an external identity for NSX-T
-      url: "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-external-identity-source-nsx-t"
 
 - description: Use HCX Network Extension High Availability
   aprlGuid: bce16eee-0933-4baa-ab4d-8d1bb5653fc2
@@ -50,8 +48,6 @@
   learnMoreLink:
     - name: HCX Network extension high availability
       url: "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-hcx-network-extension-high-availability"
-    - name: Understanding Network Extension High Availability
-      url: "https://docs.vmware.com/en/VMware-HCX/4.8/hcx-user-guide/GUID-E1353511-697A-44B0-82A0-852DB55F97D7.html"
 
 - description: Verify Management Networks are not extended with HCX Network Extension
   aprlGuid: 6be9a543-cf82-4926-82ea-7e1f1ffaad80
@@ -86,8 +82,6 @@
   learnMoreLink:
     - name: Use fault domains
       url: "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/application-platform#use-fault-domains"
-    - name: Configure storage policy
-      url: "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-storage-policy"
 
 - description: Align ExpressRoute configuration with best practices for circuit resilience
   aprlGuid: 6f573d60-be93-4f18-8016-42e923e3c05e
@@ -105,8 +99,6 @@
   learnMoreLink:
     - name: APRL guidance for ExpressRoute circuits
       url: "https://azure.github.io/Azure-Proactive-Resiliency-Library/services/networking/expressroute-circuits"
-    - name: Create a new ExpressRoute circuit
-      url: "https://learn.microsoft.com/azure/expressroute/expressroute-howto-circuit-portal-resource-manager?pivots=expressroute-preview#create-a-new-expressroute-circuit-preview"
 
 - description: Deploy two or more circuits in different peering locations when using stretched clusters
   aprlGuid: 91c84596-1c41-48fe-8d5e-3f817e6a273b
@@ -141,5 +133,3 @@
   learnMoreLink:
     - name: Private Clouds in two regions
       url: "https://learn.microsoft.com/en-us/azure/azure-vmware/move-azure-vmware-solution-across-regions"
-    - name: Dual Region Network Topology
-      url: "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-dual-region-network-topology"

--- a/azure-specialized-workloads/sap/recommendations.yaml
+++ b/azure-specialized-workloads/sap/recommendations.yaml
@@ -12,14 +12,6 @@
   automationAvailable: false
   tags: SAP
   learnMoreLink:
-    - name: SAP ACSS Quality Insights
-      url: "https://learn.microsoft.com/en-us/azure/sap/center-sap-solutions/get-quality-checks-insights"
-    - name: OpenSource Inventory Checks
-      url: "https://aka.ms/ACESInventoryCheckSAP"
-    - name: OpenSource Quality Checks
-      url: "https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities/tree/main/QualityCheck"
-    - name: Move Regional SAP HA to Zonal
-      url: "https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities/tree/main/Move-VM-from-AvSet-to-AvZone/Move-Regional-SAP-HA-To-Zonal-SAP-HA-WhitePaper"
     - name: High Availability Deployment Options for SAP
       url: "https://learn.microsoft.com/en-us/azure/sap/workloads/sap-high-availability-architecture-scenarios#high-availability-deployment-options-for-sap-workload"
 
@@ -37,14 +29,8 @@
   automationAvailable: false
   tags: SAP
   learnMoreLink:
-    - name: OpenSource Inventory Checks
-      url: "https://aka.ms/ACESInventoryCheckSAP"
     - name: Virtual machine Scale Set SAP Deployment Guide
       url: "https://learn.microsoft.com/en-us/azure/sap/workloads/virtual-machine-scale-set-sap-deployment-guide"
-    - name: Considerations for Flexible VM Scale Sets for SAP
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/virtual-machine-scale-set-sap-deployment-guide?tabs=scaleset-cli#important-consideration-of-flexible-virtual-machine-scale-sets-for-sap-workload"
-    - name: Migrate existing SAP system VMs to VMSS Flex
-      url: "https://techcommunity.microsoft.com/t5/running-sap-applications-on-the/how-to-easily-migrate-an-existing-sap-system-vms-to-flexible/ba-p/3833548"
 
 - description: If using single-instance VMs all OS and data disks must be Premium SSD or Ultra Disk
   aprlGuid: b60ae773-9917-4bca-8a42-7cb45365a917
@@ -60,14 +46,6 @@
   automationAvailable: true
   tags: SAP
   learnMoreLink:
-    - name: SAP ACSS Insights
-      url: "https://learn.microsoft.com/en-us/azure/sap/center-sap-solutions/get-quality-checks-insights"
-    - name: OpenSource Inventory Checks
-      url: "https://aka.ms/ACESInventoryCheckSAP"
-    - name: OpenSource Quality Checks
-      url: "https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities/tree/main/QualityCheck"
-    - name: VM SLA
-      url: "https://www.azure.cn/en-us/support/sla/virtual-machines/"
     - name: SAP Storage Planning Guide
       url: "https://learn.microsoft.com/en-us/azure/sap/workloads/planning-guide-storage"
 
@@ -85,8 +63,6 @@
   automationAvailable: false
   tags: SAP
   learnMoreLink:
-    - name: SAP ACSS Insights
-      url: "https://learn.microsoft.com/en-us/azure/sap/center-sap-solutions/get-quality-checks-insights"
     - name: OpenSource Quality Checks
       url: "https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities/tree/main/QualityCheck"
 
@@ -192,8 +168,6 @@
   learnMoreLink:
     - name: SAP ACSS Insights
       url: "https://learn.microsoft.com/en-us/azure/sap/center-sap-solutions/get-quality-checks-insights"
-    - name: OpenSource Inventory Checks
-      url: "https://aka.ms/ACESInventoryCheckSAP"
 
 - description: SAP shared files systems are replicated or backed up to DR location
   aprlGuid: ee4dc309-00a1-49fe-92fa-1724baf5f103
@@ -279,8 +253,6 @@
   learnMoreLink:
     - name: VM Scheduled Events
       url: "https://learn.microsoft.com/en-us/azure/virtual-machines/linux/scheduled-events"
-    - name: Configure Pacemaker for Azure Scheduled Events
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker?tabs=msi#configure-pacemaker-for-azure-scheduled-events"
 
 - description: Configure a Pacemaker cluster for SAP ASCS high availability
   aprlGuid: 9d8f6678-694c-4da4-8384-415201f65194
@@ -296,10 +268,6 @@
   automationAvailable: false
   tags: SAP
   learnMoreLink:
-    - name: SAP ACSS Insights
-      url: "https://learn.microsoft.com/en-us/azure/sap/center-sap-solutions/get-quality-checks-insights"
-    - name: OpenSource Quality Checks
-      url: "https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities/tree/main/QualityCheck"
     - name: ASCS-Pacemaker - Central Server Instance
       url: "https://docs.microsoft.com/en-us/azure/advisor/advisor-reference-reliability-recommendations"
 
@@ -317,10 +285,6 @@
   automationAvailable: false
   tags: SAP
   learnMoreLink:
-    - name: SAP ACSS Insights
-      url: "https://learn.microsoft.com/en-us/azure/sap/center-sap-solutions/get-quality-checks-insights"
-    - name: OpenSource Quality Checks
-      url: "https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities/tree/main/QualityCheck"
     - name: ASCS-LB - Central Server Instance
       url: "https://docs.microsoft.com/en-us/azure/advisor/advisor-reference-reliability-recommendations"
 
@@ -338,10 +302,6 @@
   automationAvailable: false
   tags: SAP
   learnMoreLink:
-    - name: SAP ACSS Insights
-      url: "https://learn.microsoft.com/en-us/azure/sap/center-sap-solutions/get-quality-checks-insights"
-    - name: OpenSource Quality Checks
-      url: "https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities/tree/main/QualityCheck"
     - name: DBHANA-Pacemaker - Database Instance
       url: "https://docs.microsoft.com/en-us/azure/advisor/advisor-reference-reliability-recommendations"
 
@@ -359,10 +319,6 @@
   automationAvailable: false
   tags: SAP
   learnMoreLink:
-    - name: SAP ACSS Insights
-      url: "https://learn.microsoft.com/en-us/azure/sap/center-sap-solutions/get-quality-checks-insights"
-    - name: OpenSource Quality Checks
-      url: "https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities/tree/main/QualityCheck"
     - name: DBHANA-LB- Database Instance
       url: "https://docs.microsoft.com/en-us/azure/advisor/advisor-reference-reliability-recommendations"
 
@@ -399,13 +355,3 @@
   learnMoreLink:
     - name: High-availability SAP NetWeaver with simple mount and NFS on SLES for SAP Applications VMs
       url: "https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-nfs-simple-mount?tabs=lb-portal%2Censa1"
-    - name: High availability for SAP NetWeaver on Azure VMs on SUSE Linux Enterprise Server with Azure NetApp Files for SAP applications
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-netapp-files?tabs=lb-portal%2Censa1"
-    - name: High availability of SAP HANA scale-up with Azure NetApp Files on SUSE Enterprise Linux
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability-netapp-files-suse?tabs=lb-portal"
-    - name: Azure Virtual Machines HA for SAP NetWeaver on RHEL with Azure NetApp Files for SAP applications
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-rhel-netapp-files?tabs=lb-portal%2Censa1"
-    - name: High availability of SAP HANA scale-up with Azure NetApp Files on RHEL
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability-netapp-files-red-hat?tabs=lb-portal"
-    - name: OpenSource Quality Checks
-      url: "https://github.com/Azure/SAP-on-Azure-Scripts-and-Utilities/blob/main/QualityCheck/"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

In order to align to Azure Advisor schema, we need to reduce the number of allowed links per recommendation to 1.

I have used AI to select the most relevant links to keep.

## Related Issues/Work Items

Fixes [AB#38474](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/38474)

### Breaking Changes

1. None

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
