### PR TITLE
fix: Remove language part in MS Learn URLs

### DIFF
--- a/azure-specialized-workloads/sap/recommendations.yaml
+++ b/azure-specialized-workloads/sap/recommendations.yaml
@@ -269,7 +269,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: ASCS-Pacemaker - Central Server Instance
-      url: "https://docs.microsoft.com/en-us/azure/advisor/advisor-reference-reliability-recommendations"
+      url: "https://docs.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations"
 
 - description: Ensure the load balancer is configured correctly for SAP ASCS High availability
   aprlGuid: 5c2e52d0-25be-4b1c-833c-b98b5ef1a26b
@@ -286,7 +286,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: ASCS-LB - Central Server Instance
-      url: "https://docs.microsoft.com/en-us/azure/advisor/advisor-reference-reliability-recommendations"
+      url: "https://docs.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations"
 
 - description: Ensure the Pacemaker cluster has been setup for SAP HANA DB high availability
   aprlGuid: 6648fe61-880d-4a96-8d2d-190a23d5580b
@@ -303,7 +303,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: DBHANA-Pacemaker - Database Instance
-      url: "https://docs.microsoft.com/en-us/azure/advisor/advisor-reference-reliability-recommendations"
+      url: "https://docs.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations"
 
 - description: Ensure the load balancer is configured correctly for SAP HANA DB High availability
   aprlGuid: 2e4c2171-a83f-4238-a8e3-b51c90d86a99
@@ -320,7 +320,7 @@
   tags: [SAP]
   learnMoreLink:
     - name: DBHANA-LB- Database Instance
-      url: "https://docs.microsoft.com/en-us/azure/advisor/advisor-reference-reliability-recommendations"
+      url: "https://docs.microsoft.com/azure/advisor/advisor-reference-reliability-recommendations"
 
 - description: Review SAP configuration for timeout values used with Azure NetApp Files
   aprlGuid: 4884cada-b9c7-42d5-8153-3853e4a6f6c4


### PR DESCRIPTION
# Overview/Summary

Removes a language part in MS Learn URLs.

## Related Issues/Work Items

- #642
- #661

### Breaking Changes

- None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
