### PR TITLE
fix: Remove low relevant learn more link

### DIFF
--- a/azure-resources/Network/bastionHosts/recommendations.yaml
+++ b/azure-resources/Network/bastionHosts/recommendations.yaml
@@ -14,8 +14,6 @@
   learnMoreLink:
     - name: Reliability in Azure Bastion
       url: "https://learn.microsoft.com/en-us/azure/reliability/reliability-bastion"
-    - name: Deploy Azure Bastion by using specified settings
-      url: "https://learn.microsoft.com/en-us/azure/bastion/tutorial-create-host-portal"
 
 - description: Deploy Azure Bastion into the virtual network in secondary Azure region
   aprlGuid: 0e57956d-71d9-4a35-bdcf-d7cfd7cd71f4

--- a/tools/data/recommendations.json
+++ b/tools/data/recommendations.json
@@ -5005,10 +5005,6 @@
       {
         "url": "https://learn.microsoft.com/en-us/azure/reliability/reliability-bastion",
         "name": "Reliability in Azure Bastion"
-      },
-      {
-        "url": "https://learn.microsoft.com/en-us/azure/bastion/tutorial-create-host-portal",
-        "name": "Deploy Azure Bastion by using specified settings"
       }
     ],
     "recommendationControl": "HighAvailability",


### PR DESCRIPTION
# Overview/Summary

Deploy Azure Bastion across Availability Zones (c9b0c6f6-1f64-4b4b-8165-00770b295dd7) has two learn more links. So, remove a low relevant learn more link from the recommendation.

## Related Issues/Work Items

- #618

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
