### PR TITLE
fix: Added advisor ID's for PostgreSQL, Firewall and Load Balancer Zone re…

### DIFF
--- a/azure-resources/DBforPostgreSQL/flexibleServers/recommendations.yaml
+++ b/azure-resources/DBforPostgreSQL/flexibleServers/recommendations.yaml
@@ -1,6 +1,6 @@
 - description: Enable HA with zone redundancy
   aprlGuid: ca87914f-aac4-4783-ab67-82a6f936f194
-  recommendationTypeId: null
+  recommendationTypeId: 80b4e93c-4500-4fbd-bd6f-3ec245f72be9
   recommendationControl: HighAvailability
   recommendationImpact: High
   recommendationResourceType: Microsoft.DBforPostgreSQL/flexibleServers

--- a/azure-resources/Network/azureFirewalls/recommendations.yaml
+++ b/azure-resources/Network/azureFirewalls/recommendations.yaml
@@ -1,6 +1,6 @@
 - description: Deploy Azure Firewall across multiple availability zones
   aprlGuid: c72b7fee-1fa0-5b4b-98e5-54bcae95bb74
-  recommendationTypeId: null
+  recommendationTypeId: e82f5b61-b0f8-48e7-8e18-5aa1f57bff81
   recommendationControl: HighAvailability
   recommendationImpact: High
   recommendationResourceType: Microsoft.Network/azureFirewalls

--- a/azure-resources/Network/loadBalancers/recommendations.yaml
+++ b/azure-resources/Network/loadBalancers/recommendations.yaml
@@ -51,7 +51,7 @@
 
 - description: Ensure Standard Load Balancer is zone-redundant
   aprlGuid: 621dbc78-3745-4d32-8eac-9e65b27b7512
-  recommendationTypeId: null
+  recommendationTypeId: 796b9be0-487d-4daa-8771-f08e4d7c9c0c
   recommendationControl: HighAvailability
   recommendationImpact: High
   recommendationResourceType: Microsoft.Network/loadBalancers


### PR DESCRIPTION
# Overview/Summary

Added advisor ID's for PostgreSQL, Firewall and Load Balancer Zone recommendations

[AB#40842](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/40842)

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [X] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
