### PR TITLE
Remove cosmosdb recommendation 9cabded7-a1fc-6e4a-944b-d7dd98ea31a2

### DIFF
--- a/azure-resources/DocumentDB/databaseAccounts/kql/9cabded7-a1fc-6e4a-944b-d7dd98ea31a2.kql
+++ b/azure-resources/DocumentDB/databaseAccounts/kql/9cabded7-a1fc-6e4a-944b-d7dd98ea31a2.kql
@@ -1,9 +1,0 @@
-// Azure Resource Graph Query
-// Query to list all Azure Cosmos DB accounts that do not have multiple write locations or automatic failover enabled
-Resources
-| where type =~ 'Microsoft.DocumentDb/databaseAccounts'
-| where
-    array_length(properties.locations) > 1 and
-    tobool(properties.enableAutomaticFailover) == false and
-    tobool(properties.enableMultipleWriteLocations) == false
-| project recommendationId='9cabded7-a1fc-6e4a-944b-d7dd98ea31a2', name, id, tags

--- a/azure-resources/DocumentDB/databaseAccounts/recommendations.yaml
+++ b/azure-resources/DocumentDB/databaseAccounts/recommendations.yaml
@@ -15,23 +15,6 @@
     - name: Distribute data globally with Azure Cosmos DB
       url: "https://learn.microsoft.com/azure/cosmos-db/distribute-data-globally"
 
-- description: Enable service-managed failover for multi-region accounts with single write region
-  aprlGuid: 9cabded7-a1fc-6e4a-944b-d7dd98ea31a2
-  recommendationTypeId: 5de9f2e6-087e-40da-863a-34b7943beed4
-  recommendationControl: DisasterRecovery
-  recommendationImpact: High
-  recommendationResourceType: Microsoft.DocumentDB/databaseAccounts
-  recommendationMetadataState: Active
-  longDescription: |
-    Cosmos DB boasts high uptime and resiliency. Even so, issues may arise. With Service-Managed failover, if a region is down, Cosmos DB automatically switches to the next available region, requiring no user action.
-  potentialBenefits: Auto failover for high uptime
-  pgVerified: true
-  automationAvailable: true
-  tags: []
-  learnMoreLink:
-    - name: Manage an Azure Cosmos DB account by using the Azure portal
-      url: "https://learn.microsoft.com/azure/cosmos-db/how-to-manage-database-account#automatic-failover"
-
 - description: Enable availability zones
   aprlGuid: 921631f6-ed59-49a5-94c1-f0f3ececa580
   recommendationTypeId: null


### PR DESCRIPTION
# Overview/Summary

This PR removes the recommendation 9cabded7-a1fc-6e4a-944b-d7dd98ea31a2 as requested by Santosh Hari. 


## As part of this pull request I have

<!-- Use the checkboxes [x] on the options that are relevant. -->

- [ ] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [ ] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
