### PR TITLE
fix: Fix recommended minimum node count for system node pools of AKS

### DIFF
--- a/azure-resources/ContainerService/managedClusters/kql/7f7ae535-a5ba-4665-b7e0-c451dbdda01f.kql
+++ b/azure-resources/ContainerService/managedClusters/kql/7f7ae535-a5ba-4665-b7e0-c451dbdda01f.kql
@@ -5,6 +5,6 @@ resources
 | mv-expand agentPoolProfile = properties.agentPoolProfiles
 | extend taints = tostring(parse_json(agentPoolProfile.nodeTaints))
 | extend nodePool = tostring(parse_json(agentPoolProfile.name))
-| where taints has "CriticalAddonsOnly=true:NoSchedule" and  agentPoolProfile.minCount < 2
+| where taints has "CriticalAddonsOnly=true:NoSchedule" and  agentPoolProfile.minCount < 3
 | project recommendationId="7f7ae535-a5ba-4665-b7e0-c451dbdda01f", name, id, tags, param1=strcat("nodePoolName: ", nodePool), param2=strcat("nodePoolMinNodeCount: ", agentPoolProfile.minCount)
 

--- a/azure-resources/ContainerService/managedClusters/recommendations.yaml
+++ b/azure-resources/ContainerService/managedClusters/recommendations.yaml
@@ -295,7 +295,7 @@
   recommendationResourceType: Microsoft.ContainerService/managedClusters
   recommendationMetadataState: Active
   longDescription: |
-    The system node pool should be configured with a minimum node count of two to ensure critical system pods are resilient to node outages.
+    The system node pool should be configured with a minimum node count of three to ensure critical system pods are resilient to node outages.
   potentialBenefits: Ensures pod resilience
   pgVerified: true
   automationAvailable: true


### PR DESCRIPTION
# Overview/Summary

Fixes the recommended minimum node count for system node pools of AKS to three.

- [Architecture best practices for Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/well-architected/service-guides/azure-kubernetes-service#design-checklist)
    > At a minimum, include two nodes for user node pools and **three** nodes for the system node pool.

- [Manage system node pools in Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/use-system-pools?tabs=azure-cli)
    > If you run a single system node pool for your AKS cluster in a production environment, we recommend you use at least **three** nodes for the node pool.

    > A minimum of **three** nodes of 8 vCPUs or two nodes of at least 16 vCPUs is recommended (for example, Standard_DS4_v2), especially for large clusters (Multiple CoreDNS Pod replicas, 3-4+ add-ons, etc.).

    > For your production workloads, ensure you're using system node pools with at least **three** nodes.

## Related Issues/Work Items

None

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
