### PR TITLE
feat: Remove "en-us" locale identifier from URLs (#642)

### DIFF
--- a/azure-resources/AAD/domainServices/recommendations.yaml
+++ b/azure-resources/AAD/domainServices/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Create and use replica sets for resiliency or geolocation in Microsoft Entra Domain Services
-      url: "https://learn.microsoft.com/en-us/entra/identity/domain-services/tutorial-create-replica-set"
+      url: "https://learn.microsoft.com/entra/identity/domain-services/tutorial-create-replica-set"
 
 - description: Use replica sets for resiliency or geolocation in Microsoft Entra Domain Services
   aprlGuid: a3058909-fcf8-4450-88b5-499f57449178
@@ -31,4 +31,4 @@
   tags: []
   learnMoreLink:
     - name: Create and use replica sets for resiliency or geolocation in Microsoft Entra Domain Services
-      url: "https://learn.microsoft.com/en-us/entra/identity/domain-services/tutorial-create-replica-set"
+      url: "https://learn.microsoft.com/entra/identity/domain-services/tutorial-create-replica-set"

--- a/azure-resources/AVS/privateClouds/recommendations.yaml
+++ b/azure-resources/AVS/privateClouds/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Configure Azure Service Health alerts
-      url: "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring#design-recommendations"
+      url: "https://learn.microsoft.com/azure/cloud-adoption-framework/scenarios/azure-vmware/eslz-management-and-monitoring#design-recommendations"
 
 - description: Monitor when Azure VMware Solution Private Cloud is reaching the capacity limit
   aprlGuid: 29d7a115-dfb6-4df1-9205-04824109548f
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Configure and streamline alerts
-      url: "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
+      url: "https://learn.microsoft.com/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
 
 - description: Monitor when Azure VMware Solution Cluster Size is approaching the host limit
   aprlGuid: f86355e3-de7c-4dad-8080-1b0b411e66c8
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Configure and streamline alerts
-      url: "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
+      url: "https://learn.microsoft.com/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
 
 - description: Enable Stretched Clusters for Multi-AZ Availability of the vSAN Datastore
   aprlGuid: 9ec5b4c8-3dd8-473a-86ee-3273290331b9
@@ -64,7 +64,7 @@
   tags: []
   learnMoreLink:
     - name: Stretched Clusters
-      url: "https://learn.microsoft.com/en-us/azure/azure-vmware/deploy-vsan-stretched-clusters"
+      url: "https://learn.microsoft.com/azure/azure-vmware/deploy-vsan-stretched-clusters"
 
 - description: Configure Azure Monitor Alert warning thresholds for vSAN datastore utilization
   aprlGuid: 4232eb32-3241-4049-9e14-9b8005817b56
@@ -81,7 +81,7 @@
   tags: []
   learnMoreLink:
     - name: Supported metrics and activities
-      url: "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-alerts-for-azure-vmware-solution#supported-metrics-and-activities"
+      url: "https://learn.microsoft.com/azure/azure-vmware/configure-alerts-for-azure-vmware-solution#supported-metrics-and-activities"
 
 - description: Configure Syslog in Diagnostic Settings for Azure VMware Solution
   aprlGuid: fa4ab927-bced-429a-971a-53350de7f14b
@@ -98,7 +98,7 @@
   tags: []
   learnMoreLink:
     - name: Manage logs and archives
-      url: "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#manage-logs-and-archives"
+      url: "https://learn.microsoft.com/azure/well-architected/azure-vmware/monitoring#manage-logs-and-archives"
 
 - description: Monitor CPU Utilization to ensure sufficient resources for workloads
   aprlGuid: 4ee5d535-c47b-470a-9557-4a3dd297d62f
@@ -115,7 +115,7 @@
   tags: []
   learnMoreLink:
     - name: Configure and streamline alerts
-      url: "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
+      url: "https://learn.microsoft.com/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
 
 - description: Monitor Memory Utilization to ensure sufficient resources for workloads
   aprlGuid: 029208c8-5186-4a76-8ee8-6e3445fef4dd
@@ -132,7 +132,7 @@
   tags: []
   learnMoreLink:
     - name: Configure and streamline alerts
-      url: "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
+      url: "https://learn.microsoft.com/azure/well-architected/azure-vmware/monitoring#configure-and-streamline-alerts"
 
 - description: Apply Resource delete lock on the resource group hosting the private cloud
   aprlGuid: a5ef7c05-c611-4842-9af5-11efdc99123a
@@ -149,7 +149,7 @@
   tags: []
   learnMoreLink:
     - name: Lock your resources to protect your infrastructure
-      url: "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources"
+      url: "https://learn.microsoft.com/azure/azure-resource-manager/management/lock-resources"
 
 - description: Use key autorotation for vSAN datastore customer-managed keys
   aprlGuid: e0ac2f57-c8c0-4b8c-a7c8-19e5797828b5
@@ -166,7 +166,7 @@
   tags: []
   learnMoreLink:
     - name: Configure Customer Managed Keys
-      url: "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-customer-managed-keys?tabs=azure-portal"
+      url: "https://learn.microsoft.com/azure/azure-vmware/configure-customer-managed-keys?tabs=azure-portal"
 
 - description: Use multiple DNS servers per private FQDN zone
   aprlGuid: fcc2e257-23af-4c68-aac8-9cc03033c939
@@ -183,4 +183,4 @@
   tags: []
   learnMoreLink:
     - name: Configure DNS forwarder
-      url: "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-dns-azure-vmware-solution#configure-dns-forwarder"
+      url: "https://learn.microsoft.com/azure/azure-vmware/configure-dns-azure-vmware-solution#configure-dns-forwarder"

--- a/azure-resources/ApiManagement/service/recommendations.yaml
+++ b/azure-resources/ApiManagement/service/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Change your API Management service tier
-      url: "https://learn.microsoft.com/en-us/azure/api-management/upgrade-and-scale#change-your-api-management-service-tier"
+      url: "https://learn.microsoft.com/azure/api-management/upgrade-and-scale#change-your-api-management-service-tier"
 
 - description: Enable Availability Zones on Premium API Management instances
   aprlGuid: 740f2c1c-8857-4648-80eb-47d2c56d5a50
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Ensure API Management availability and reliability
-      url: "https://learn.microsoft.com/en-us/azure/api-management/high-availability#availability-zones"
+      url: "https://learn.microsoft.com/azure/api-management/high-availability#availability-zones"
 
 - description: Azure API Management platform version should be stv2
   aprlGuid: e35cf148-8eee-49d1-a1c9-956160f99e0b
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Azure API Management - stv1 platform retirement (August 2024)
-      url: "https://learn.microsoft.com/en-us/azure/api-management/breaking-changes/stv1-platform-retirement-august-2024"
+      url: "https://learn.microsoft.com/azure/api-management/breaking-changes/stv1-platform-retirement-august-2024"
 
 - description: Enable auto-scale for production workloads on API Management services
   aprlGuid: c79680ea-de85-44fa-a596-f31fa17a952f
@@ -81,7 +81,7 @@
   tags: [AI-GPT-RAG]
   learnMoreLink:
     - name: Deploy API Management instance to multiple Azure regions
-      url: "https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-deploy-multi-region"
+      url: "https://learn.microsoft.com/azure/api-management/api-management-howto-deploy-multi-region"
 
 - description: Enable caching to improve performance in Azure API Management
   aprlGuid: badd9a1f-222a-498d-ab84-1f14892b1c1b
@@ -98,4 +98,4 @@
   tags: []
   learnMoreLink:
     - name: Add caching to improve performance in Azure API Management
-      url: "https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-cache"
+      url: "https://learn.microsoft.com/azure/api-management/api-management-howto-cache"

--- a/azure-resources/App/managedEnvironments/recommendations.yaml
+++ b/azure-resources/App/managedEnvironments/recommendations.yaml
@@ -13,5 +13,5 @@
   tags: []
   learnMoreLink:
     - name: Reliability in Azure Container Apps
-      url: "https://learn.microsoft.com/en-us/azure/reliability/reliability-azure-container-apps"
+      url: "https://learn.microsoft.com/azure/reliability/reliability-azure-container-apps"
 

--- a/azure-resources/AppConfiguration/configurationStores/recommendations.yaml
+++ b/azure-resources/AppConfiguration/configurationStores/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Purge protection
-      url: "https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-soft-delete#purge-protection"
+      url: "https://learn.microsoft.com/azure/azure-app-configuration/concept-soft-delete#purge-protection"
 
 - description: Upgrade to App Configuration Standard tier
   aprlGuid: 2102a57a-a056-4d5e-afe5-9df9f92177ca

--- a/azure-resources/Automation/automationAccounts/recommendations.yaml
+++ b/azure-resources/Automation/automationAccounts/recommendations.yaml
@@ -13,4 +13,4 @@
   tags: []
   learnMoreLink:
     - name: Disaster recovery for Automation accounts
-      url: "https://learn.microsoft.com/en-us/azure/automation/automation-disaster-recovery?tabs=win-hrw%2Cps-script%2Coption-one"
+      url: "https://learn.microsoft.com/azure/automation/automation-disaster-recovery?tabs=win-hrw%2Cps-script%2Coption-one"

--- a/azure-resources/Cache/Redis/recommendations.yaml
+++ b/azure-resources/Cache/Redis/recommendations.yaml
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Schedule Redis Updates
-      url: "https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-administration#update-channel-and-schedule-updates"
+      url: "https://learn.microsoft.com/azure/azure-cache-for-redis/cache-administration#update-channel-and-schedule-updates"
 
 - description: Configure Private Endpoints
   aprlGuid: c474fc96-4e6a-4fb0-95d0-a26b3f35933c

--- a/azure-resources/Cdn/profiles/recommendations.yaml
+++ b/azure-resources/Cdn/profiles/recommendations.yaml
@@ -251,4 +251,4 @@
   tags: []
   learnMoreLink:
     - name: Compare pricing between Azure Front Door tiers
-      url: "https://learn.microsoft.com/en-us/azure/frontdoor/understanding-pricing"
+      url: "https://learn.microsoft.com/azure/frontdoor/understanding-pricing"

--- a/azure-resources/CognitiveServices/accounts/recommendations.yaml
+++ b/azure-resources/CognitiveServices/accounts/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Learn More
-      url: "https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/deployment-types#global-provisioned"
+      url: "https://learn.microsoft.com/azure/ai-services/openai/how-to/deployment-types#global-provisioned"
 
 - description: Ensure PAYG AOAI models leverage Global Standard deployment
   aprlGuid: 081fc8a4-b2d9-405b-b351-334e621016f5
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Learn More
-      url: "https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/deployment-types#global-standard"
+      url: "https://learn.microsoft.com/azure/ai-services/openai/how-to/deployment-types#global-standard"
 
 - description: Deploy a PAYG instance of the model with provisioned throughput to manage overflow effectively
   aprlGuid: 0c193899-da60-4a52-b4a0-77d75ac8c5c5
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Learn More
-      url: "https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/provisioned-throughput"
+      url: "https://learn.microsoft.com/azure/ai-services/openai/concepts/provisioned-throughput"
 
 - description: Ensure that models are deployed using Global batch for large scale processing
   aprlGuid: 8aa9744b-f302-4b05-9776-51d6dd3d0c3a
@@ -64,7 +64,7 @@
   tags: [AI-GPT-RAG]
   learnMoreLink:
     - name: Learn More
-      url: "https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/deployment-types#global-batch"
+      url: "https://learn.microsoft.com/azure/ai-services/openai/how-to/deployment-types#global-batch"
 
 - description: Ensure AOAI models are deployed using Data Zone Standard for data residency requirements
   aprlGuid: ac3add17-013e-41a5-af91-9fefce794a00
@@ -81,7 +81,7 @@
   tags: [AI-GPT-RAG]
   learnMoreLink:
     - name: Learn More
-      url: "https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/deployment-types#data-zone-standard"
+      url: "https://learn.microsoft.com/azure/ai-services/openai/how-to/deployment-types#data-zone-standard"
 
 - description: Use comprehensive monitoring solution for AOAI service
   aprlGuid: 72b1b4ad-a14b-4430-9799-91bda782973d
@@ -98,7 +98,7 @@
   tags: [AI-GPT-RAG]
   learnMoreLink:
     - name: Learn more
-      url: "https://learn.microsoft.com/en-us/azure/architecture/ai-ml/openai/architecture/log-monitor-azure-openai"
+      url: "https://learn.microsoft.com/azure/architecture/ai-ml/openai/architecture/log-monitor-azure-openai"
 
 - description: Deploy AOAI Service in multiple regions using Standard and/or Provisioned deployments
   aprlGuid: 61187af4-7d36-4b48-b16e-de78bef143a0
@@ -115,5 +115,5 @@
   tags: []
   learnMoreLink:
     - name: Learn More
-      url: "https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/business-continuity-disaster-recovery"
+      url: "https://learn.microsoft.com/azure/ai-services/openai/how-to/business-continuity-disaster-recovery"
 

--- a/azure-resources/Compute/galleries/recommendations.yaml
+++ b/azure-resources/Compute/galleries/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Compute Gallery best practices
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices"
+      url: "https://learn.microsoft.com/azure/virtual-machines/azure-compute-gallery#best-practices"
 
 - description: Zone redundant storage should be used for image versions
   aprlGuid: 488dcc8b-f2e3-40ce-bf95-73deb2db095f
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Compute Gallery best practices
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices"
+      url: "https://learn.microsoft.com/azure/virtual-machines/azure-compute-gallery#best-practices"
 
 - description: Consider creating TrustedLaunchSupported images where possible
   aprlGuid: 1c5e1e58-4e56-491c-8529-10f37af9d4ed
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Compute Gallery best practices
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#best-practices"
+      url: "https://learn.microsoft.com/azure/virtual-machines/azure-compute-gallery#best-practices"
 
 - description: Create Image Versions replicas in secondary region
   aprlGuid: b14ee8ed-7d27-447b-b6fb-6472cb5f4b75
@@ -81,4 +81,4 @@
   tags: []
   learnMoreLink:
     - name: Compute Gallery Scaling
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#scaling"
+      url: "https://learn.microsoft.com/azure/virtual-machines/azure-compute-gallery#scaling"

--- a/azure-resources/Compute/virtualMachineScaleSets/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachineScaleSets/recommendations.yaml
@@ -149,5 +149,5 @@
   tags: []
   learnMoreLink:
     - name: Deprecated Azure Marketplace images
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/deprecated-images"
+      url: "https://learn.microsoft.com/azure/virtual-machines/deprecated-images"
 

--- a/azure-resources/Compute/virtualMachines/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachines/recommendations.yaml
@@ -319,7 +319,7 @@
   tags: []
   learnMoreLink:
     - name: Azure Monitor Agent overview
-      url: "https://learn.microsoft.com/en-us/azure/azure-monitor/agents/agents-overview"
+      url: "https://learn.microsoft.com/azure/azure-monitor/agents/agents-overview"
 
 - description: Use maintenance configurations for the VMs
   aprlGuid: 52ab9e5c-eec0-3148-8bd7-b6dd9e1be870
@@ -353,7 +353,7 @@
   tags: []
   learnMoreLink:
     - name: B-series burstable virtual machine sizes
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/sizes-b-series-burstable"
+      url: "https://learn.microsoft.com/azure/virtual-machines/sizes-b-series-burstable"
 
 - description: Mission Critical Workloads should consider using Premium or Ultra Disks
   aprlGuid: df0ff862-814d-45a3-95e4-4fad5a244ba6
@@ -370,7 +370,7 @@
   tags: []
   learnMoreLink:
     - name: Disk type comparison and decision tree
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#disk-type-comparison"
+      url: "https://learn.microsoft.com/azure/virtual-machines/disks-types#disk-type-comparison"
 
 - description: Use Azure Boost VMs for Maintenance sensitive workload
   aprlGuid: 9ab499d8-8844-424d-a2d4-8f53690eb8f8
@@ -438,7 +438,7 @@
   tags: []
   learnMoreLink:
     - name: How to update the Azure Linux Agent on a VM
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/update-linux-agent?tabs=ubuntu"
+      url: "https://learn.microsoft.com/azure/virtual-machines/extensions/update-linux-agent?tabs=ubuntu"
 
 - description: Reserve Compute Capacity in Disaster Recovery Regions
   aprlGuid: 587ca3e4-113b-4c4f-b4e0-92cd8d2065b6

--- a/azure-resources/ContainerRegistry/registries/recommendations.yaml
+++ b/azure-resources/ContainerRegistry/registries/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Container Registry Best Practices
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices"
+      url: "https://learn.microsoft.com/azure/container-registry/container-registry-best-practices"
 
 - description: Enable zone redundancy
   aprlGuid: 63491f70-22e4-3b4a-8b0c-845450e46fac
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Registry best practices - Enable zone redundancy
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/zone-redundancy?toc=%2Fazure%2Freliability%2Ftoc.json&bc=%2Fazure%2Freliability%2Fbreadcrumb%2Ftoc.json&branch=main"
+      url: "https://learn.microsoft.com/azure/container-registry/zone-redundancy?toc=%2Fazure%2Freliability%2Ftoc.json&bc=%2Fazure%2Freliability%2Fbreadcrumb%2Ftoc.json&branch=main"
 
 - description: Create container registries with geo-replication enabled
   aprlGuid: 36ea6c09-ef6e-d743-9cfb-bd0c928a430b
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Registry best practices - Enable geo-replication
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#geo-replicate-multi-region-deployments"
+      url: "https://learn.microsoft.com/azure/container-registry/container-registry-best-practices#geo-replicate-multi-region-deployments"
 
 - description: Use Repository namespaces
   aprlGuid: a5a0101a-a240-8742-90ba-81dbde9a0c0c
@@ -64,7 +64,7 @@
   tags: []
   learnMoreLink:
     - name: Registry best practices - use repository namespaces
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#repository-namespaces"
+      url: "https://learn.microsoft.com/azure/container-registry/container-registry-best-practices#repository-namespaces"
 
 - description: Move Container Registry to a dedicated resource group
   aprlGuid: 8e389532-5db5-7e4c-9d4d-443b3e55ae82
@@ -81,7 +81,7 @@
   tags: []
   learnMoreLink:
     - name: Registry best practices - Use dedicated resource group
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#dedicated-resource-group"
+      url: "https://learn.microsoft.com/azure/container-registry/container-registry-best-practices#dedicated-resource-group"
 
 - description: Manage registry size
   aprlGuid: 3ef86f16-f65b-c645-9901-7830d6dc3a1b
@@ -98,7 +98,7 @@
   tags: []
   learnMoreLink:
     - name: Registry best practices - Manage registry size
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-best-practices#manage-registry-size"
+      url: "https://learn.microsoft.com/azure/container-registry/container-registry-best-practices#manage-registry-size"
 
 - description: Disable anonymous pull access
   aprlGuid: 03f4a7d8-c5b4-7842-8e6e-14997a34842b
@@ -115,7 +115,7 @@
   tags: []
   learnMoreLink:
     - name: Enable anonymous pull access
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/anonymous-pull-access#about-anonymous-pull-access"
+      url: "https://learn.microsoft.com/azure/container-registry/anonymous-pull-access#about-anonymous-pull-access"
 
 - description: Configure Diagnostic Settings for all Azure Container Registries
   aprlGuid: 44107155-7a32-9348-89f3-d5aa7e7c5a1d
@@ -132,7 +132,7 @@
   tags: []
   learnMoreLink:
     - name: Monitor Azure Container Registry - Enable diagnostic logs
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service#collection-and-routing"
+      url: "https://learn.microsoft.com/azure/container-registry/monitor-service#collection-and-routing"
 
 - description: Monitor Azure Container Registry with Azure Monitor
   aprlGuid: d594cde6-4116-d143-a64a-25f63289a2f8
@@ -149,7 +149,7 @@
   tags: []
   learnMoreLink:
     - name: Monitor Azure Container Registry
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/monitor-service"
+      url: "https://learn.microsoft.com/azure/container-registry/monitor-service"
 
 - description: Enable soft delete policy
   aprlGuid: e7f0fd54-fba0-054e-9ab8-e676f2851f88
@@ -166,4 +166,4 @@
   tags: []
   learnMoreLink:
     - name: Enable soft delete policy
-      url: "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-soft-delete-policy"
+      url: "https://learn.microsoft.com/azure/container-registry/container-registry-soft-delete-policy"

--- a/azure-resources/ContainerService/managedClusters/recommendations.yaml
+++ b/azure-resources/ContainerService/managedClusters/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: AKS Availability Zones
-      url: "https://learn.microsoft.com/en-us/azure/aks/availability-zones"
+      url: "https://learn.microsoft.com/azure/aks/availability-zones"
 
 - description: Isolate system and application pods
   aprlGuid: 5ee083cd-6ac3-4a83-8913-9549dd36cf56
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: System and user node pools
-      url: "https://learn.microsoft.com/en-us/azure/aks/use-system-pools?tabs=azure-cli#system-and-user-node-pools"
+      url: "https://learn.microsoft.com/azure/aks/use-system-pools?tabs=azure-cli#system-and-user-node-pools"
 
 - description: Disable local accounts
   aprlGuid: ca324d71-54b0-4a3e-b9e4-10e767daa9fc
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Entra integration
-      url: "https://learn.microsoft.com/en-us/azure/aks/concepts-identity#azure-ad-integration"
+      url: "https://learn.microsoft.com/azure/aks/concepts-identity#azure-ad-integration"
 
 - description: Configure Azure CNI networking for dynamic allocation of IPs or use CNI overlay
   aprlGuid: c22db132-399b-4e7c-995d-577a60881be8
@@ -64,7 +64,7 @@
   tags: []
   learnMoreLink:
     - name: Configure Azure CNI networking
-      url: "https://learn.microsoft.com/en-us/azure/aks/configure-azure-cni-dynamic-ip-allocation"
+      url: "https://learn.microsoft.com/azure/aks/configure-azure-cni-dynamic-ip-allocation"
 
 - description: Enable the cluster auto-scaler on an existing cluster
   aprlGuid: 902c82ff-4910-4b61-942d-0d6ef7f39b67
@@ -98,7 +98,7 @@
   tags: []
   learnMoreLink:
     - name: AKS Backups
-      url: "https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-cluster-backup"
+      url: "https://learn.microsoft.com/azure/backup/azure-kubernetes-service-cluster-backup"
 
 - description: Use zone-redundant storage for persistent volumes when running multi-zone AKS
   aprlGuid: d3111036-355d-431b-ab49-8ddad042800b
@@ -183,7 +183,7 @@
   tags: []
   learnMoreLink:
     - name: Pricing Tiers
-      url: "https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers"
+      url: "https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers"
 
 - description: Enable AKS Monitoring
   aprlGuid: dcaf8128-94bd-4d53-9235-3a0371df6b74
@@ -234,7 +234,7 @@
   tags: []
   learnMoreLink:
     - name: AKS Baseline - Policy Management
-      url: "https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks/baseline-aks?toc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Faks%2Ftoc.json&bc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#policy-management"
+      url: "https://learn.microsoft.com/azure/architecture/reference-architectures/containers/aks/baseline-aks?toc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Faks%2Ftoc.json&bc=https%3A%2F%2Flearn.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#policy-management"
 
 - description: Enable GitOps when using DevOps frameworks
   aprlGuid: 5f3cbd68-692a-4121-988c-9770914859a9
@@ -251,7 +251,7 @@
   tags: []
   learnMoreLink:
     - name: GitOps with AKS
-      url: "https://learn.microsoft.com/en-us/azure/architecture/guide/aks/aks-cicd-github-actions-and-gitops"
+      url: "https://learn.microsoft.com/azure/architecture/guide/aks/aks-cicd-github-actions-and-gitops"
 
 - description: Use pod topology spread constraints to ensure that pods are spread across different nodes or zones
   aprlGuid: 928fcc6f-5e9a-42d9-9bd4-260af42de2e5

--- a/azure-resources/DBforMySQL/flexibleServers/recommendations.yaml
+++ b/azure-resources/DBforMySQL/flexibleServers/recommendations.yaml
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Backup and restore in Azure Database for MySQL - Flexible Server
-      url: "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-backup-restore"
+      url: "https://learn.microsoft.com/azure/mysql/flexible-server/concepts-backup-restore"
 
 - description: Configure one or more read replicas
   aprlGuid: b49a8653-cc43-48c9-8513-a2d2e3f14dd1
@@ -64,7 +64,7 @@
   tags: []
   learnMoreLink:
     - name: Read replicas in Azure Database for MySQL - Flexible Server
-      url: "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-read-replicas"
+      url: "https://learn.microsoft.com/azure/mysql/flexible-server/concepts-read-replicas"
 
 - description: Configure storage auto-grow
   aprlGuid: 8176a79d-8645-4e52-96be-a10fc0204fe5
@@ -81,4 +81,4 @@
   tags: []
   learnMoreLink:
     - name: Azure Database for MySQL - Flexible Server service tiers - Storage auto grow
-      url: "https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-service-tiers-storage#storage-auto-grow"
+      url: "https://learn.microsoft.com/azure/mysql/flexible-server/concepts-service-tiers-storage#storage-auto-grow"

--- a/azure-resources/DBforPostgreSQL/flexibleServers/recommendations.yaml
+++ b/azure-resources/DBforPostgreSQL/flexibleServers/recommendations.yaml
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Backup and restore in Azure Database for PostgreSQL - Flexible Server
-      url: "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-backup-restore"
+      url: "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-backup-restore"
 
 - description: Configure one or more read replicas
   aprlGuid: 2ab85a67-26be-4ed2-a0bb-101b2513ec63
@@ -64,7 +64,7 @@
   tags: []
   learnMoreLink:
     - name: Read replicas in Azure Database for PostgreSQL - Flexible Server
-      url: "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-read-replicas"
+      url: "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-read-replicas"
 
 - description: Configure storage auto-grow
   aprlGuid: 6293a3cc-6b4a-4c0f-9ea7-b8ae8d7dd3d5
@@ -81,4 +81,4 @@
   tags: []
   learnMoreLink:
     - name: Storage autogrow using Azure portal in Azure Database for PostgreSQL - Flexible Server
-      url: "https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-auto-grow-storage-portal"
+      url: "https://learn.microsoft.com/azure/postgresql/flexible-server/how-to-auto-grow-storage-portal"

--- a/azure-resources/Databricks/workspaces/recommendations.yaml
+++ b/azure-resources/Databricks/workspaces/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Databricks runtime support lifecycles
-      url: "https://learn.microsoft.com/en-us/azure/databricks/release-notes/runtime/databricks-runtime-ver"
+      url: "https://learn.microsoft.com/azure/databricks/release-notes/runtime/databricks-runtime-ver"
 
 - description: Use SSD backed VMs for Worker VM Type and Driver type
   aprlGuid: 5877a510-8444-7a4c-8412-a8dab8662f7e
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#enable-autoscaling-for-batch-workloadss"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices#enable-autoscaling-for-batch-workloadss"
 
 - description: Enable autoscaling for SQL warehouse
   aprlGuid: 362ad2b6-b92c-414f-980a-0cf69467ccce
@@ -64,7 +64,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#enable-autoscaling-for-sql-warehouse"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices#enable-autoscaling-for-sql-warehouse"
 
 - description: Use Delta Live Tables enhanced autoscaling
   aprlGuid: cd77db98-9b13-6e4b-bd2b-74c2cb538628
@@ -98,7 +98,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices"
 
 - description: Enable Logging-Cluster log delivery
   aprlGuid: 7fb90127-5364-bb4d-86fa-30778ed713fb
@@ -115,7 +115,7 @@
   tags: []
   learnMoreLink:
     - name: Create a cluster
-      url: "https://learn.microsoft.com/en-us/azure/databricks/clusters/configure#cluster-log-delivery"
+      url: "https://learn.microsoft.com/azure/databricks/clusters/configure#cluster-log-delivery"
 
 - description: Use Delta Lake for higher reliability
   aprlGuid: da4ea916-4df3-8c4d-8060-17b49da45977
@@ -132,7 +132,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices"
 
 - description: Automatically rescue invalid or nonconforming data with Databricks Auto Loader or Delta Live Tables
   aprlGuid: 7e52d64d-8cc0-8548-a593-eb49ab45630d
@@ -149,7 +149,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices"
 
 - description: Configure jobs for automatic retries and termination
   aprlGuid: 84e44da6-8cd7-b349-b02c-c8bf72cf587c
@@ -166,7 +166,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices"
 
 - description: Use a scalable and production-grade model serving infrastructure
   aprlGuid: 4cbb7744-ff3d-0447-badb-baf068c95696
@@ -183,7 +183,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices"
 
 - description: Use a layered storage architecture
   aprlGuid: 1b0d0893-bf0e-8f4c-9dc6-f18f145c1ecf
@@ -200,7 +200,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices"
 
 - description: Improve data integrity by reducing data redundancy
   aprlGuid: e93fe702-e385-d741-ba37-1f1656482ecd
@@ -217,7 +217,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices"
 
 - description: Actively manage schemas
   aprlGuid: b7e1d13f-54c9-1648-8a52-34c0abe8ce16
@@ -234,7 +234,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices"
 
 - description: Use constraints and data expectations
   aprlGuid: a42297c4-7e4f-8b41-8d4b-114033263f0e
@@ -251,7 +251,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#use-constraints-and-data-expectations"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices#use-constraints-and-data-expectations"
 
 - description: Create regular backups
   aprlGuid: 932d45d6-b46d-e341-abfb-d97bce832f1f
@@ -268,7 +268,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#create-regular-backups"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices#create-regular-backups"
 
 - description: Recover from Structured Streaming query failures
   aprlGuid: 12e9d852-5cdc-2743-bffe-ee21f2ef7781
@@ -285,7 +285,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#recover-from-structured-streaming-query-failures"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices#recover-from-structured-streaming-query-failures"
 
 - description: Recover ETL jobs based on Delta time travel
   aprlGuid: a18d60f8-c98c-ba4e-ad6e-2fac72879df1
@@ -302,7 +302,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#recover-etl-jobs-based-on-delta-time-travel"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices#recover-etl-jobs-based-on-delta-time-travel"
 
 - description: Use Databricks Workflows and built-in recovery
   aprlGuid: c0e22580-3819-444d-8546-a80e4ed85c83
@@ -319,7 +319,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices"
 
 - description: Configure a disaster recovery pattern
   aprlGuid: 4fdb7112-4531-6f48-b60e-c917a6068d9b
@@ -355,7 +355,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for operational excellence
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/operational-excellence/best-practices#2-automate-deployments-and-workloads"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/operational-excellence/best-practices#2-automate-deployments-and-workloads"
 
 - description: Set up monitoring, alerting, and logging
   aprlGuid: 20193ff9-dbcd-a74e-b197-71d7d9d3c1e6
@@ -372,7 +372,7 @@
   tags: []
   learnMoreLink:
     - name: Best practices for operational excellence
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/operational-excellence/best-practices#system-monitoring"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/operational-excellence/best-practices#system-monitoring"
 
 - description: Deploy workspaces in separate Subscriptions
   aprlGuid: 397cdebb-9d6e-ab4f-83a1-8c481de0a3a7
@@ -440,7 +440,7 @@
   tags: []
   learnMoreLink:
     - name: Use Azure Spot Virtual Machines
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/spot-vms"
+      url: "https://learn.microsoft.com/azure/virtual-machines/spot-vms"
 
 - description: Evaluate regional isolation for workspaces
   aprlGuid: 8aa63c34-dd9d-49bd-9582-21ec310dfbdd
@@ -491,4 +491,4 @@
   tags: []
   learnMoreLink:
     - name: Best practices for reliability
-      url: "https://learn.microsoft.com/en-us/azure/databricks/lakehouse-architecture/reliability/best-practices#use-managed-services-where-possible"
+      url: "https://learn.microsoft.com/azure/databricks/lakehouse-architecture/reliability/best-practices#use-managed-services-where-possible"

--- a/azure-resources/DesktopVirtualization/hostPools/recommendations.yaml
+++ b/azure-resources/DesktopVirtualization/hostPools/recommendations.yaml
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Configure the VMs and install Active Directory Domain Services
-      url: "https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/deploy/virtual-dc/adds-on-azure-vm#configure-the-vms-and-install-active-directory-domain-services"
+      url: "https://learn.microsoft.com/windows-server/identity/ad-ds/deploy/virtual-dc/adds-on-azure-vm#configure-the-vms-and-install-active-directory-domain-services"
 
 - description: Use Azure Site Recovery to protect stateful session hosts
   aprlGuid: 38721758-2cc2-4d6b-b7b7-8b47dadbf7df
@@ -64,4 +64,4 @@
   tags: []
   learnMoreLink:
     - name: About Site Recovery
-      url: "https://learn.microsoft.com/en-us/azure/site-recovery/site-recovery-overview"
+      url: "https://learn.microsoft.com/azure/site-recovery/site-recovery-overview"

--- a/azure-resources/Devices/iotHubs/recommendations.yaml
+++ b/azure-resources/Devices/iotHubs/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Import and export IoT Hub device identities in bulk
-      url: "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-bulk-identity-mgmt"
+      url: "https://learn.microsoft.com/azure/iot-hub/iot-hub-bulk-identity-mgmt"
 
 - description: Do not use free tier
   aprlGuid: eeba3a49-fef0-481f-a471-7ff01139b474
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Choose the right IoT Hub tier and size for your solution
-      url: "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-scaling"
+      url: "https://learn.microsoft.com/azure/iot-hub/iot-hub-scaling"
 
 - description: Use Availability Zones
   aprlGuid: 214cbc46-747e-4354-af6e-6bf0054196a5
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Azure IoT Hub high availability and disaster recovery
-      url: "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr#availability-zones"
+      url: "https://learn.microsoft.com/azure/iot-hub/iot-hub-ha-dr#availability-zones"
 
 - description: Use Device Provisioning Service
   aprlGuid: b1e1378d-4572-4414-bebd-b8872a6d4d1c
@@ -64,7 +64,7 @@
   tags: []
   learnMoreLink:
     - name: IoT Hub Device Provisioning Service (DPS) terminology
-      url: "https://learn.microsoft.com/en-us/azure/iot-dps/concepts-service"
+      url: "https://learn.microsoft.com/azure/iot-dps/concepts-service"
 
 - description: Define Failover Guidelines
   aprlGuid: 02568a5d-335e-4e51-9f7c-fe2ada977300
@@ -81,7 +81,7 @@
   tags: []
   learnMoreLink:
     - name: IoT Hub high availability and disaster recovery
-      url: "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ha-dr"
+      url: "https://learn.microsoft.com/azure/iot-hub/iot-hub-ha-dr"
 
 - description: Disabled Fallback Route
   aprlGuid: e7dbd21f-b27a-4b8c-a901-cedb1e6d8e1e
@@ -98,4 +98,4 @@
   tags: []
   learnMoreLink:
     - name: Use message routing - Fallback route
-      url: "https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-d2c#fallback-route"
+      url: "https://learn.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-d2c#fallback-route"

--- a/azure-resources/DocumentDB/databaseAccounts/recommendations.yaml
+++ b/azure-resources/DocumentDB/databaseAccounts/recommendations.yaml
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: High availability in Azure Cosmos DB
-      url: "https://learn.microsoft.com/en-us/azure/reliability/reliability-cosmos-db-nosql"
+      url: "https://learn.microsoft.com/azure/reliability/reliability-cosmos-db-nosql"
 
 - description: Evaluate multi-region write capability
   aprlGuid: 9ce78192-74a0-104c-b5bb-9a443f941649

--- a/azure-resources/EventGrid/topics/recommendations.yaml
+++ b/azure-resources/EventGrid/topics/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Azure Event Grid - Enable diagnostic logs for Event Grid resources
-      url: "https://learn.microsoft.com/en-us/azure/event-grid/enable-diagnostic-logs-topic"
+      url: "https://learn.microsoft.com/azure/event-grid/enable-diagnostic-logs-topic"
 
 - description: Configure Dead-letter to save events that cannot be delivered
   aprlGuid: 92162eb5-4323-3145-8a6c-525ce2f0700e
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Azure Event Grid delivery and retry
-      url: "https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry#dead-letter-events"
+      url: "https://learn.microsoft.com/azure/event-grid/delivery-and-retry#dead-letter-events"
 
 - description: Azure Event Grid topics should use Private Link Private Endpoints
   aprlGuid: b2069f64-4741-3d4a-a71d-50c8b03f5ab7
@@ -47,4 +47,4 @@
   tags: []
   learnMoreLink:
     - name: Configure private endpoints for Azure Event Grid topics or domains
-      url: "https://learn.microsoft.com/en-us/azure/event-grid/configure-private-endpoints"
+      url: "https://learn.microsoft.com/azure/event-grid/configure-private-endpoints"

--- a/azure-resources/Insights/activityLogAlerts/recommendations.yaml
+++ b/azure-resources/Insights/activityLogAlerts/recommendations.yaml
@@ -13,4 +13,4 @@
   tags: []
   learnMoreLink:
     - name: Resource Health
-      url: "https://learn.microsoft.com/en-us/azure/service-health/resource-health-overview"
+      url: "https://learn.microsoft.com/azure/service-health/resource-health-overview"

--- a/azure-resources/MachineLearningServices/registries/recommendations.yaml
+++ b/azure-resources/MachineLearningServices/registries/recommendations.yaml
@@ -13,4 +13,4 @@
   tags: [AI-GPT-RAG]
   learnMoreLink:
     - name: Manage Azure Machine Learning registries
-      url: "https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-registries?view=azureml-api-2&tabs=cli"
+      url: "https://learn.microsoft.com/azure/machine-learning/how-to-manage-registries?view=azureml-api-2&tabs=cli"

--- a/azure-resources/MachineLearningServices/workspaces/recommendations.yaml
+++ b/azure-resources/MachineLearningServices/workspaces/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: [AI-GPT-RAG]
   learnMoreLink:
     - name: Plan for multi-regional deployment
-      url: "https://learn.microsoft.com/en-us/azure/machine-learning/how-to-high-availability-machine-learning?view=azureml-api-2"
+      url: "https://learn.microsoft.com/azure/machine-learning/how-to-high-availability-machine-learning?view=azureml-api-2"
 
 - description: Deploy Azure Machine learning workspace in secondary region
   aprlGuid: 675d249a-9486-45e3-8e89-863f5802782d
@@ -30,7 +30,7 @@
   tags: [AI-GPT-RAG]
   learnMoreLink:
     - name: Failover for business continuity and disaster recovery
-      url: "https://learn.microsoft.com/en-us/azure/machine-learning/how-to-high-availability-machine-learning?view=azureml-api-2"
+      url: "https://learn.microsoft.com/azure/machine-learning/how-to-high-availability-machine-learning?view=azureml-api-2"
 
 - description: Ensure to create Machine Learning Compute resources in secondary region
   aprlGuid: 13794a63-8d95-47ce-acbd-5925ede5b208
@@ -47,7 +47,7 @@
   tags: [AI-GPT-RAG]
   learnMoreLink:
     - name: Failover for business continuity and disaster recovery
-      url: "https://learn.microsoft.com/en-us/azure/machine-learning/how-to-high-availability-machine-learning?view=azureml-api-2"
+      url: "https://learn.microsoft.com/azure/machine-learning/how-to-high-availability-machine-learning?view=azureml-api-2"
 
 - description: Ensure checkpoints are used for AI training models
   aprlGuid: 98f15850-f31e-4fb2-8874-74f5aabbcf91
@@ -64,7 +64,7 @@
   tags: []
   learnMoreLink:
     - name: Importance of checkpoint optimization
-      url: "https://learn.microsoft.com/en-us/azure/machine-learning/reference-checkpoint-performance-for-large-models?view=azureml-api-2&tabs=PYTORCH#why-checkpoint-optimization-for-large-model-training-matters"
+      url: "https://learn.microsoft.com/azure/machine-learning/reference-checkpoint-performance-for-large-models?view=azureml-api-2&tabs=PYTORCH#why-checkpoint-optimization-for-large-model-training-matters"
 
 - description: Selecting regions for BCDR, ensure that both regions offer adequate compute quotas
   aprlGuid: 6e4f0fd1-1853-4b94-9736-6d6d239d2694
@@ -81,7 +81,7 @@
   tags: []
   learnMoreLink:
     - name: Manage resource quotas
-      url: "https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-quotas?view=azureml-api-2"
+      url: "https://learn.microsoft.com/azure/machine-learning/how-to-manage-quotas?view=azureml-api-2"
 
 - description: Choose SKUs with longer terms and avoid those nearing retirement
   aprlGuid: 6e2af91f-477d-46a5-b8ce-6cd1b8176550
@@ -98,7 +98,7 @@
   tags: []
   learnMoreLink:
     - name: What are compute targets in Azure Machine Learning
-      url: "https://learn.microsoft.com/en-us/azure/machine-learning/concept-compute-target?view=azureml-api-2#supported-vm-series-and-sizes"
+      url: "https://learn.microsoft.com/azure/machine-learning/concept-compute-target?view=azureml-api-2#supported-vm-series-and-sizes"
 
 - description: Avoid NC and NC_Promo series Azure VMs for machine learning quotas; migrate to newer versions
   aprlGuid: cf2569bb-1cf2-46ce-8885-d742dc6f4a4c
@@ -115,7 +115,7 @@
   tags: []
   learnMoreLink:
     - name: Migration Guide for GPU Compute Workloads in Azure
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/n-series-migration"
+      url: "https://learn.microsoft.com/azure/virtual-machines/n-series-migration"
 
 - description: Make Azure Machine Learning quota requests through the Azure Machine Learning Studio
   aprlGuid: 48ea6480-6263-40ba-8937-326d790e63f6
@@ -132,4 +132,4 @@
   tags: []
   learnMoreLink:
     - name: Manage and increase quotas and limits for resources with Azure Machine Learning
-      url: "https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-quotas?view=azureml-api-2"
+      url: "https://learn.microsoft.com/azure/machine-learning/how-to-manage-quotas?view=azureml-api-2"

--- a/azure-resources/NetApp/netAppAccounts/recommendations.yaml
+++ b/azure-resources/NetApp/netAppAccounts/recommendations.yaml
@@ -115,7 +115,7 @@
   tags: []
   learnMoreLink:
     - name: Cross-region replication of Azure NetApp Files volumes
-      url: "https://learn.microsoft.com/en-us/azure/azure-netapp-files/cross-region-replication-introduction"
+      url: "https://learn.microsoft.com/azure/azure-netapp-files/cross-region-replication-introduction"
 
 - description: Enable Cross-zone replication of Azure NetApp Files volumes
   aprlGuid: e3d742e1-dacd-9b48-b6b1-510ec9f87c96

--- a/azure-resources/Network/applicationGateways/recommendations.yaml
+++ b/azure-resources/Network/applicationGateways/recommendations.yaml
@@ -149,4 +149,4 @@
   tags: []
   learnMoreLink:
     - name: Azure Application Gateway infrastructure configuration | Microsoft Learn
-      url: "https://learn.microsoft.com/en-us/azure/application-gateway/configuration-infrastructure#size-of-the-subnet"
+      url: "https://learn.microsoft.com/azure/application-gateway/configuration-infrastructure#size-of-the-subnet"

--- a/azure-resources/Network/azureFirewalls/recommendations.yaml
+++ b/azure-resources/Network/azureFirewalls/recommendations.yaml
@@ -81,7 +81,7 @@
   tags: []
   learnMoreLink:
     - name: Azure Well-Architected Framework review - Azure Firewall
-      url: "https://learn.microsoft.com/en-us/azure/well-architected/service-guides/azure-firewall#recommendations"
+      url: "https://learn.microsoft.com/azure/well-architected/service-guides/azure-firewall#recommendations"
 
 - description: Monitor "AZFW Latency Probe" metric
   aprlGuid: 8faace2d-a36e-425c-aa58-2ad99e3e0b7a

--- a/azure-resources/Network/bastionHosts/recommendations.yaml
+++ b/azure-resources/Network/bastionHosts/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: [AI-GPT-RAG]
   learnMoreLink:
     - name: Reliability in Azure Bastion
-      url: "https://learn.microsoft.com/en-us/azure/reliability/reliability-bastion"
+      url: "https://learn.microsoft.com/azure/reliability/reliability-bastion"
 
 - description: Deploy Azure Bastion into the virtual network in secondary Azure region
   aprlGuid: 0e57956d-71d9-4a35-bdcf-d7cfd7cd71f4
@@ -30,4 +30,4 @@
   tags: [AI-GPT-RAG]
   learnMoreLink:
     - name: Multi-region support in Azure bastion
-      url: "https://learn.microsoft.com/en-us/azure/reliability/reliability-bastion#multi-region-support"
+      url: "https://learn.microsoft.com/azure/reliability/reliability-bastion#multi-region-support"

--- a/azure-resources/Network/connections/recommendations.yaml
+++ b/azure-resources/Network/connections/recommendations.yaml
@@ -13,4 +13,4 @@
   tags: []
   learnMoreLink:
     - name: About ExpressRoute FastPath
-      url: "https://learn.microsoft.com/en-us/azure/expressroute/about-fastpath"
+      url: "https://learn.microsoft.com/azure/expressroute/about-fastpath"

--- a/azure-resources/Network/ddosProtectionPlans/recommendations.yaml
+++ b/azure-resources/Network/ddosProtectionPlans/recommendations.yaml
@@ -13,4 +13,4 @@
   tags: []
   learnMoreLink:
     - name: Monitoring Azure DDoS Protection
-      url: "https://learn.microsoft.com/en-us/azure/ddos-protection/monitor-ddos-protection-reference"
+      url: "https://learn.microsoft.com/azure/ddos-protection/monitor-ddos-protection-reference"

--- a/azure-resources/Network/expressRouteCircuits/recommendations.yaml
+++ b/azure-resources/Network/expressRouteCircuits/recommendations.yaml
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Designing for high availability with ExpressRoute
-      url: "https://learn.microsoft.com/en-us/azure/expressroute/designing-for-high-availability-with-expressroute"
+      url: "https://learn.microsoft.com/azure/expressroute/designing-for-high-availability-with-expressroute"
 
 - description: Ensure both connections of an ExpressRoute are configured in active-active mode
   aprlGuid: f06a2bbe-5839-d447-9f39-fc3d20562d88
@@ -115,4 +115,4 @@
   tags: []
   learnMoreLink:
     - name: Rate limiting for ExpressRoute Direct circuits (Preview)
-      url: "https://learn.microsoft.com/en-us/azure/expressroute/rate-limit"
+      url: "https://learn.microsoft.com/azure/expressroute/rate-limit"

--- a/azure-resources/Network/expressRouteGateways/recommendations.yaml
+++ b/azure-resources/Network/expressRouteGateways/recommendations.yaml
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Virtual WAN Monitoring Best Practices
-      url: "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#expressroute-gateway"
+      url: "https://learn.microsoft.com/azure/virtual-wan/monitoring-best-practices#expressroute-gateway"
 
 - description: Avoid using ExpressRoute circuits for VNet to VNet communication
   aprlGuid: 560a76a7-8f64-4ce3-ad27-d174468861a1

--- a/azure-resources/Network/expressRoutePorts/recommendations.yaml
+++ b/azure-resources/Network/expressRoutePorts/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: How to configure ExpressRoute Direct Change Admin State of links
-      url: "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-howto-erdirect#state"
+      url: "https://learn.microsoft.com/azure/expressroute/expressroute-howto-erdirect#state"
 
 - description: Ensure ExpressRoute Direct is not over-subscribed
   aprlGuid: 0bee356b-7348-4799-8cab-0c71ffe13018
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: About ExpressRoute Direct Circuit Sizes
-      url: "https://learn.microsoft.com/en-us/azure/expressroute/expressroute-erdirect-about?source=recommendations#circuit-sizes"
+      url: "https://learn.microsoft.com/azure/expressroute/expressroute-erdirect-about?source=recommendations#circuit-sizes"
 
 - description: Configure monitoring and alerting for ExpressRoute Ports
   aprlGuid: 55815823-d588-4cb7-a5b8-ae581837356e
@@ -81,7 +81,7 @@
   tags: []
   learnMoreLink:
     - name: Designing for high availability with ExpressRoute
-      url: "https://learn.microsoft.com/en-us/azure/expressroute/designing-for-high-availability-with-expressroute"
+      url: "https://learn.microsoft.com/azure/expressroute/designing-for-high-availability-with-expressroute"
 
 - description: Ensure both connections of an ExpressRoute are configured in active-active mode
   aprlGuid: 859886df-3996-4eab-8439-c1a38c416e0e

--- a/azure-resources/Network/loadBalancers/recommendations.yaml
+++ b/azure-resources/Network/loadBalancers/recommendations.yaml
@@ -64,7 +64,7 @@
   tags: []
   learnMoreLink:
     - name: Load Balancer and Availability Zones
-      url: "https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-availability-zones#zone-redundant"
+      url: "https://learn.microsoft.com/azure/load-balancer/load-balancer-standard-availability-zones#zone-redundant"
 
 - description: Use Health Probes to detect backend instances availability
   aprlGuid: e5f5fcea-f925-4578-8599-9a391e888a60
@@ -81,4 +81,4 @@
   tags: []
   learnMoreLink:
     - name: Load Balancer Health Probe Overview
-      url: "https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-custom-probe-overview"
+      url: "https://learn.microsoft.com/azure/load-balancer/load-balancer-custom-probe-overview"

--- a/azure-resources/Network/natGateways/recommendations.yaml
+++ b/azure-resources/Network/natGateways/recommendations.yaml
@@ -13,4 +13,4 @@
   tags: []
   learnMoreLink:
     - name: What is Azure NAT Gateway metrics and alerts?
-      url: "https://learn.microsoft.com/en-us/azure/nat-gateway/nat-metrics"
+      url: "https://learn.microsoft.com/azure/nat-gateway/nat-metrics"

--- a/azure-resources/Network/networkWatchers/recommendations.yaml
+++ b/azure-resources/Network/networkWatchers/recommendations.yaml
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Connection monitor overview
-      url: "https://learn.microsoft.com/en-us/azure/network-watcher/connection-monitor-overview"
+      url: "https://learn.microsoft.com/azure/network-watcher/connection-monitor-overview"
 
 - description: Enable traffic analytics in Virtual Network Flow Logs configuration
   aprlGuid: bf0b7dbd-016d-458c-af99-70fcb03ad451
@@ -64,4 +64,4 @@
   tags: []
   learnMoreLink:
     - name: Network Watcher traffic analytics
-      url: "https://learn.microsoft.com/en-us/azure/network-watcher/traffic-analytics"
+      url: "https://learn.microsoft.com/azure/network-watcher/traffic-analytics"

--- a/azure-resources/Network/p2sVpnGateways/recommendations.yaml
+++ b/azure-resources/Network/p2sVpnGateways/recommendations.yaml
@@ -13,4 +13,4 @@
   tags: []
   learnMoreLink:
     - name: Virtual WAN Monitoring Best Practices
-      url: "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#point-to-site-vpn-gateway"
+      url: "https://learn.microsoft.com/azure/virtual-wan/monitoring-best-practices#point-to-site-vpn-gateway"

--- a/azure-resources/Network/privateDnsZones/recommendations.yaml
+++ b/azure-resources/Network/privateDnsZones/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Protecting private DNS Zones and Records - Azure DNS
-      url: "https://learn.microsoft.com/en-us/azure/dns/dns-protect-private-zones-recordsets"
+      url: "https://learn.microsoft.com/azure/dns/dns-protect-private-zones-recordsets"
 
 - description: Monitor Private DNS Zones health and set up alerts
   aprlGuid: ab896e8c-49b9-2c44-adec-98339aff7821

--- a/azure-resources/Network/publicIPAddresses/recommendations.yaml
+++ b/azure-resources/Network/publicIPAddresses/recommendations.yaml
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Upgrading a basic public IP address to Standard SKU - Guidance
-      url: "https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance"
+      url: "https://learn.microsoft.com/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance"
 
 - description: Public IP addresses should have DDoS protection enabled
   aprlGuid: c4254c66-b8a5-47aa-82f6-e7d7fb418f47
@@ -64,4 +64,4 @@
   tags: []
   learnMoreLink:
     - name: Azure DDoS Protection
-      url: "https://learn.microsoft.com/en-us/azure/ddos-protection/ddos-protection-overview"
+      url: "https://learn.microsoft.com/azure/ddos-protection/ddos-protection-overview"

--- a/azure-resources/Network/routeTables/recommendations.yaml
+++ b/azure-resources/Network/routeTables/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Azure activity log - Azure Monitor | Microsoft Learn
-      url: "https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell"
+      url: "https://learn.microsoft.com/azure/azure-monitor/essentials/activity-log?tabs=powershell"
 
 - description: Configure locks for Route Tables to avoid accidental changes or deletion
   aprlGuid: 89d1166a-1a20-0f46-acc8-3194387bf127
@@ -30,4 +30,4 @@
   tags: []
   learnMoreLink:
     - name: Protect your Azure resources with a lock - Azure Resource Manager | Microsoft Learn
-      url: "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources?toc=%2Fazure%2Fvirtual-network%2Ftoc.json&tabs=json"
+      url: "https://learn.microsoft.com/azure/azure-resource-manager/management/lock-resources?toc=%2Fazure%2Fvirtual-network%2Ftoc.json&tabs=json"

--- a/azure-resources/Network/virtualHubs/recommendations.yaml
+++ b/azure-resources/Network/virtualHubs/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Upgrade a virtual WAN from Basic to Standard
-      url: "https://learn.microsoft.com/en-us/azure/virtual-wan/upgrade-virtual-wan"
+      url: "https://learn.microsoft.com/azure/virtual-wan/upgrade-virtual-wan"
 
 - description: Monitor health for v-Hubs
   aprlGuid: 30ec8a5e-46de-4323-87e9-a7c56b72813b
@@ -30,4 +30,4 @@
   tags: []
   learnMoreLink:
     - name: Virtual WAN Monitoring Best Practices
-      url: "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#virtual-hub"
+      url: "https://learn.microsoft.com/azure/virtual-wan/monitoring-best-practices#virtual-hub"

--- a/azure-resources/Network/virtualNetworkGateways/recommendations.yaml
+++ b/azure-resources/Network/virtualNetworkGateways/recommendations.yaml
@@ -81,7 +81,7 @@
   tags: []
   learnMoreLink:
     - name: Configure customer-controlled maintenance for your virtual network gateway - ExpressRoute | Microsoft Learn
-      url: "https://learn.microsoft.com/en-us/azure/expressroute/customer-controlled-gateway-maintenance#azure-portal-steps"
+      url: "https://learn.microsoft.com/azure/expressroute/customer-controlled-gateway-maintenance#azure-portal-steps"
 
 - description: Configure customer-controlled VPN gateway maintenance
   aprlGuid: f8c2e6d9-4b3a-45d6-b9e2-8e7f3a1c2d04

--- a/azure-resources/Network/vpnGateways/recommendations.yaml
+++ b/azure-resources/Network/vpnGateways/recommendations.yaml
@@ -13,4 +13,4 @@
   tags: []
   learnMoreLink:
     - name: Virtual WAN Monitoring Best Practices
-      url: "https://learn.microsoft.com/en-us/azure/virtual-wan/monitoring-best-practices#virtual-wan-gateways"
+      url: "https://learn.microsoft.com/azure/virtual-wan/monitoring-best-practices#virtual-wan-gateways"

--- a/azure-resources/Network/vpnSites/recommendations.yaml
+++ b/azure-resources/Network/vpnSites/recommendations.yaml
@@ -13,4 +13,4 @@
   tags: []
   learnMoreLink:
     - name: vWAN VPN Gateway Disaster Recovery
-      url: "https://learn.microsoft.com/en-us/azure/virtual-wan/disaster-recovery-design#multi-link-topology"
+      url: "https://learn.microsoft.com/azure/virtual-wan/disaster-recovery-design#multi-link-topology"

--- a/azure-resources/NetworkFunction/azureTrafficCollectors/recommendations.yaml
+++ b/azure-resources/NetworkFunction/azureTrafficCollectors/recommendations.yaml
@@ -13,4 +13,4 @@
   tags: []
   learnMoreLink:
     - name: Azure ExpressRoute Traffic Collector
-      url: "https://learn.microsoft.com/en-us/azure/expressroute/traffic-collector"
+      url: "https://learn.microsoft.com/azure/expressroute/traffic-collector"

--- a/azure-resources/RecoveryServices/vaults/recommendations.yaml
+++ b/azure-resources/RecoveryServices/vaults/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Setup network mapping for site recovery
-      url: "https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-network-mapping#set-up-ip-addressing-for-target-vms"
+      url: "https://learn.microsoft.com/azure/site-recovery/azure-to-azure-network-mapping#set-up-ip-addressing-for-target-vms"
 
 - description: Validate VM functionality with a Site Recovery test failover to check performance at target
   aprlGuid: 17e877f7-3a89-4205-8a24-0670de54ddcd
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Run a test failover
-      url: "https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-tutorial-dr-drill#run-a-test-failover"
+      url: "https://learn.microsoft.com/azure/site-recovery/azure-to-azure-tutorial-dr-drill#run-a-test-failover"
 
 - description: Migrate from classic alerts to built-in Azure Monitor alerts for Azure Recovery Services Vaults
   aprlGuid: 2912472d-0198-4bdc-aa90-37f145790edc

--- a/azure-resources/Search/searchServices/recommendations.yaml
+++ b/azure-resources/Search/searchServices/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Reliability in Azure AI Search
-      url: "https://learn.microsoft.com/en-us/azure/search/search-reliability#availability-zone-support"
+      url: "https://learn.microsoft.com/azure/search/search-reliability#availability-zone-support"
 
 - description: Enable Multi Region deployments for AI Search
   aprlGuid: dff62efe-c3a3-4621-98b3-c877c65cb195
@@ -30,4 +30,4 @@
   tags: []
   learnMoreLink:
     - name: Reliability in Azure AI Search
-      url: "https://learn.microsoft.com/en-us/azure/search/search-reliability#multiple-services-in-separate-geographic-regions"
+      url: "https://learn.microsoft.com/azure/search/search-reliability#multiple-services-in-separate-geographic-regions"

--- a/azure-resources/ServiceBus/namespaces/recommendations.yaml
+++ b/azure-resources/ServiceBus/namespaces/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Service Bus and reliability
-      url: "https://learn.microsoft.com/en-us/azure/well-architected/services/messaging/service-bus/reliability"
+      url: "https://learn.microsoft.com/azure/well-architected/services/messaging/service-bus/reliability"
 
 - description: Enable auto-scale for production workloads on Service Bus namespaces
   aprlGuid: d810e3a8-600f-4be1-895b-1a93e61d37fd

--- a/azure-resources/Sql/servers/recommendations.yaml
+++ b/azure-resources/Sql/servers/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Active Geo Replication
-      url: "https://learn.microsoft.com/en-us/azure/azure-sql/database/active-geo-replication-overview"
+      url: "https://learn.microsoft.com/azure/azure-sql/database/active-geo-replication-overview"
 
 - description: Auto Failover Groups can encompass one or multiple databases, usually used by the same app.
   aprlGuid: 943c168a-2ec2-a94c-8015-85732a1b4859
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: AutoFailover Groups
-      url: "https://learn.microsoft.com/en-us/azure/azure-sql/database/auto-failover-group-overview?tabs=azure-powershell"
+      url: "https://learn.microsoft.com/azure/azure-sql/database/auto-failover-group-overview?tabs=azure-powershell"
 
 - description: Enable zone redundancy for Azure SQL Database to achieve high availability and resiliency
   aprlGuid: c0085c32-84c0-c247-bfa9-e70977cbf108
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Zone Redundant Databases
-      url: "https://learn.microsoft.com/en-us/azure/azure-sql/database/high-availability-sla"
+      url: "https://learn.microsoft.com/azure/azure-sql/database/high-availability-sla"
 
 - description: Implement Retry Logic
   aprlGuid: cbb17a29-64fb-c943-95d0-8df814a37c40
@@ -64,7 +64,7 @@
   tags: []
   learnMoreLink:
     - name: How to Implement Retry Logic
-      url: "https://learn.microsoft.com/en-us/azure/azure-sql/database/troubleshoot-common-connectivity-issues"
+      url: "https://learn.microsoft.com/azure/azure-sql/database/troubleshoot-common-connectivity-issues"
 
 - description: Monitor your Azure SQL Database in Near Real-Time to Detect Reliability Incidents
   aprlGuid: 7e7daec9-6a81-3546-a4cc-9aef72fec1f7
@@ -81,7 +81,7 @@
   tags: []
   learnMoreLink:
     - name: Azure Monitor
-      url: "https://learn.microsoft.com/en-us/azure/azure-monitor/insights/azure-sql#analyze-data-and-create-alerts"
+      url: "https://learn.microsoft.com/azure/azure-monitor/insights/azure-sql#analyze-data-and-create-alerts"
 
 - description: Back Up Your Keys
   aprlGuid: d6ef87aa-574e-584e-a955-3e6bb8b5425b
@@ -98,7 +98,7 @@
   tags: []
   learnMoreLink:
     - name: Azure Key Vault
-      url: "https://learn.microsoft.com/en-us/azure/key-vault/general/overview"
+      url: "https://learn.microsoft.com/azure/key-vault/general/overview"
 
 - description: Use Failover Group endpoints for database connections
   aprlGuid: de266d8a-a9f3-4cb9-be95-9306001fceea

--- a/azure-resources/Storage/storageAccounts/recommendations.yaml
+++ b/azure-resources/Storage/storageAccounts/recommendations.yaml
@@ -132,4 +132,4 @@
   tags: []
   learnMoreLink:
     - name: Private Link
-      url: "https://learn.microsoft.com/en-us/azure/well-architected/azure-virtual-desktop/networking#private-endpoints-private-link"
+      url: "https://learn.microsoft.com/azure/well-architected/azure-virtual-desktop/networking#private-endpoints-private-link"

--- a/azure-resources/Subscription/subscriptions/recommendations.yaml
+++ b/azure-resources/Subscription/subscriptions/recommendations.yaml
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Management group recommendations
-      url: "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-group-recommendations"
+      url: "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-management-groups#management-group-recommendations"
 
 - description: Configure Service Health Alerts
   aprlGuid: 9729c89d-8118-41b4-a39b-e12468fa872b
@@ -64,4 +64,4 @@
   tags: []
   learnMoreLink:
     - name: Azure Resource Manager Overview
-      url: "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-group-location-alignment"
+      url: "https://learn.microsoft.com/azure/azure-resource-manager/management/overview#resource-group-location-alignment"

--- a/azure-resources/VirtualMachineImages/imageTemplates/recommendations.yaml
+++ b/azure-resources/VirtualMachineImages/imageTemplates/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Generation 1 vs generation 2 virtual machines
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/generation-2#features-and-capabilities"
+      url: "https://learn.microsoft.com/azure/virtual-machines/generation-2#features-and-capabilities"
 
 - description: Replicate your Image Templates to a secondary region
   aprlGuid: 21fb841b-ba70-1f4e-a460-1f72fb41aa51
@@ -30,4 +30,4 @@
   tags: []
   learnMoreLink:
     - name: Image Template resiliency
-      url: "https://learn.microsoft.com/en-us/azure/reliability/reliability-image-builder?toc=%2Fazure%2Fvirtual-machines%2Ftoc.json&bc=%2Fazure%2Fvirtual-machines%2Fbreadcrumb%2Ftoc.json&tabs=graph#disaster-recovery"
+      url: "https://learn.microsoft.com/azure/reliability/reliability-image-builder?toc=%2Fazure%2Fvirtual-machines%2Ftoc.json&bc=%2Fazure%2Fvirtual-machines%2Fbreadcrumb%2Ftoc.json&tabs=graph#disaster-recovery"

--- a/azure-resources/Web/serverFarms/recommendations.yaml
+++ b/azure-resources/Web/serverFarms/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: []
   learnMoreLink:
     - name: Migrate App Service to availability zone support
-      url: "https://learn.microsoft.com/en-us/azure/reliability/migrate-app-service"
+      url: "https://learn.microsoft.com/azure/reliability/migrate-app-service"
 
 - description: Use Standard or Premium tier
   aprlGuid: b2113023-a553-2e41-9789-597e2fb54c31
@@ -30,7 +30,7 @@
   tags: []
   learnMoreLink:
     - name: Resiliency checklist for specific Azure services
-      url: "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service"
+      url: "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#app-service"
 
 - description: Avoid scaling up or down
   aprlGuid: 07243659-4643-d44c-a1c6-07ac21635072
@@ -47,7 +47,7 @@
   tags: []
   learnMoreLink:
     - name: Resiliency checklist for specific Azure services
-      url: "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service"
+      url: "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#app-service"
 
 - description: Create separate App Service plans for production and test
   aprlGuid: dbe3fd66-fb2a-9d46-b162-1791e21da236
@@ -64,7 +64,7 @@
   tags: []
   learnMoreLink:
     - name: Resiliency checklist for specific Azure services
-      url: "https://learn.microsoft.com/en-us/azure/architecture/checklist/resiliency-per-service#app-service"
+      url: "https://learn.microsoft.com/azure/architecture/checklist/resiliency-per-service#app-service"
 
 - description: Enable Autoscale/Automatic scaling to ensure adequate resources are available to service requests
   aprlGuid: 6320abf6-f917-1843-b2ae-4779c35985ae
@@ -81,7 +81,7 @@
   tags: []
   learnMoreLink:
     - name: Automatic scaling in Azure App Service
-      url: "https://learn.microsoft.com/en-us/azure/app-service/manage-automatic-scaling?tabs=azure-portal"
+      url: "https://learn.microsoft.com/azure/app-service/manage-automatic-scaling?tabs=azure-portal"
 
 - description: Set minimum instance count to 2 for app service
   aprlGuid: 855ca19a-6518-4f2e-9e5a-01796fbca9f8

--- a/azure-resources/Web/sites/recommendations.yaml
+++ b/azure-resources/Web/sites/recommendations.yaml
@@ -115,7 +115,7 @@
   tags: []
   learnMoreLink:
     - name: Monitor the health of App Service instances
-      url: "https://learn.microsoft.com/en-us/azure/app-service/monitor-instances-health-check?tabs=dotnet#enable-health-check"
+      url: "https://learn.microsoft.com/azure/app-service/monitor-instances-health-check?tabs=dotnet#enable-health-check"
 
 - description: Configure network access restrictions
   aprlGuid: aab6b4a4-9981-43a4-8728-35c7ecbb746d
@@ -132,7 +132,7 @@
   tags: []
   learnMoreLink:
     - name: Set up Azure App Service access restrictions
-      url: "https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions?tabs=azurecli"
+      url: "https://learn.microsoft.com/azure/app-service/app-service-ip-restrictions?tabs=azurecli"
 
 - description: Enable auto heal for Functions App
   aprlGuid: c6c4b962-5af4-447a-9d74-7b9c53a5dff5
@@ -166,7 +166,7 @@
   tags: []
   learnMoreLink:
     - name: Azure Functions Warmup Trigger
-      url: "https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-warmup?tabs=in-process%2Cnodejs-v4&pivots=programming-language-csharp#trigger"
+      url: "https://learn.microsoft.com/azure/azure-functions/functions-bindings-warmup?tabs=in-process%2Cnodejs-v4&pivots=programming-language-csharp#trigger"
 
 - description: Ensure unique hostid set for Function App
   aprlGuid: 0b06a688-0dd6-4d73-9f72-6666ff853ca9
@@ -183,7 +183,7 @@
   tags: []
   learnMoreLink:
     - name: Resource naming restrictions - Azure Resource Manager
-      url: "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules"
+      url: "https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules"
 
 - description: Ensure Function App runs a supported version
   aprlGuid: c9a278b7-024b-454b-bd54-41587c512b74
@@ -200,7 +200,7 @@
   tags: []
   learnMoreLink:
     - name: Migrate version 3.x to 4.x
-      url: "https://learn.microsoft.com/en-us/azure/azure-functions/migrate-version-3-version-4?tabs=net6-in-proc%2Cazure-cli%2Cwindows&pivots=programming-language-csharp"
+      url: "https://learn.microsoft.com/azure/azure-functions/migrate-version-3-version-4?tabs=net6-in-proc%2Cazure-cli%2Cwindows&pivots=programming-language-csharp"
 
 - description: Ensure FUNCTIONS_WORKER_RUNTIME is set properly
   aprlGuid: 7c608f46-46b2-4cc0-bbd6-1d457c16671c
@@ -217,4 +217,4 @@
   tags: []
   learnMoreLink:
     - name: FUNCTIONS_WORKER_RUNTIME
-      url: "https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#functions_worker_runtime"
+      url: "https://learn.microsoft.com/azure/azure-functions/functions-app-settings#functions_worker_runtime"

--- a/azure-specialized-workloads/ai/recommendations.yaml
+++ b/azure-specialized-workloads/ai/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: [AI-GPT-RAG]
   learnMoreLink:
     - name: Monitor online endpoints using Application Insights
-      url: "https://learn.microsoft.com/en-us/azure/machine-learning/how-to-monitor-online-endpoints?view=azureml-api-2#using-application-insights"
+      url: "https://learn.microsoft.com/azure/machine-learning/how-to-monitor-online-endpoints?view=azureml-api-2#using-application-insights"
 
 - description: Create Application insights for Machine learning workspace in both the regions
   aprlGuid: 89928e61-bba8-4c25-99c5-a06a09849ecc
@@ -30,7 +30,7 @@
   tags: [AI-GPT-RAG]
   learnMoreLink:
     - name: Data collection, retention, and storage in Application Insights
-      url: "https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-retention-configure?tabs=portal-3%2Cportal-1%2Cportal-2"
+      url: "https://learn.microsoft.com/azure/azure-monitor/logs/data-retention-configure?tabs=portal-3%2Cportal-1%2Cportal-2"
 
 - description: Use Azure Traffic Manager to route search requests via geo-located clients for failover redundancy.
   aprlGuid: a6c8f3f3-199a-4a13-aaf0-eb51eed5352e
@@ -47,4 +47,4 @@
   tags: []
   learnMoreLink:
     - name: Reliability in Azure AI Search
-      url: "https://learn.microsoft.com/en-us/azure/search/search-reliability#fail-over-or-redirect-query-requests"
+      url: "https://learn.microsoft.com/azure/search/search-reliability#fail-over-or-redirect-query-requests"

--- a/azure-specialized-workloads/avs/recommendations.yaml
+++ b/azure-specialized-workloads/avs/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: [AVS]
   learnMoreLink:
     - name: Connect Private Clouds in the same region
-      url: "https://learn.microsoft.com/en-us/azure/azure-vmware/connect-multiple-private-clouds-same-region"
+      url: "https://learn.microsoft.com/azure/azure-vmware/connect-multiple-private-clouds-same-region"
 
 - description: Integrate LDAPS Identity with dual sources for enhanced NSX and vCenter security
   aprlGuid: c2794660-ffd7-4da3-96ba-5d546b70b1c6
@@ -30,7 +30,7 @@
   tags: [AVS]
   learnMoreLink:
     - name: Set an external identity source for vCenter
-      url: "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-identity-source-vcenter"
+      url: "https://learn.microsoft.com/azure/azure-vmware/configure-identity-source-vcenter"
 
 - description: Use HCX Network Extension High Availability
   aprlGuid: bce16eee-0933-4baa-ab4d-8d1bb5653fc2
@@ -47,7 +47,7 @@
   tags: [AVS]
   learnMoreLink:
     - name: HCX Network extension high availability
-      url: "https://learn.microsoft.com/en-us/azure/azure-vmware/configure-hcx-network-extension-high-availability"
+      url: "https://learn.microsoft.com/azure/azure-vmware/configure-hcx-network-extension-high-availability"
 
 - description: Verify Management Networks are not extended with HCX Network Extension
   aprlGuid: 6be9a543-cf82-4926-82ea-7e1f1ffaad80
@@ -81,7 +81,7 @@
   tags: [AVS]
   learnMoreLink:
     - name: Use fault domains
-      url: "https://learn.microsoft.com/en-us/azure/well-architected/azure-vmware/application-platform#use-fault-domains"
+      url: "https://learn.microsoft.com/azure/well-architected/azure-vmware/application-platform#use-fault-domains"
 
 - description: Align ExpressRoute configuration with best practices for circuit resilience
   aprlGuid: 6f573d60-be93-4f18-8016-42e923e3c05e
@@ -115,7 +115,7 @@
   tags: [AVS]
   learnMoreLink:
     - name: Deploy vSAN streched cluster
-      url: "https://learn.microsoft.com/en-us/azure/azure-vmware/deploy-vsan-stretched-clusters#deploy-a-stretched-cluster-private-cloud"
+      url: "https://learn.microsoft.com/azure/azure-vmware/deploy-vsan-stretched-clusters#deploy-a-stretched-cluster-private-cloud"
 
 - description: Deploy dual Azure VMware Solution clouds in different regions for disaster recovery
   aprlGuid: bdac462a-2eda-4a67-887d-46d58f141afe
@@ -132,4 +132,4 @@
   tags: [AVS]
   learnMoreLink:
     - name: Private Clouds in two regions
-      url: "https://learn.microsoft.com/en-us/azure/azure-vmware/move-azure-vmware-solution-across-regions"
+      url: "https://learn.microsoft.com/azure/azure-vmware/move-azure-vmware-solution-across-regions"

--- a/azure-specialized-workloads/hpc/recommendations.yaml
+++ b/azure-specialized-workloads/hpc/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: [HPC]
   learnMoreLink:
     - name: Learn More
-      url: "https://learn.microsoft.com/en-us/powershell/high-performance-computing/hpcpack-ha-cloud?view=hpc19-ps#hpc-pack-cluster-shares"
+      url: "https://learn.microsoft.com/powershell/high-performance-computing/hpcpack-ha-cloud?view=hpc19-ps#hpc-pack-cluster-shares"
 
 - description: Automatically grow and shrink HPC Pack cluster resources
   aprlGuid: b02b5a0e-3770-44da-a099-5dd4d9f8cd70
@@ -30,7 +30,7 @@
   tags: [HPC]
   learnMoreLink:
     - name: Learn More
-      url: "https://learn.microsoft.com/en-us/powershell/high-performance-computing/hpcpack-auto-grow-shrink?view=hpc19-ps"
+      url: "https://learn.microsoft.com/powershell/high-performance-computing/hpcpack-auto-grow-shrink?view=hpc19-ps"
 
 - description: Use multiple head nodes for HPC Pack
   aprlGuid: a48b1be6-77a3-4e3c-8205-dda2ba010a99
@@ -47,7 +47,7 @@
   tags: [HPC]
   learnMoreLink:
     - name: Learn More
-      url: "https://learn.microsoft.com/en-us/powershell/high-performance-computing/hpcpack-ha-cloud?view=hpc19-ps#dealing-with-head-node-failure"
+      url: "https://learn.microsoft.com/powershell/high-performance-computing/hpcpack-ha-cloud?view=hpc19-ps#dealing-with-head-node-failure"
 
 - description: Use HPC Pack Azure AD Integration or other highly available AD configuration
   aprlGuid: 37eec891-7880-4759-b597-7cd925512fe3
@@ -64,4 +64,4 @@
   tags: [HPC]
   learnMoreLink:
     - name: Learn More
-      url: "https://learn.microsoft.com/en-us/powershell/high-performance-computing/hpcpack-ha-cloud?view=hpc19-ps#dealing-with-ad-failure"
+      url: "https://learn.microsoft.com/powershell/high-performance-computing/hpcpack-ha-cloud?view=hpc19-ps#dealing-with-ad-failure"

--- a/azure-specialized-workloads/sap/recommendations.yaml
+++ b/azure-specialized-workloads/sap/recommendations.yaml
@@ -13,7 +13,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: High Availability Deployment Options for SAP
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/sap-high-availability-architecture-scenarios#high-availability-deployment-options-for-sap-workload"
+      url: "https://learn.microsoft.com/azure/sap/workloads/sap-high-availability-architecture-scenarios#high-availability-deployment-options-for-sap-workload"
 
 - description: Run SAP application servers on two or more VMs using VMSS Flex
   aprlGuid: 49bd34ab-d117-4b0e-99f8-34cc8a5394bc
@@ -30,7 +30,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: Virtual machine Scale Set SAP Deployment Guide
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/virtual-machine-scale-set-sap-deployment-guide"
+      url: "https://learn.microsoft.com/azure/sap/workloads/virtual-machine-scale-set-sap-deployment-guide"
 
 - description: If using single-instance VMs all OS and data disks must be Premium SSD or Ultra Disk
   aprlGuid: b60ae773-9917-4bca-8a42-7cb45365a917
@@ -47,7 +47,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: SAP Storage Planning Guide
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/planning-guide-storage"
+      url: "https://learn.microsoft.com/azure/sap/workloads/planning-guide-storage"
 
 - description: Ensure synchronous data replication (SYNC mode) between primary and secondary VM nodes
   aprlGuid: 094400a5-f112-408d-a334-afd68873ff0f
@@ -99,7 +99,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: Test Cases
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal#test-the-cluster-setup"
+      url: "https://learn.microsoft.com/azure/sap/workloads/sap-hana-high-availability?tabs=lb-portal#test-the-cluster-setup"
 
 - description: Remove unwanted location constraints from Linux Pacemaker clusters
   aprlGuid: 1b8a3051-dfd4-4780-bfb7-446296774029
@@ -133,7 +133,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: Capacity Reservation
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/capacity-reservation-overview"
+      url: "https://learn.microsoft.com/azure/virtual-machines/capacity-reservation-overview"
 
 - description: Replicate production databases to DR location (ASYNC) using the vendor's replication technology
   aprlGuid: fb8bdcee-d88f-408d-8572-a76a4aaa733b
@@ -150,7 +150,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: SAP Disaster Recovery Guide
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/disaster-recovery-sap-guide?tabs=windows"
+      url: "https://learn.microsoft.com/azure/sap/workloads/disaster-recovery-sap-guide?tabs=windows"
 
 - description: SAP components are backed up to DR location using an appropriate backup tool or ASR
   aprlGuid: 41f0d88e-7866-4444-aac4-ef5fee3e6874
@@ -167,7 +167,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: SAP ACSS Insights
-      url: "https://learn.microsoft.com/en-us/azure/sap/center-sap-solutions/get-quality-checks-insights"
+      url: "https://learn.microsoft.com/azure/sap/center-sap-solutions/get-quality-checks-insights"
 
 - description: SAP shared files systems are replicated or backed up to DR location
   aprlGuid: ee4dc309-00a1-49fe-92fa-1724baf5f103
@@ -184,7 +184,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: DR Guidance
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/disaster-recovery-sap-guide?tabs=windows"
+      url: "https://learn.microsoft.com/azure/sap/workloads/disaster-recovery-sap-guide?tabs=windows"
 
 - description: Automate DR infrastructure build or pre-deploy DR resources
   aprlGuid: 0fabc52e-cdbb-4acd-8626-c4c637061e2d
@@ -201,7 +201,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: DR Guidance
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/disaster-recovery-sap-guide?tabs=windows"
+      url: "https://learn.microsoft.com/azure/sap/workloads/disaster-recovery-sap-guide?tabs=windows"
 
 - description: Document and test DR procedure ensure it meets RPO and RTO targets
   aprlGuid: c300e949-528d-4ac9-889b-cacf8b4a6e90
@@ -218,7 +218,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: DR Guidance
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/disaster-recovery-sap-guide?tabs=windows"
+      url: "https://learn.microsoft.com/azure/sap/workloads/disaster-recovery-sap-guide?tabs=windows"
 
 - description: Ensure there is a robust monitoring and alerting solution in place for the entire DR solution
   aprlGuid: c27134b7-6917-4852-8276-3dbef5c71578
@@ -235,7 +235,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: DR Guidance
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/disaster-recovery-sap-guide?tabs=windows"
+      url: "https://learn.microsoft.com/azure/sap/workloads/disaster-recovery-sap-guide?tabs=windows"
 
 - description: Configure scheduled events notification
   aprlGuid: 6b589ce6-c847-4cee-af35-f6e8eb1cf983
@@ -252,7 +252,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: VM Scheduled Events
-      url: "https://learn.microsoft.com/en-us/azure/virtual-machines/linux/scheduled-events"
+      url: "https://learn.microsoft.com/azure/virtual-machines/linux/scheduled-events"
 
 - description: Configure a Pacemaker cluster for SAP ASCS high availability
   aprlGuid: 9d8f6678-694c-4da4-8384-415201f65194
@@ -337,7 +337,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: SAP on Azure NetApp Planning Guide
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/planning-guide-storage#azure-netapp-files"
+      url: "https://learn.microsoft.com/azure/sap/workloads/planning-guide-storage#azure-netapp-files"
 
 - description: Provision recommended storage configuration on database VMs
   aprlGuid: 697deb1d-d398-4989-9734-9e6c18f7e0ad
@@ -354,4 +354,4 @@
   tags: [SAP]
   learnMoreLink:
     - name: High-availability SAP NetWeaver with simple mount and NFS on SLES for SAP Applications VMs
-      url: "https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-nfs-simple-mount?tabs=lb-portal%2Censa1"
+      url: "https://learn.microsoft.com/azure/sap/workloads/high-availability-guide-suse-nfs-simple-mount?tabs=lb-portal%2Censa1"

--- a/azure-waf/reliability/recommendations.yaml
+++ b/azure-waf/reliability/recommendations.yaml
@@ -98,7 +98,7 @@
   tags: [WAF]
   learnMoreLink:
     - name: RE:05 High-availability multi-region design
-      url: "https://learn.microsoft.com/en-us/azure/well-architected/reliability/highly-available-multi-region-design"
+      url: "https://learn.microsoft.com/azure/well-architected/reliability/highly-available-multi-region-design"
 
 - description: RE:05 Design for high availability with availability zones
   aprlGuid: 3d6adb0a-042f-47f7-a7ea-db2e360903d5

--- a/docs/content/contributing/create-content/create-recommendations/_index.md
+++ b/docs/content/contributing/create-content/create-recommendations/_index.md
@@ -78,7 +78,10 @@ The YAML structure for adding new recommendations consists of several key-value 
 | pgVerified | false | Boolean | true, false | Indicates whether the recommendation is verified by the relevant product group |
 | automationAvailable | false| Boolean | true, false | Indicates whether automation is available for validating the recommendation |
 | tags | [AVD]| String | [AI-GTP-RAG, AVD, AVS, HPC, SAP] or [] | Indicates which type of specialized workload the recommendation is associated to if any |
-| learnMoreLink | - name: Learn More url: "<https://learn.microsoft.com/en-us/azure/reliability/reliability-batch#cross-region-disaster-recovery-and-business-continuity>" | Object | Only 1 link per recommendation | Links related to the recommendation, such as announcements or documentation |
+| learnMoreLink | - name: Learn More url: "<https://learn.microsoft.com/azure/reliability/reliability-batch#cross-region-disaster-recovery-and-business-continuity>" | Object | Only 1 link per recommendation | Links related to the recommendation, such as announcements or documentation |
+
+> [!NOTE]
+> When referencing MS Learn content, avoid including locale identifiers such as **en-us** or **ja-jp** in the URL. Without a locale identifier, the display language will automatically be selected based on the user’s browser language settings.
 
 ### Recommendation Categories
 


### PR DESCRIPTION

# Overview/Summary
This PR standardizes URLs in recommendations by removing locale identifiers like “en-us” to improve accessibility. If no locale is specified in the URL, the displayed language is automatically selected based on the user’s browser settings.

- Removed "en-us" locale identifier from learnMoreLink URLs in "recommendations.yaml" files
- Updated documentation to specify that URLs should not contain locale identifiers to improve accessibility

## Related Issues/Work Items
Resolves #642

### Breaking Changes
None

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
