### PR TITLE
refactor: Removing Public IP security recommendations

### DIFF
--- a/azure-resources/Network/publicIPAddresses/recommendations.yaml
+++ b/azure-resources/Network/publicIPAddresses/recommendations.yaml
@@ -48,20 +48,3 @@
   learnMoreLink:
     - name: Upgrading a basic public IP address to Standard SKU - Guidance
       url: "https://learn.microsoft.com/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance"
-
-- description: Public IP addresses should have DDoS protection enabled
-  aprlGuid: c4254c66-b8a5-47aa-82f6-e7d7fb418f47
-  recommendationTypeId: null
-  recommendationControl: Security
-  recommendationImpact: Medium
-  recommendationResourceType: Microsoft.Network/publicIPAddresses
-  recommendationMetadataState: Active
-  longDescription: |
-    DDoS attacks can be targeted at any endpoint that is publicly reachable through the internet.
-  potentialBenefits: Avoids service disruption
-  pgVerified: true
-  automationAvailable: true
-  tags: []
-  learnMoreLink:
-    - name: Azure DDoS Protection
-      url: "https://learn.microsoft.com/azure/ddos-protection/ddos-protection-overview"


### PR DESCRIPTION
# Overview/Summary

This is an effort from DRI leads to move security recommendations from APRL to Defender for Cloud.

## Related Issues/Work Items

Fixes [AB#40219](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/40219)

### Breaking Changes
No breaking changes

## As part of this pull request I have removed 1 recommendation that belong to security: Public IP addresses should have DDoS protection enabled.

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
