### PR TITLE
docs: Update Compute Virtual Machines VMSS recommendations

### DIFF
--- a/azure-resources/Compute/virtualMachines/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachines/recommendations.yaml
@@ -40,7 +40,7 @@
   recommendationResourceType: Microsoft.Compute/virtualMachines
   recommendationMetadataState: Active
   longDescription: |
-    Availability Sets aren’t being deprecated immediately but will be in the future. To improve reliability, migrate workloads to VMSS Flex for deployment across zones or within a zone across multiple fault domains (FDs). VMSS Flex offers better VM distribution control, enhancing availability.
+    Availability Sets aren’t being deprecated immediately, but they will be in the future. To improve reliability, migrate workloads to VMSS Flex for deployment either across zones or within a zone, utilizing multiple fault domains (FDs). VMSS Flex offers better VM distribution control, enhancing availability.
   potentialBenefits: Enhances reliability and future-proofs VMs
   pgVerified: true
   automationAvailable: true

--- a/azure-resources/Compute/virtualMachines/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachines/recommendations.yaml
@@ -40,7 +40,7 @@
   recommendationResourceType: Microsoft.Compute/virtualMachines
   recommendationMetadataState: Active
   longDescription: |
-    While Availability Sets are not scheduled for immediate deprecation, they are planned for deprecation in the future. To enhance reliability, migrate workloads from Availability Sets to VMSS Flex for deployment either across zones or within the same zone across multiple fault domains (FDs). VMSS Flex offers greater flexibility in placing VMs across fault domains, improving availability by allowing more granular control over their distribution.
+    Availability Sets aren’t being deprecated immediately but will be in the future. To improve reliability, migrate workloads to VMSS Flex for deployment across zones or within a zone across multiple fault domains (FDs). VMSS Flex offers better VM distribution control, enhancing availability.
   potentialBenefits: Enhances reliability and future-proofs VMs
   pgVerified: true
   automationAvailable: true

--- a/azure-resources/Compute/virtualMachines/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachines/recommendations.yaml
@@ -40,7 +40,7 @@
   recommendationResourceType: Microsoft.Compute/virtualMachines
   recommendationMetadataState: Active
   longDescription: |
-    While availability sets are not scheduled for immediate deprecation, they are planned to be deprecated in the future. Migrate workloads from VMs to VMSS Flex for deployment across zones or within the same zone across different fault domains (FDs) for better reliability.
+    While Availability Sets are not scheduled for immediate deprecation, they are planned for deprecation in the future. To enhance reliability, migrate workloads from Availability Sets to VMSS Flex for deployment either across zones or within the same zone across multiple fault domains (FDs). VMSS Flex offers greater flexibility in placing VMs across fault domains, improving availability by allowing more granular control over their distribution.
   potentialBenefits: Enhances reliability and future-proofs VMs
   pgVerified: true
   automationAvailable: true


### PR DESCRIPTION
# Overview/Summary

Availability Sets aren’t being deprecated immediately but will be in the future. To improve reliability, migrate workloads to VMSS Flex for deployment across zones or within a zone across multiple fault domains (FDs). VMSS Flex offers better VM distribution control, enhancing availability.

## Related Issues/Work Items
Fixing wording based on #616 

### Breaking Changes

No breaking changes

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
