### PR TITLE
fix: Moved SQL Monitoring recommendation to disabled

### DIFF
--- a/azure-resources/Sql/servers/recommendations.yaml
+++ b/azure-resources/Sql/servers/recommendations.yaml
@@ -72,7 +72,7 @@
   recommendationControl: MonitoringAndAlerting
   recommendationImpact: High
   recommendationResourceType: Microsoft.Sql/servers/databases
-  recommendationMetadataState: Active
+  recommendationMetadataState: Disabled
   longDescription: |
     Monitoring and alerting are an important part of database operations. When working with Azure SQL Database, make use of Azure Monitor and SQL Insights to ensure that you capture relevant database metrics.
   potentialBenefits: Quick incident detection and response


### PR DESCRIPTION
# Overview/Summary

Changed the SQL DB monitoring recommendation to disabled as per PG not accepting in Advisor

## Related Issues/Work Items

Fixes [AB#41015](https://dev.azure.com/CSUSolEng/12ba7e46-a92a-47f6-ad6a-fba0479234a7/_workitems/edit/41015)

- [X] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
