### PR TITLE
fix: oracle to aprl schema

### DIFF
--- a/.github/scripts/schemas/aprl-schema.yaml
+++ b/.github/scripts/schemas/aprl-schema.yaml
@@ -8,9 +8,9 @@ recommendation:
   recommendationControl: enum('HighAvailability', 'BusinessContinuity', 'DisasterRecovery', 'Scalability', 'MonitoringAndAlerting', 'ServiceUpgradeAndRetirement', 'OtherBestPractices', 'Personalized', 'Governance', 'Security')
   recommendationImpact: enum('Low', 'Medium', 'High')
   recommendationResourceType: any(
-    regex('^Microsoft\\.[a-zA-Z0-9.]+/[a-zA-Z0-9]+$'),
-    regex('^Microsoft\\.[a-zA-Z0-9.]+/[a-zA-Z0-9.]+/[a-zA-Z0-9]+$'),
-    regex('^Microsoft\\.[a-zA-Z0-9.]+/[a-zA-Z0-9.]+/[a-zA-Z0-9.]+/[a-zA-Z0-9]+$'),
+    regex('^(Microsoft|Oracle)\\.[a-zA-Z0-9.]+/[a-zA-Z0-9]+$'),
+    regex('^(Microsoft|Oracle)\\.[a-zA-Z0-9.]+/[a-zA-Z0-9.]+/[a-zA-Z0-9]+$'),
+    regex('^(Microsoft|Oracle)\\.[a-zA-Z0-9.]+/[a-zA-Z0-9.]+/[a-zA-Z0-9.]+/[a-zA-Z0-9]+$'),
     regex('^WellArchitected/[A-Za-z]+$'),
     regex('^Specialized\\.Workload/[A-Za-z]+$'))
   recommendationMetadataState: enum('Active', 'Disabled')


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

This PR adds Oracle to the list of allowed resource types in the APRL schema.

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
