### PR TITLE
feat: Add Advisor's GUID to recommendation details

### DIFF
--- a/docs/layouts/shortcodes/azure-resources-recommendationlist.html
+++ b/docs/layouts/shortcodes/azure-resources-recommendationlist.html
@@ -73,6 +73,12 @@ Azure Resources Recommendation List
         <span style="font-weight: normal">{{ .aprlGuid }}</span>
       </h4>
     </div>
+    <div style="margin-top: 10px;">
+      <h4>
+        <span style="font-weight: bold;">Advisor GUID:</span>&nbsp;
+        <span style="font-weight: normal">{{ if .recommendationTypeId }}{{ .recommendationTypeId }}{{ else }}n/a{{ end }}</span>
+      </h4>
+    </div>
     <div style="max-width: 100%; word-wrap: break-word; overflow-wrap: break-word;">
       <h4>Description:</h4>
       <pre


### PR DESCRIPTION
# Overview/Summary

Added the Advisor's GUID to the recommendation details to easy to find corresponding Advisor's recommendation.

![image](https://github.com/user-attachments/assets/0df020b8-83c8-4fe0-ac32-62450c0ba596)

Easy to find the corresponding Advisor's recommendation from [Reliability recommendations](https://learn.microsoft.com/en-us/azure/advisor/advisor-reference-reliability-recommendations) by using the above GUID of the APRL pages.

![image](https://github.com/user-attachments/assets/94a08146-2489-427c-ba4d-715063ba3dda)

## Related Issues/Work Items

None

### Breaking Changes

None

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
