### PR TITLE
fix: Update app gw subnet recommendation to reflect Advisor recs.

### DIFF
--- a/azure-resources/Network/applicationGateways/kql/8364fd0a-7c0e-e240-9d95-4bf965aec243.kql
+++ b/azure-resources/Network/applicationGateways/kql/8364fd0a-7c0e-e240-9d95-4bf965aec243.kql
@@ -21,4 +21,8 @@ resources
     | extend subnetPrefixLength = split(prefix, '/')[1]
 ) on subnetId
 | where subnetPrefixLength > 24 and subnetPrefixLength != 64
-| distinct id, subscriptionId
+| project
+    recommendationId = id,
+    name = tostring(split(id, '/')[8]), // Extract resource name from id
+    tags = iif(isnull(properties.tags), array(), properties.tags),
+    param1 = subnetId

--- a/azure-resources/Network/applicationGateways/kql/8364fd0a-7c0e-e240-9d95-4bf965aec243.kql
+++ b/azure-resources/Network/applicationGateways/kql/8364fd0a-7c0e-e240-9d95-4bf965aec243.kql
@@ -2,14 +2,23 @@
 // This query will validate the subnet id for an appGW ends with a /24
 
 resources
-| where type =~ 'Microsoft.Network/applicationGateways'
-| extend subnetid = tostring(properties.gatewayIPConfigurations[0].properties.subnet.id)
-| join kind=leftouter(resources
-    | where type == "microsoft.network/virtualnetworks"
-    | mv-expand properties.subnets
-    | extend subnetid = tostring(properties_subnets.id)
-    | extend addressprefix = tostring(properties_subnets.properties.addressPrefix)
-    | project subnetid, addressprefix) on subnetid
-| where addressprefix !endswith '/24'
-| project recommendationId = "8364fd0a-7c0e-e240-9d95-4bf965aec243", name, id, tags, param1 = strcat('AppGW subnet prefix: ', addressprefix)
-
+| where type == 'microsoft.network/applicationgateways'
+| extend subnetId = tostring(properties.gatewayIPConfigurations[0].properties.subnet.id)
+| project id, subscriptionId, subnetId
+| join (
+    resources
+    | where type == 'microsoft.network/virtualnetworks'
+    | project id, subnets = properties.subnets
+    | mv-expand subnets
+    | mv-expand subnets.properties.addressPrefixes
+    | project
+        id,
+        subnetId = tostring(subnets.id),
+        prefix1 = subnets.properties.addressPrefix,
+        prefix2 = subnets.properties.addressPrefixes
+    | mv-expand prefix2
+    | extend prefix = iff(isnotnull(prefix1), prefix1, prefix2)
+    | extend subnetPrefixLength = split(prefix, '/')[1]
+) on subnetId
+| where subnetPrefixLength > 24 and subnetPrefixLength != 64
+| distinct id, subscriptionId

--- a/azure-resources/Network/applicationGateways/kql/8364fd0a-7c0e-e240-9d95-4bf965aec243.kql
+++ b/azure-resources/Network/applicationGateways/kql/8364fd0a-7c0e-e240-9d95-4bf965aec243.kql
@@ -1,13 +1,12 @@
 // Azure Resource Graph Query
 // This query will validate the subnet id for an appGW ends with a /24
-
 resources
-| where type == 'microsoft.network/applicationgateways'
+| where type == "microsoft.network/applicationgateways"
 | extend subnetId = tostring(properties.gatewayIPConfigurations[0].properties.subnet.id)
-| project id, subscriptionId, subnetId
+| project id, subscriptionId, subnetId, name, tags
 | join (
     resources
-    | where type == 'microsoft.network/virtualnetworks'
+    | where type == "microsoft.network/virtualnetworks"
     | project id, subnets = properties.subnets
     | mv-expand subnets
     | mv-expand subnets.properties.addressPrefixes
@@ -18,11 +17,7 @@ resources
         prefix2 = subnets.properties.addressPrefixes
     | mv-expand prefix2
     | extend prefix = iff(isnotnull(prefix1), prefix1, prefix2)
-    | extend subnetPrefixLength = split(prefix, '/')[1]
+    | extend subnetPrefixLength = split(prefix, "/")[1]
 ) on subnetId
 | where subnetPrefixLength > 24 and subnetPrefixLength != 64
-| project
-    recommendationId = id,
-    name = tostring(split(id, '/')[8]), // Extract resource name from id
-    tags = iif(isnull(properties.tags), array(), properties.tags),
-    param1 = subnetId
+| project recommendationId = "8364fd0a-7c0e-e240-9d95-4bf965aec243",name,id,tags,param1 = strcat("AppGW subnet prefix: ", prefix)

--- a/azure-resources/Network/applicationGateways/recommendations.yaml
+++ b/azure-resources/Network/applicationGateways/recommendations.yaml
@@ -134,16 +134,16 @@
     - name: Application Gateway Connection Draining
       url: "https://learn.microsoft.com/azure/application-gateway/features#connection-draining"
 
-- description: Ensure Application Gateway Subnet is using a /24 subnet mask
+- description: A minimum subnet size of /24 is recommended for Application Gateway v2 subnets.
   aprlGuid: 8364fd0a-7c0e-e240-9d95-4bf965aec243
-  recommendationTypeId: null
+  recommendationTypeId: ef4da732-f541-4109-bc0e-465c68b6c7eb
   recommendationControl: OtherBestPractices
   recommendationImpact: High
   recommendationResourceType: Microsoft.Network/applicationGateways
   recommendationMetadataState: Active
   longDescription: |
-    Application Gateway v2 (Standard_v2 or WAF_v2 SKU) can support up to 125 instances. A /24 subnet isn't mandatory for deployment but is advised to provide enough space for autoscaling and maintenance upgrades.
-  potentialBenefits: Allows autoscaling and maintenance
+    Application Gateway (Standard_v2 or WAF_v2 SKU) can support up to 125 instances (125 instance IP addresses + 1 private frontend IP configuration + 5 Azure reserved). A minimum subnet size of /24 is recommended.
+  potentialBenefits: Enough room for scalability
   pgVerified: true
   automationAvailable: true
   tags: []


### PR DESCRIPTION
# Overview/Summary
This pull request updates the Application Gateway subnet size recommendation and refines the associated KQL query to better validate subnet configurations for scalability. The main changes clarify the minimum subnet size guidance and improve the logic for checking subnet prefixes.

* Updated the recommendation description in `recommendations.yaml` to clarify that a minimum subnet size of /24 is recommended for Application Gateway v2 subnets, including a more detailed explanation and benefits. The `recommendationTypeId` was also set.
* Refactored the KQL query in `8364fd0a-7c0e-e240-9d95-4bf965aec243.kql` to more accurately validate subnet prefixes by handling multiple address prefixes and ensuring the subnet prefix length is greater than /24 and not equal to /64.

## Related Issues/Work Items

NA

-->

### Breaking Changes

NA

## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [x] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
