### PR TITLE
docs: remove Word report references for report generator guide

### DIFF
--- a/docs/content/tools/reports/_index.md
+++ b/docs/content/tools/reports/_index.md
@@ -26,26 +26,26 @@ The Reports cmdlet serves as the final step in a Well-Architected Reliability As
 The `Start-WARAReport` cmdlet is used to generate the WARA reports.
 
 {{< hint type=note >}}
-Whatever directory you run the `Start-WARAReport` cmdlet in, the Word and PowerPoint files will be created in that directory. For example: if you run the `Start-WARAReport` cmdlet in the `C:\Temp` directory, the Word and PowerPoint files will be created in the `C:\Temp` directory.
+Whatever directory you run the `Start-WARAReport` cmdlet in, the PowerPoint and Excel files will be created in that directory. For example: if you run the `Start-WARAReport` cmdlet in the `C:\Temp` directory, the PowerPoint and Excel files will be created in the `C:\Temp` directory.
 {{< /hint >}}
 
 You can review all of the parameters of Start-WARAReport [here](https://github.com/Azure/Well-Architected-Reliability-Assessment/blob/main/docs/wara/Start-WARAReport.md).
 
 #### Examples
 
-#### Create the Word and PowerPoint reports from the Action Plan Excel output
+#### Create the PowerPoint and Excel reports from the Action Plan Excel output
 
 ```PowerShell
 Start-WARAReport -ExpertAnalysisFile 'C:\WARA\Expert-Analysis-v1-2025-02-04-11-14.xlsx'
 ```
 
-#### Create the Word and PowerPoint reports from the Action Plan Excel output using the alias `ExcelFile` for the parameter
+#### Create the PowerPoint and Excel reports from the Action Plan Excel output using the alias `ExcelFile` for the parameter
 
 ```PowerShell
 Start-WARAReport -ExcelFile 'C:\WARA\Expert-Analysis-v1-2025-02-04-11-14.xlsx'
 ```
 
-#### Create the Word and PowerPoint reports from the Action Plan Excel output specifying the customer name and workload name
+#### Create the PowerPoint and Excel reports from the Action Plan Excel output specifying the customer name and workload name
 
 ```PowerShell
 Start-WARAReport -ExpertAnalysisFile 'C:\WARA\Expert-Analysis-v1-2025-02-04-11-14.xlsx' -CustomerName "Contoso" -WorkloadName "Contoso Web App"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Remove references to Word report from reports generator module guide

## Related Issues/Work Items

AB#39737

### Breaking Changes

1. None

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
