### PR TITLE
fix: url path for oracle exadata

### DIFF
--- a/azure-specialized-workloads/oracle/_index.md
+++ b/azure-specialized-workloads/oracle/_index.md
@@ -9,7 +9,7 @@ geekdocHidden: false
 | Recommendation                                                                                   | Provider Namespace |  Resource Type  |
 | :----------------------------------------------------------------------------------------------- | :----------------: | :-------------: |
 | [Ensure ODAA infrastructure is in Available state under normal operations](../../../Azure-Proactive-Resiliency-Library-v2/azure-resources/Oracledatabase/cloudexadatainfrastructures/#) |       Oracledatabase        |  cloudexadatainfrastructures  |
-| [Ensure ODAA clusters are in Available state under normal operations](../../../Azure-Proactive-Resiliency-Library-v2/azure-resources/Oracledatabase/cloudvmclusters/#) |      Oracledatabase       | cloudvmclusters |
+| [Ensure ODAA clusters are in Available state under normal operations](../../../Azure-Proactive-Resiliency-Library-v2/azure-resources/Oracledatabase/cloudvmclusters/cloudexadatavmclusters#) |      Oracledatabase       | cloudvmclusters |
 
 <br>
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

This PR changes the url for the specialized workload Oracle for cloudvmclusters:

![image](https://github.com/user-attachments/assets/7f951338-2d6c-4e15-9de3-6abbfb1be57c)


## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
