### PR TITLE
fix: Update container registry recommendation with Advisor ID

### DIFF
--- a/azure-resources/ContainerRegistry/registries/recommendations.yaml
+++ b/azure-resources/ContainerRegistry/registries/recommendations.yaml
@@ -1,7 +1,7 @@
 - description: Use Premium tier for critical production workloads
   aprlGuid: eb005943-40a8-194b-9db2-474d430046b7
-  recommendationTypeId: null
-  recommendationControl: Scalability
+  recommendationTypeId: af0cdbce-c610-499b-9bd7-b169cdb1bb2e
+  recommendationControl: HighAvailability
   recommendationImpact: High
   recommendationResourceType: Microsoft.ContainerRegistry/registries
   recommendationMetadataState: Active


### PR DESCRIPTION
# Overview/Summary

2 recommendations were being returned for using premium tier container registry. 1 from APRL & 1 from Advisor. Added the recommendationTypeId from Advisor to APRL to remove both being returned by automation

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [X] Ensured PR tests are passing
- [X] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
