### PR TITLE
fix: Hide vwan page as no recommendations

### DIFF
--- a/azure-resources/Network/virtualWans/_index.md
+++ b/azure-resources/Network/virtualWans/_index.md
@@ -1,7 +1,7 @@
 ---
 title: virtualWans
 geekdocCollapseSection: true
-geekdocHidden: false
+geekdocHidden: true
 ---
 
 {{< azure-resources-recommendationlist name="azure-resources-recommendationlist" >}}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

This pull request includes a small change to the `azure-resources/Network/virtualWans/_index.md` file. The change updates the `geekdocHidden` property from `false` to `true`, which hides VWAN as there are no recommendations.
## Related Issues/Work Items


### Breaking Changes

1. None

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
