### PR TITLE
Added missing Advisor ID's

### DIFF
--- a/azure-resources/Compute/virtualMachines/recommendations.yaml
+++ b/azure-resources/Compute/virtualMachines/recommendations.yaml
@@ -1,6 +1,6 @@
 - description: Run production workloads on two or more VMs using VMSS Flex
   aprlGuid: 273f6b30-68e0-4241-85ea-acf15ffb60bf
-  recommendationTypeId: null
+  recommendationTypeId: 5f2613df-629f-4b07-9425-2a47ea0dfad3
   recommendationControl: HighAvailability
   recommendationImpact: High
   recommendationResourceType: Microsoft.Compute/virtualMachines
@@ -34,7 +34,7 @@
 
 - description: Migrate VMs using availability sets to VMSS Flex
   aprlGuid: a8d25876-7951-b646-b4e8-880c9031596b
-  recommendationTypeId: null
+  recommendationTypeId: 39fb2718-a2ae-4662-a8c9-cd8df23f01eb
   recommendationControl: HighAvailability
   recommendationImpact: High
   recommendationResourceType: Microsoft.Compute/virtualMachines
@@ -340,7 +340,7 @@
 
 - description: Don't use A or B-Series VMs for production needing constant full CPU performance
   aprlGuid: 3201dba8-d1da-4826-98a4-104066545170
-  recommendationTypeId: null
+  recommendationTypeId: 7f71b153-c0b7-4e99-a23e-db8179183ec9
   recommendationControl: Scalability
   recommendationImpact: High
   recommendationResourceType: Microsoft.Compute/virtualMachines
@@ -408,7 +408,7 @@
 
 - description: Reserve Compute Capacity for critical workloads
   aprlGuid: 302fda08-ee65-4fbe-a916-6dc0b33169c4
-  recommendationTypeId: null
+  recommendationTypeId: 1670c0af-6536-4cbf-872f-152c91a51a80
   recommendationControl: HighAvailability
   recommendationImpact: High
   recommendationResourceType: Microsoft.Compute/virtualMachines

--- a/azure-resources/DBforPostgreSQL/flexibleServers/recommendations.yaml
+++ b/azure-resources/DBforPostgreSQL/flexibleServers/recommendations.yaml
@@ -51,7 +51,7 @@
 
 - description: Configure one or more read replicas
   aprlGuid: 2ab85a67-26be-4ed2-a0bb-101b2513ec63
-  recommendationTypeId: null
+  recommendationTypeId: 7d2149f5-94f7-458d-8171-92cf66832cb2
   recommendationControl: DisasterRecovery
   recommendationImpact: High
   recommendationResourceType: Microsoft.DBforPostgreSQL/flexibleServers

--- a/azure-resources/NetApp/netAppAccounts/recommendations.yaml
+++ b/azure-resources/NetApp/netAppAccounts/recommendations.yaml
@@ -68,7 +68,7 @@
 
 - description: Use snapshots for data protection in Azure NetApp Files
   aprlGuid: 72827434-c773-4345-9493-34848ddf5803
-  recommendationTypeId: null
+  recommendationTypeId: cda11061-35a8-4ca3-aa03-b242dcdf7319
   recommendationControl: HighAvailability
   recommendationImpact: High
   recommendationResourceType: Microsoft.NetApp/netAppAccounts
@@ -85,7 +85,7 @@
 
 - description: Enable backup for data protection in Azure NetApp Files
   aprlGuid: b2fb3e60-97ec-e34d-af29-b16a0d61c2ac
-  recommendationTypeId: null
+  recommendationTypeId: c70fc854-2814-4b03-9b93-8ad7b918bfcf
   recommendationControl: DisasterRecovery
   recommendationImpact: High
   recommendationResourceType: Microsoft.NetApp/netAppAccounts
@@ -102,7 +102,7 @@
 
 - description: Enable Cross-region replication of Azure NetApp Files volumes
   aprlGuid: e30317d2-c502-4dfe-a2d3-0a737cc79545
-  recommendationTypeId: null
+  recommendationTypeId: 26f91380-cb68-4642-bb6f-1bce3c64c55e
   recommendationControl: DisasterRecovery
   recommendationImpact: High
   recommendationResourceType: Microsoft.NetApp/netAppAccounts

--- a/azure-resources/Network/applicationGateways/recommendations.yaml
+++ b/azure-resources/Network/applicationGateways/recommendations.yaml
@@ -85,7 +85,7 @@
 
 - description: Use Health Probes to detect backend availability
   aprlGuid: 847a8d88-21c4-bc48-a94e-562206edd767
-  recommendationTypeId: null
+  recommendationTypeId: 01c0dcd3-d6f7-4d50-a98b-4e15f9486a32
   recommendationControl: MonitoringAndAlerting
   recommendationImpact: High
   recommendationResourceType: Microsoft.Network/applicationGateways

--- a/azure-resources/Network/trafficManagerProfiles/recommendations.yaml
+++ b/azure-resources/Network/trafficManagerProfiles/recommendations.yaml
@@ -68,7 +68,7 @@
 
 - description: Avoid combining Traffic Manager and Front Door
   aprlGuid: 9437634c-d69e-2747-b13e-631c13182150
-  recommendationTypeId: null
+  recommendationTypeId: 825ff735-ed9a-4335-b132-321df86b0e81
   recommendationControl: BusinessContinuity
   recommendationImpact: High
   recommendationResourceType: Microsoft.Network/trafficManagerProfiles


### PR DESCRIPTION
# Overview/Summary

Many APRL recommendations have been added to Advisor, but the Advisor ID has not been added to APRL. This adds the missing Advisor ID's to the corresponding APRL recommendations

[User Story 39989](https://csusoleng.visualstudio.com/Well-Architected%20Framework/_workitems/edit/39989): Update APRL with Advisor ID's from pilot

AB#39989

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [X] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
