### PR TITLE
fix: Set recommendationTypeId to null for zone-redundant Load Balancer

### DIFF
--- a/azure-resources/Network/loadBalancers/recommendations.yaml
+++ b/azure-resources/Network/loadBalancers/recommendations.yaml
@@ -51,7 +51,7 @@
 
 - description: Ensure Standard Load Balancer is zone-redundant
   aprlGuid: 621dbc78-3745-4d32-8eac-9e65b27b7512
-  recommendationTypeId: 796b9be0-487d-4daa-8771-f08e4d7c9c0c
+  recommendationTypeId: null
   recommendationControl: HighAvailability
   recommendationImpact: High
   recommendationResourceType: Microsoft.Network/loadBalancers


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->

# Overview/Summary

The "Ensure Standard Load Balancer is zone-redundant" recommendation (`621dbc78-3745-4d32-8eac-9e65b27b7512`) stopped detecting **internal (private) load balancers** with non-zone-redundant frontend IPs after PR #743 mapped it to Azure Advisor via `recommendationTypeId: 796b9be0-487d-4daa-8771-f08e4d7c9c0c`.

**Root cause:** The WARA collector skips direct KQL execution for any recommendation that has a non-null `recommendationTypeId`, delegating detection to Azure Advisor instead. However, the corresponding Advisor recommendation does **not** cover internal/private load balancers — it only evaluates public-facing LBs. This means internal Standard LBs with zonal or no-zone frontend IPs are silently missed in assessment output.

**Fix:** Set `recommendationTypeId` back to `null` so the collector runs the existing KQL query directly against Azure Resource Graph, which correctly detects both internal and public LBs lacking zone-redundant frontend IPs.

### How the collector filters recommendations

In the [WARA collector module](https://github.com/Azure/Well-Architected-Reliability-Assessment) (`collector.psm1`, `Invoke-WAFQueryLoop`), the query loop applies this filter:

```powershell
$QueryObject.Where({
    $_.automationAvailable -eq $true -and
    $_.recommendationMetadataState -eq "Active" -and
    [string]::IsNullOrEmpty($_.recommendationTypeId)
})
```

Any recommendation with a non-null `recommendationTypeId` is excluded from KQL execution and instead routed to Advisor. Since Advisor doesn't cover internal LBs for this scenario, those resources go undetected.

### What the KQL query covers

The ARG query has two parts:
1. **Internal LBs** — Checks `frontendIPConfigurations` with a `subnet` (private), flags those with `zones` null or `array_length(zones) < 2`
2. **Public LBs** — Joins with `microsoft.network/publicipaddresses`, flags public IPs with `zones` null or `array_length(zones) < 2`

Advisor only covers scenario 2. This change restores coverage for scenario 1.

### Change

**File:** `azure-resources/Network/loadBalancers/recommendations.yaml`

```diff
 - description: Ensure Standard Load Balancer is zone-redundant
   aprlGuid: 621dbc78-3745-4d32-8eac-9e65b27b7512
-  recommendationTypeId: 796b9be0-487d-4daa-8771-f08e4d7c9c0c
+  recommendationTypeId: null
   recommendationControl: HighAvailability
```

## Related Issues/Work Items

Fixes the regression introduced in #743

<!-- Related WARA collector issues with similar Advisor-vs-KQL mismatch:
- https://github.com/Azure/Well-Architected-Reliability-Assessment/issues/185
- https://github.com/Azure/Well-Architected-Reliability-Assessment/issues/186
-->

### Breaking Changes

1. None — this restores previous behavior where the KQL query ran directly via the collector. I have tested and this now shows the recommendation in the Excel output.

## As part of this pull request I have

- [x] Read the [Contribution Guide](https://azure.github.io/Azure-Proactive-Resiliency-Library-v2/contributing) and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Proactive-Resiliency-Library-v2/tree/main)
- [x] Ensured PR tests are passing
- [ ] Performed testing and provided evidence (e.g. screenshot of output) for any changes associated to ARG queries
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)