### PR TITLE
fix: fix on filtering resourcetypes on ImpactedResources

### DIFF
--- a/tools/2_wara_data_analyzer.ps1
+++ b/tools/2_wara_data_analyzer.ps1
@@ -323,32 +323,32 @@ $Script:Runtime = Measure-Command -Expression {
               }
               $Script:MergedRecommendation += $tmp
             }
-            # Populating resource types without recommendations
-            else {
-              $tmp = @{
-                'How was the resource/recommendation validated or what actions need to be taken?' = $Recom.validationAction;
-                recommendationId                                                                  = '';
-                recommendationTitle                                                               = $RecomTitle.description;
-                resourceType                                                                      = $Recom.recommendationId;
-                impact                                                                            = '';
-                subscriptionId                                                                    = $Recom.subscriptionId;
-                resourceGroup                                                                     = $Recom.resourceGroup;
-                name                                                                              = $Recom.name;
-                id                                                                                = $Recom.id;
-                location                                                                          = $Recom.location;
-                param1                                                                            = $Recom.param1;
-                param2                                                                            = $Recom.param2;
-                param3                                                                            = $Recom.param3;
-                param4                                                                            = $Recom.param4;
-                param5                                                                            = $Recom.param5;
-                supportTicketId                                                                   = $Tickets;
-                source                                                                            = $Recom.selector;
-                checkName                                                                         = $Recom.checkName;
-                'WAF Pillar'                                                                      = 'Reliability';
-                tagged                                                                            = $Recom.tagged
-              }
-              $Script:MergedRecommendation += $tmp
+          }
+          # Populating resource types without recommendations
+          if ( $Recom.validationAction -eq 'IMPORTANT - Resource Type is not available in either APRL or Advisor - Validate Resources manually if Applicable, if not Delete this line') {
+            $tmp = @{
+              'How was the resource/recommendation validated or what actions need to be taken?' = $Recom.validationAction;
+              recommendationId                                                                  = '';
+              recommendationTitle                                                               = $RecomTitle.description;
+              resourceType                                                                      = $Recom.recommendationId;
+              impact                                                                            = '';
+              subscriptionId                                                                    = $Recom.subscriptionId;
+              resourceGroup                                                                     = $Recom.resourceGroup;
+              name                                                                              = $Recom.name;
+              id                                                                                = $Recom.id;
+              location                                                                          = $Recom.location;
+              param1                                                                            = $Recom.param1;
+              param2                                                                            = $Recom.param2;
+              param3                                                                            = $Recom.param3;
+              param4                                                                            = $Recom.param4;
+              param5                                                                            = $Recom.param5;
+              supportTicketId                                                                   = $Tickets;
+              source                                                                            = $Recom.selector;
+              checkName                                                                         = $Recom.checkName;
+              'WAF Pillar'                                                                      = 'Reliability';
+              tagged                                                                            = $Recom.tagged
             }
+            $Script:MergedRecommendation += $tmp
           }
         }
       }
@@ -1068,7 +1068,7 @@ $Script:Runtime = Measure-Command -Expression {
   }
 
   #Call the functions
-  $Script:Version = '2.1.19'
+  $Script:Version = '2.1.20'
   Write-Host 'Version: ' -NoNewline
   Write-Host $Script:Version -ForegroundColor DarkBlue
 

--- a/tools/Version.json
+++ b/tools/Version.json
@@ -2,7 +2,7 @@
   {
 
     "Collector": "2.1.19",
-    "Analyzer": "2.1.19",
+    "Analyzer": "2.1.20",
     "Generator": "2.1.7"
   }
 ]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Fix resource types not present in APRL being left out from ImpactedResources sheet


## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [X] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
