### PR TITLE
fix: 6d82d042-6d61-ad49-86f0-6a5455398081

### DIFF
--- a/azure-resources/Network/loadBalancers/kql/6d82d042-6d61-ad49-86f0-6a5455398081.kql
+++ b/azure-resources/Network/loadBalancers/kql/6d82d042-6d61-ad49-86f0-6a5455398081.kql
@@ -5,6 +5,6 @@ resources
 | mv-expand bpool = properties.backendAddressPools
 | extend BackendAddresses = array_length(bpool.properties.loadBalancerBackendAddresses)
 | where BackendAddresses <= 1
-| extend lbId = id, lbName = name, poolName = tostring(bpool.name)
-| summarize anyPool = any(poolName), anyTags = any(tags) by lbId, lbName
-| project recommendationId = "6d82d042-6d61-ad49-86f0-6a5455398081", name = lbName, id = lbId, tags = anyTags, param1 = strcat("backendPoolName: ", anyPool)
+| extend lbId = id, lbName = name, poolName = tostring(bpool.name), lbTags = tostring(tags)
+| summarize impactedPools = make_list(poolName) by lbId, lbName, lbTags
+| project recommendationId = "6d82d042-6d61-ad49-86f0-6a5455398081",name = lbName,id = lbId,tags = lbTags,param1 = strcat("backendPoolNames: ", strcat_array(impactedPools, ", "))


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

Issue: the current query is not printing all impacted BackEndPool names, only the first, the query below fixes this problem.

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
