### PR TITLE
chore: remove security as a recommendationcontrol for AKS and ACR

### DIFF
--- a/azure-resources/ContainerRegistry/registries/recommendations.yaml
+++ b/azure-resources/ContainerRegistry/registries/recommendations.yaml
@@ -52,7 +52,7 @@
 - description: Use Repository namespaces
   aprlGuid: a5a0101a-a240-8742-90ba-81dbde9a0c0c
   recommendationTypeId: null
-  recommendationControl: Security
+  recommendationControl: OtherBestPractices
   recommendationImpact: Medium
   recommendationResourceType: Microsoft.ContainerRegistry/registries
   recommendationMetadataState: Active
@@ -103,7 +103,7 @@
 - description: Disable anonymous pull access
   aprlGuid: 03f4a7d8-c5b4-7842-8e6e-14997a34842b
   recommendationTypeId: null
-  recommendationControl: Security
+  recommendationControl: OtherBestPractices
   recommendationImpact: Medium
   recommendationResourceType: Microsoft.ContainerRegistry/registries
   recommendationMetadataState: Active

--- a/azure-resources/ContainerService/managedClusters/recommendations.yaml
+++ b/azure-resources/ContainerService/managedClusters/recommendations.yaml
@@ -35,7 +35,7 @@
 - description: Disable local accounts
   aprlGuid: ca324d71-54b0-4a3e-b9e4-10e767daa9fc
   recommendationTypeId: null
-  recommendationControl: Security
+  recommendationControl: OtherBestPractices
   recommendationImpact: High
   recommendationResourceType: Microsoft.ContainerService/managedClusters
   recommendationMetadataState: Disabled


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary
remove security as a recommendationcontrol for AKS and ACR and replace them with "OtherBestPractices"
